### PR TITLE
feat: XYNE-62953 multi bundle handling for dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,6 @@ security-reports/
 /vespa-core/generated
 #vespa models
 /vespa-core/vespa/models/*
+
+# Build exports (make export-dashboard-bundle)
+out/

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ VERSION ?= $(shell git rev-parse --short=7 HEAD)
 BACKEND_IMAGE_NAME ?= xyne-spaces-backend
 RUNNER_IMAGE_NAME ?= xyne-spaces-runner
 DASHBOARD_IMAGE_NAME ?= xyne-spaces-dashboard
+DASHBOARD_EDGE_IMAGE_NAME ?= xyne-spaces-dashboard-edge
 EXTERNAL_DASHBOARD_IMAGE_NAME ?= xyne-spaces-dashboard-external
 LIGHTON_OCR_WRAPPER_IMAGE_NAME ?= lighton-ocr-server
 TRANSCRIPTION_AGENT_IMAGE_NAME ?= xyne-spaces-transcription-agent
@@ -70,6 +71,33 @@ push-dashboard:
 clean-dashboard:
 	docker rmi $(DASHBOARD_IMAGE_NAME):$(SOURCE_SHORT_COMMIT) || true
 	docker rmi $(NS)/$(DASHBOARD_IMAGE_NAME):$(SOURCE_SHORT_COMMIT) || true
+
+# Export the built dashboard bundles (dist + releases/dashboard.zip) for
+# upload to the dashboard edge's bucket: the normal bundle to
+# $(DASHBOARD_BUNDLE_OUT) and the SDLC-mode bundle (build:sdlc, base
+# /sdlc-app/) to $(DASHBOARD_BUNDLE_OUT)-sdlc. Same build args as
+# push-dashboard so the builder stage is served from cache.
+DASHBOARD_BUNDLE_OUT ?= out/dashboard-bundle
+export-dashboard-bundle:
+	$(info Exporting dashboard bundles to $(DASHBOARD_BUNDLE_OUT) and $(DASHBOARD_BUNDLE_OUT)-sdlc / git-head: $(SOURCE_COMMIT))
+	rm -rf $(DASHBOARD_BUNDLE_OUT) $(DASHBOARD_BUNDLE_OUT)-sdlc
+	docker buildx build -f apps/dashboard/Dockerfile --target bundle --output type=local,dest=$(DASHBOARD_BUNDLE_OUT) --build-arg "SOURCE_COMMIT=$(SOURCE_COMMIT)" --build-arg "VITE_POSTHOG_KEY=$(VITE_POSTHOG_KEY)" --build-arg "VITE_POSTHOG_HOST=$(VITE_POSTHOG_HOST)" .
+	docker buildx build -f apps/dashboard/Dockerfile --target bundle --output type=local,dest=$(DASHBOARD_BUNDLE_OUT)-sdlc --build-arg "SOURCE_COMMIT=$(SOURCE_COMMIT)" --build-arg "BUILD_SCRIPT=build:sdlc" --build-arg "VITE_POSTHOG_KEY=$(VITE_POSTHOG_KEY)" --build-arg "VITE_POSTHOG_HOST=$(VITE_POSTHOG_HOST)" .
+	$(info Exported: $(DASHBOARD_BUNDLE_OUT) and $(DASHBOARD_BUNDLE_OUT)-sdlc)
+
+# Dashboard edge targets (nginx + Node app serving bundles from object storage; apps/dashboard-edge)
+build-dashboard-edge:
+	$(info Building $(DASHBOARD_EDGE_IMAGE_NAME):$(SOURCE_SHORT_COMMIT))
+	docker buildx build -f apps/dashboard-edge/Dockerfile -t $(DASHBOARD_EDGE_IMAGE_NAME):$(SOURCE_SHORT_COMMIT) --load .
+
+push-dashboard-edge:
+	$(info Pushing to registry: $(NS)/$(DASHBOARD_EDGE_IMAGE_NAME):$(SOURCE_SHORT_COMMIT))
+	docker buildx build -f apps/dashboard-edge/Dockerfile -t $(NS)/$(DASHBOARD_EDGE_IMAGE_NAME):$(SOURCE_SHORT_COMMIT) --push .
+	$(info Successfully pushed: $(NS)/$(DASHBOARD_EDGE_IMAGE_NAME):$(SOURCE_SHORT_COMMIT))
+
+clean-dashboard-edge:
+	docker rmi $(DASHBOARD_EDGE_IMAGE_NAME):$(SOURCE_SHORT_COMMIT) || true
+	docker rmi $(NS)/$(DASHBOARD_EDGE_IMAGE_NAME):$(SOURCE_SHORT_COMMIT) || true
 
 # External Dashboard targets (public call-join SPA — deployed without mTLS)
 build-external-dashboard:
@@ -236,4 +264,4 @@ configure-docker:
 revoke-sa:
 	gcloud auth revoke $(SERVICE_ACCOUNT) -q || true
 
-.PHONY: build-backend push-backend clean-backend prisma-generate build-runner push-runner clean-runner build-dashboard push-dashboard clean-dashboard build-external-dashboard push-external-dashboard clean-external-dashboard build-lighton-ocr-wrapper push-lighton-ocr-wrapper clean-lighton-ocr-wrapper build-transcription-agent push-transcription-agent clean-transcription-agent build-claw push-claw clean-claw build-claw-auth-backend push-claw-auth-backend clean-claw-auth-backend build-claw-auth-frontend push-claw-auth-frontend clean-claw-auth-frontend build-claw-all push-claw-all clean-claw-all lint-dashboard typecheck run-pr-police build-all push-all clean-all test configure-docker revoke-sa
+.PHONY: build-backend push-backend clean-backend prisma-generate build-runner push-runner clean-runner build-dashboard push-dashboard clean-dashboard export-dashboard-bundle build-dashboard-edge push-dashboard-edge clean-dashboard-edge build-external-dashboard push-external-dashboard clean-external-dashboard build-lighton-ocr-wrapper push-lighton-ocr-wrapper clean-lighton-ocr-wrapper build-transcription-agent push-transcription-agent clean-transcription-agent build-claw push-claw clean-claw build-claw-auth-backend push-claw-auth-backend clean-claw-auth-backend build-claw-auth-frontend push-claw-auth-frontend clean-claw-auth-frontend build-claw-all push-claw-all clean-claw-all lint-dashboard typecheck run-pr-police build-all push-all clean-all test configure-docker revoke-sa

--- a/apps/dashboard-edge/.prettierrc
+++ b/apps/dashboard-edge/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/apps/dashboard-edge/Dockerfile
+++ b/apps/dashboard-edge/Dockerfile
@@ -1,0 +1,45 @@
+# Dashboard edge: nginx disk cache in front of a loopback Node app that
+# resolves rules and fetches bundles from object storage. Build context is
+# the repo root (pnpm workspace): docker build -f apps/dashboard-edge/Dockerfile .
+
+# --- app build ---------------------------------------------------------------
+FROM node:22.22.3-slim AS builder
+RUN corepack enable && corepack prepare pnpm@10.15.0 --activate
+WORKDIR /repo
+
+# Manifests + lockfile first so the install layer caches independently of source.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY packages/storage/package.json      packages/storage/
+COPY apps/dashboard-edge/package.json   apps/dashboard-edge/
+
+# --ignore-scripts: only manifests exist at this layer; @xyne/storage's
+# prepare hook (tsc) runs explicitly after its sources are copied.
+RUN pnpm install --frozen-lockfile --prod=false --ignore-scripts --filter xyne-spaces-dashboard-edge...
+
+COPY packages/storage packages/storage
+RUN pnpm --filter @xyne/storage run build
+
+COPY apps/dashboard-edge/tsconfig.json apps/dashboard-edge/
+COPY apps/dashboard-edge/src           apps/dashboard-edge/src
+RUN pnpm --filter xyne-spaces-dashboard-edge run build
+
+# Self-contained production tree: dist + production node_modules only.
+RUN pnpm --filter xyne-spaces-dashboard-edge deploy --legacy --prod /out/app
+
+# --- runtime -----------------------------------------------------------------
+FROM nginx:1.27-alpine AS runner
+RUN apk add --no-cache nodejs gettext ca-certificates curl tini \
+ && addgroup -S -g 1001 edge && adduser -S -u 1001 -G edge edge \
+ && mkdir -p /var/cache/edge /var/run/edge /etc/edge/rules \
+ && chown -R edge:edge /var/cache/edge /var/run/edge /etc/edge
+
+COPY --from=builder --chown=edge:edge /out/app /opt/edge/app
+COPY --chown=edge:edge apps/dashboard-edge/nginx/nginx.conf        /opt/edge/nginx.conf.template
+COPY --chown=edge:edge apps/dashboard-edge/nginx/proxy-origin.conf /opt/edge/proxy-origin.conf.template
+COPY --chown=edge:edge apps/dashboard-edge/docker-entrypoint.sh    /opt/edge/docker-entrypoint.sh
+RUN chmod +x /opt/edge/docker-entrypoint.sh
+
+USER edge
+EXPOSE 8080
+ENV NODE_ENV=production
+ENTRYPOINT ["/sbin/tini", "--", "/opt/edge/docker-entrypoint.sh"]

--- a/apps/dashboard-edge/README.md
+++ b/apps/dashboard-edge/README.md
@@ -1,0 +1,278 @@
+# Dashboard edge
+
+A small CDN-style layer that serves the dashboard SPA from object storage
+instead of from images with the bundle baked in. One deployment replaces the
+per-environment nginx pods (`xyne-dashboard`, `xyne-dashboard-02`,
+`xyne-dashboard-sdlc`): a rules file decides which bundle each request gets,
+misses are fetched from the bucket and cached on local disk, and pushing a
+bundle to its prefix is the release.
+
+Two processes in one container:
+
+- **nginx** (stock `nginx:alpine`, config only): disk cache, SPA fallback,
+  gzip, security headers. No scripting.
+- **edge app** (Node 22, TypeScript, `src/`): resolves rules, hot-reloads the
+  rules file, health-checks and fingerprints bundles, fetches objects through
+  the official storage SDKs via `@xyne/storage`, and serves status and
+  metrics. Bound to loopback; nginx is the only thing that talks to it.
+
+## How a request is served
+
+1. nginx runs an `auth_request` subrequest to the app's `/resolve` before
+   touching the cache. The app matches the request (path, headers, cookies,
+   user agent) against the rules and answers with headers: rule id, bundle,
+   cache key version, object path, cache mode, bypass and SPA flags.
+2. nginx looks the object up in `proxy_cache` under
+   `bundle | version-fingerprint | object`. On a miss it proxies to the
+   app's `/objects/<bundle>/<object>`, which streams the object from storage
+   with `Content-Type` and the browser `Cache-Control` already set, so the
+   cached copy carries them. Concurrent misses coalesce.
+3. If the origin says 404 and the path has no extension, it is a client-side
+   route: nginx retries `<bundle>/index.html` through the same cache. Paths
+   with an extension return a real 404.
+4. nginx adds the security headers and `X-Edge-*` diagnostics on every
+   response.
+
+## Rules file
+
+JSON, one object with a `rules` array. Evaluated in order, first match wins,
+the last rule must be the catch-all default. Full examples in
+`rules.example.json` and `k8s/configmap-rules.yaml`.
+
+```json
+{
+  "id": "playground-cookie",
+  "match": { "cookie": { "name": "x-route-env", "regex": "^playground$" } },
+  "bundle": "main",
+  "version": 3,
+  "cache": "versioned",
+  "strip_prefix": "/sdlc-app"
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `id` | Unique name, `[A-Za-z0-9_.-]+`. Shows up in `X-Edge-Rule`, logs and metrics. |
+| `match.path_prefix` | Request path starts with this. `"/"` alone marks the default rule. |
+| `match.path_regex` | JavaScript regex on the path. Captures are usable in `bundle`. |
+| `match.header` | `{ "name", "exact" \| "regex" }`. Name is case-insensitive. |
+| `match.cookie` | `{ "name", "exact" \| "regex" }`. |
+| `match.user_agent` | `{ "regex" }`. |
+| `bundle` | Prefix in the bucket whose root holds a built dist (`<bundle>/index.html` must exist). May reference regex captures as `$1`..`$9`. |
+| `version` | Any string or number, default `1`. Part of the cache key: bump it to force an invalidation by hand. Usually unnecessary, see fingerprints below. |
+| `cache` | `versioned` (default), `never`, or `ttl`. See below. |
+| `ttl` | Seconds, `"60s"`, `"5m"`... Required for `cache: ttl`. |
+| `strip_prefix` | Removed from the path before the bucket lookup, for bundles built with a non-root base such as `/sdlc-app/`. |
+
+All matchers in one rule must hold. Several rules can point at the same
+bundle (a header rule and a cookie rule for the same lane, for example).
+
+### Cache modes and invalidation
+
+- **versioned**: the edge caches for as long as the entry is used. Freshness
+  is controlled by the key, which holds the rule's `version` and the origin
+  fingerprint of the bundle's `index.html` (its ETag). The app re-checks
+  every static bundle at the origin every `EDGE_HEALTH_INTERVAL` seconds
+  (default 30), so re-uploading a bundle under the same prefix, which is what
+  the Jenkins pipeline does, changes the key and every old entry becomes
+  unreachable with no edit. Changing `bundle` or `version` does the same by
+  hand. Old entries age out on their own. Bundles built from regex captures
+  (devqa) are fingerprinted on their per-request existence check, cached for
+  60 seconds.
+- **never**: every request goes to the origin, nothing is stored at the edge,
+  and the browser gets `no-cache` on every path. Use it for devqa branches
+  that are re-pushed under the same name. Responses show `X-Edge-Cache: BYPASS`.
+- **ttl**: like versioned, but the key also carries a time bucket of `ttl`
+  seconds, so entries roll over on a timer with no edit.
+
+### Reload and validation
+
+The rules file is re-read every `EDGE_RELOAD_INTERVAL` seconds (default 5).
+When its content changes it is validated (zod schema plus semantic checks),
+every static bundle is checked with a metadata call on its `index.html`, and
+the new set becomes active. A file that fails validation is logged and
+ignored; the last good set stays live and `/_edge/status` shows
+`last_error`. A rule whose bundle is missing keeps the bundle it was serving
+before and is reported unhealthy; with nothing to fall back to it is
+disabled and requests fall through to the next rule. Dynamic bundles built
+from regex captures (the devqa rule) are checked per request with a short
+cache; an unknown branch falls through to the next rule and the response
+carries `X-Edge-Skipped` saying why. A disabled rule recovers on its own
+once its bundle appears.
+
+With a ConfigMap mount the kubelet takes up to about a minute to sync an
+edit; the app picks it up on its next tick after that.
+
+## Storage backends and credentials
+
+Set `STORAGE_BACKEND` and the variables for that backend. Credentials are
+resolved by the provider SDK's default chain, the same way as in the backend,
+so nothing here is edge-specific.
+
+| Backend | Variables | Credentials |
+|---|---|---|
+| `gcs` (default) | `STORAGE_BUCKET`, `STORAGE_ENDPOINT` (emulator only), `GOOGLE_CLOUD_PROJECT` (optional) | Google Application Default Credentials: `GOOGLE_APPLICATION_CREDENTIALS` (a mounted key), GKE Workload Identity, GCE metadata, workload identity federation. `@google-cloud/storage` via `@xyne/storage`. |
+| `s3` | `STORAGE_BUCKET`, `STORAGE_ENDPOINT` (MinIO, Ceph, GCS interop; forces path style), `AWS_REGION` | AWS default provider chain: env vars, shared config, EKS IRSA and Pod Identity, ECS and EC2 metadata. `@aws-sdk/client-s3` via `@xyne/storage`. |
+| `azure` | `STORAGE_BUCKET` (container), `AZURE_STORAGE_ACCOUNT` or `STORAGE_ENDPOINT` | `DefaultAzureCredential` (env vars, workload identity, managed identity), or `STORAGE_AUTH=sas` with `AZURE_STORAGE_SAS_TOKEN`. `@azure/storage-blob` via `@xyne/storage`. Untested against a real account. |
+| `http` | `STORAGE_ENDPOINT` (base URL) | Optional `STORAGE_AUTH_HEADER` sent as `Authorization`. Any server exposing `<base>/<bundle>/<object>`. |
+
+`STORAGE_AUTH` is `sdk` by default; `none` is for public buckets and
+emulators (for GCS a custom endpoint already implies it); `sas` is Azure-only.
+
+To mount a GCP service-account key instead of Workload Identity:
+
+```sh
+kubectl -n xyne-apps create secret generic xyne-dashboard-edge-gcp-key --from-file=key.json=sa.json
+```
+
+then set `GOOGLE_APPLICATION_CREDENTIALS=/etc/edge/gcp/key.json` and
+uncomment the `gcp-key` volume and mount in `k8s/deployment.yaml`. The key
+needs `roles/storage.objectViewer` on the bucket. For AWS, mount a secret as
+`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env vars or annotate the service
+account for IRSA; for Azure use workload identity or the `AZURE_*` env vars.
+
+Other settings: `EDGE_RULES_FILE` (default `/etc/edge/rules/rules.json`),
+`EDGE_RELOAD_INTERVAL` (default 5), `EDGE_HEALTH_INTERVAL` (default 30),
+`EDGE_APP_PORT` (default 9101), `EDGE_SYSLOG_PORT` (default 9102),
+`CACHE_MAX_SIZE` (default `2g`), `CACHE_INACTIVE` (default `7d`),
+`CACHE_TTL` (default `30d`), `LOG_LEVEL` (`debug`, `info`, `warn`, `error`).
+
+## Endpoints
+
+| Path | Purpose |
+|---|---|
+| `/_edge/healthz` | Liveness: the app is up. |
+| `/_edge/ready` | Readiness: rules loaded and the default rule healthy. |
+| `/_edge/status` | JSON: every rule with its resolved bundle, version, fingerprint, cache mode, health and last error; storage description; last reload and health check. |
+| `/_edge/metrics` | Prometheus: `edge_requests_total{rule,cache,status}` (from nginx's access log, shipped over local syslog), `edge_upstream_errors_total{rule}`, `edge_resolve_total{rule}`, `edge_origin_requests_total{result}`, `edge_rule_healthy{rule}`. |
+
+nginx refuses these for requests carrying `x-original-host`, which the
+VirtualService sets on external traffic, so they are only reachable inside
+the cluster or via `kubectl port-forward`.
+
+Every response carries `X-Edge-Rule`, `X-Edge-Bundle`, `X-Edge-Version`
+(the cache key's version and fingerprint), `X-Edge-Object`, `X-Edge-Cache`
+(`HIT`, `MISS`, `STALE`, `UPDATING`, `BYPASS`, or empty when nothing was
+proxied) and, when a matching rule was skipped, `X-Edge-Skipped`.
+
+## Bundle layout and the Jenkins pipeline
+
+A bundle is a prefix in the bucket holding a built `dist/` at its root, plus
+`releases/dashboard.zip` for the Electron updater. The Jenkins pipeline in
+`xyne-spaces-infra` uploads one on every build, to a flat prefix per lane
+that is overwritten in place (the shape the devqa uploads always had):
+
+| Lane | Prefix | Uploaded from |
+|---|---|---|
+| public `main` | `main` | the Docker push phase, exported from the image build with `make export-dashboard-bundle` |
+| `release-YYYYMMDD` | `release-YYYYMMDD` (the branch name) | the Docker push phase, same export |
+| devqa branch | `devqa-xyne-<name>` | the source build on the agent (unchanged, so the user-agent rule keeps working) |
+| any other branch | the branch name with its `fix/`, `feat/` or `feature/` prefix stripped and `/` replaced by `-` | the source build on the agent |
+| SDLC build of any of the above | `<lane>-sdlc` (for example `main-sdlc`) | the same build as the lane, run with `build:sdlc` (base `/sdlc-app/`); `ENABLE_STAGE_UPLOAD_SDLC_BUNDLE` in the Jenkinsfile, on by default |
+
+Bundle names are lanes, never commit hashes: a lane is rewritten on every
+build, and the version of what a lane holds is inside its `version.json`
+(the semantic-release version, for example `1.184.0` on `main`). The push
+is the release: the edge notices the new `index.html` fingerprint within its
+health interval and starts serving the new bundle. Rollback is
+re-running the pipeline for the previous commit. The upload writes hashed
+assets first and `index.html` last so a client can never load a new
+`index.html` whose assets are not there yet, and prunes files from older
+builds.
+
+`make export-dashboard-bundle` builds the `bundle` stage of
+`apps/dashboard/Dockerfile` (dist plus the Electron zip, nothing else) into
+`out/dashboard-bundle`; the builder stage is shared with the image build so
+it comes from cache.
+
+## Build, deploy, cutover
+
+```sh
+make build-dashboard-edge     # local image (build context is the repo root)
+make push-dashboard-edge      # asia.gcr.io/xyne-spaces/xyne-spaces-dashboard-edge:<sha>
+```
+
+1. Create the bucket access: either Workload Identity (`k8s/serviceaccount.yaml`
+   has the gcloud commands) or a mounted key (above).
+2. Apply `k8s/serviceaccount.yaml`, `k8s/configmap-rules.yaml` with the rules
+   pointing at prefixes that exist, `k8s/deployment.yaml` with the image tag,
+   and `k8s/service.yaml`.
+3. Check `kubectl -n xyne-apps port-forward deploy/xyne-dashboard-edge 8080` and
+   `curl localhost:8080/_edge/status`.
+4. Add a temporary VirtualService route so you can test through the gateway
+   before flipping anything:
+
+   ```yaml
+   - match:
+       - headers:
+           x-route-env:
+             exact: edge
+         uri:
+           prefix: /
+     route:
+       - destination:
+           host: xyne-dashboard-edge.xyne-apps.svc.cluster.local
+           port:
+             number: 8080
+   ```
+
+5. Flip the `/` routes (default, onyx header, playground header and cookie)
+   and the `/sdlc-app/` route to `xyne-dashboard-edge`. The onyx and
+   playground `/` routes can then be removed from the VirtualService, since
+   the edge's own rules handle those headers and cookies.
+6. After a day, scale the old dashboard deployments to zero, then delete them
+   and the `push-dashboard` image build once nothing references it.
+
+Rollback at any step is reverting the VirtualService; the old pods keep
+running until step 6. The old nginx config's `/migration/` proxy is not
+carried over: the VirtualService already routes `/migrate/` straight to that
+service.
+
+## Development
+
+```sh
+pnpm --filter xyne-spaces-dashboard-edge run typecheck
+pnpm --filter xyne-spaces-dashboard-edge run lint
+pnpm --filter xyne-spaces-dashboard-edge run test        # vitest, pure matcher and schema
+pnpm --filter xyne-spaces-dashboard-edge run dev         # tsx watch, app only (no nginx)
+```
+
+Full local run against emulators, with nginx in front:
+
+```sh
+cd apps/dashboard-edge/local
+docker compose up --build -d
+./seed.sh                                                              # buckets + four sample bundles
+curl -si localhost:8089/ | head -20                                   # GCS-backed edge (fake-gcs-server)
+curl -si -H 'x-route-env: playground' localhost:8089/ | head -20     # header rule, ttl cache
+curl -si -A 'devqa-xyne-feature-x' localhost:8089/ | head -20        # regex capture, cache: never
+curl -si localhost:8089/sdlc-app/ | head -20                          # strip_prefix
+curl -si localhost:8089/some/client/route | head -20                  # SPA fallback
+curl -si localhost:8090/ | head -20                                   # same rules, S3 backend on MinIO
+curl -s localhost:8089/_edge/status | jq
+```
+
+Edit `local/rules.json` in place (the file is bind-mounted, so use an editor
+that rewrites rather than renames) and watch `X-Edge-Bundle` change within
+two seconds. Re-run `./seed.sh` with changed content and watch
+`X-Edge-Version` change within the health interval.
+
+## Layout
+
+```
+Dockerfile                 app build (pnpm workspace) + nginx:alpine runtime with Node
+docker-entrypoint.sh       renders nginx.conf, starts the app, runs nginx
+nginx/nginx.conf           cache zone, auth_request resolver, /_edge guard, SPA fallback
+nginx/proxy-origin.conf    proxy + cache settings shared by / and @spa
+src/main.ts                bootstrap
+src/config.ts              env -> Config (zod)
+src/rules/schema.ts        rules file schema, validation, normalisation
+src/rules/match.ts         pure matcher: rules x request -> bundle + object + key version
+src/rules/store.ts         load, validate, health-check, fingerprint, hot-reload
+src/origin/                storage (gcs/s3/azure via @xyne/storage), http
+src/http/                  /resolve, /objects, /_edge handlers and router
+src/metrics.ts             Prometheus registry + syslog listener for nginx access lines
+src/contentType.ts         Content-Type and Cache-Control policy
+k8s/                       ServiceAccount, ConfigMap, Deployment, Service
+local/                     compose harness with fake-gcs-server and MinIO
+```

--- a/apps/dashboard-edge/README.md
+++ b/apps/dashboard-edge/README.md
@@ -144,11 +144,28 @@ Other settings: `EDGE_RULES_FILE` (default `/etc/edge/rules/rules.json`),
 | `/_edge/healthz` | Liveness: the app is up. |
 | `/_edge/ready` | Readiness: rules loaded and the default rule healthy. |
 | `/_edge/status` | JSON: every rule with its resolved bundle, version, fingerprint, cache mode, health and last error; storage description; last reload and health check. |
-| `/_edge/metrics` | Prometheus: `edge_requests_total{rule,cache,status}` (from nginx's access log, shipped over local syslog), `edge_upstream_errors_total{rule}`, `edge_resolve_total{rule}`, `edge_origin_requests_total{result}`, `edge_rule_healthy{rule}`. |
 
 nginx refuses these for requests carrying `x-original-host`, which the
 VirtualService sets on external traffic, so they are only reachable inside
 the cluster or via `kubectl port-forward`.
+
+## Metrics
+
+Metrics are pushed, not scraped: the app runs the OpenTelemetry NodeSDK with
+a periodic OTLP/HTTP exporter, the same setup as the backend, controlled by
+the same variables (`ENABLE_OTEL_METRICS`, default `true`; `OTEL_BASE_URL`,
+default `http://localhost:4318`; `OTEL_SERVICE_NAME`, default
+`xyne-spaces-dashboard-edge`; `OTEL_EXPORT_INTERVAL_MS`, default 60000). In
+the cluster `OTEL_BASE_URL` points at the collector in the `monitoring`
+namespace. Instruments:
+
+| Metric | Attributes | Source |
+|---|---|---|
+| `edge_requests_total` | `rule`, `cache` (nginx cache status), `status` | nginx's JSON access log, shipped over local syslog into the app |
+| `edge_upstream_errors_total` | `rule` | same, origin responses with a 5xx status |
+| `edge_resolve_total` | `rule` (or `none`, `not_ready`, `bad_request`) | the resolver |
+| `edge_origin_requests_total` | `result` (`ok`, `not_found`, `not_modified`, `error`) | the objects endpoint |
+| `edge_rule_healthy` | `rule` | gauge, 1 when the rule's bundle exists at the origin |
 
 Every response carries `X-Edge-Rule`, `X-Edge-Bundle`, `X-Edge-Version`
 (the cache key's version and fingerprint), `X-Edge-Object`, `X-Edge-Cache`
@@ -271,7 +288,8 @@ src/rules/match.ts         pure matcher: rules x request -> bundle + object + ke
 src/rules/store.ts         load, validate, health-check, fingerprint, hot-reload
 src/origin/                storage (gcs/s3/azure via @xyne/storage), http
 src/http/                  /resolve, /objects, /_edge handlers and router
-src/metrics.ts             Prometheus registry + syslog listener for nginx access lines
+src/telemetry.ts           OpenTelemetry NodeSDK + OTLP/HTTP metric exporter
+src/metrics.ts             OTel instruments + syslog listener for nginx access lines
 src/contentType.ts         Content-Type and Cache-Control policy
 k8s/                       ServiceAccount, ConfigMap, Deployment, Service
 local/                     compose harness with fake-gcs-server and MinIO

--- a/apps/dashboard-edge/docker-entrypoint.sh
+++ b/apps/dashboard-edge/docker-entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Render nginx.conf from the template, start the edge app (Node) on loopback,
+# then run nginx in the foreground.
+set -eu
+
+export LOG_LEVEL="${LOG_LEVEL:-info}"
+export CACHE_MAX_SIZE="${CACHE_MAX_SIZE:-2g}"
+export CACHE_INACTIVE="${CACHE_INACTIVE:-7d}"
+export CACHE_TTL="${CACHE_TTL:-30d}"
+export EDGE_APP_ADDR="${EDGE_APP_ADDR:-127.0.0.1}"
+export EDGE_APP_PORT="${EDGE_APP_PORT:-9101}"
+export EDGE_SYSLOG_PORT="${EDGE_SYSLOG_PORT:-9102}"
+
+mkdir -p /var/run/edge /var/cache/edge
+envsubst '${LOG_LEVEL} ${CACHE_MAX_SIZE} ${CACHE_INACTIVE} ${EDGE_APP_PORT} ${EDGE_SYSLOG_PORT}' \
+  < /opt/edge/nginx.conf.template > /var/run/edge/nginx.conf
+envsubst '${CACHE_TTL}' < /opt/edge/proxy-origin.conf.template > /var/run/edge/proxy-origin.conf
+
+# The edge app owns rules, storage access and status. Restarted if it ever
+# exits; nginx keeps serving cached objects meanwhile.
+(
+  set +e # the loop must survive a non-zero exit from the app
+  while :; do
+    node /opt/edge/app/dist/main.js
+    echo "edge app exited with $?, restarting in 1s" >&2
+    sleep 1
+  done
+) &
+
+i=0
+until curl -sf "http://${EDGE_APP_ADDR}:${EDGE_APP_PORT}/_edge/healthz" >/dev/null 2>&1; do
+  i=$((i + 1))
+  [ "$i" -ge 100 ] && { echo "edge app did not become healthy" >&2; break; }
+  sleep 0.2
+done
+
+exec nginx -c /var/run/edge/nginx.conf -g 'daemon off;'

--- a/apps/dashboard-edge/eslint.config.mjs
+++ b/apps/dashboard-edge/eslint.config.mjs
@@ -1,0 +1,19 @@
+import tseslint from 'typescript-eslint';
+
+export default [
+  ...tseslint.configs.recommended,
+  {
+    files: ['src/**/*.ts'],
+    rules: {
+      'no-console': 'error',
+      eqeqeq: ['error', 'always'],
+      curly: ['error', 'all'],
+      'prefer-const': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+      ],
+      '@typescript-eslint/explicit-function-return-type': 'warn',
+    },
+  },
+];

--- a/apps/dashboard-edge/k8s/configmap-rules.yaml
+++ b/apps/dashboard-edge/k8s/configmap-rules.yaml
@@ -1,0 +1,53 @@
+# The live routing table. Edit and apply; the edge picks it up within
+# EDGE_RELOAD_INTERVAL seconds of kubelet syncing the mount (about a minute)
+# with no restart. Rules are evaluated top to bottom, first match wins, and
+# the last rule must be the catch-all default. See apps/dashboard-edge/README.md.
+#
+# "bundle" is a lane prefix in the bucket exactly as the Jenkins pipeline
+# names it: main, release-YYYYMMDD, devqa-xyne-<name>, or a branch name with
+# its fix/feat/feature prefix stripped, plus <lane>-sdlc for the SDLC-mode
+# build of the same commit (served under /sdlc-app/ with strip_prefix). Never a commit hash: a lane is
+# overwritten in place on every build and the edge fingerprints index.html.
+# Every static prefix here must exist before the rule can go live.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: xyne-dashboard-edge-rules
+  namespace: xyne-apps
+data:
+  rules.json: |
+    {
+      "rules": [
+        {
+          "id": "sdlc",
+          "match": { "path_prefix": "/sdlc-app/" },
+          "bundle": "main-sdlc",
+          "version": 1,
+          "strip_prefix": "/sdlc-app"
+        },
+        {
+          "id": "playground-header",
+          "match": { "header": { "name": "x-route-env", "exact": "playground" } },
+          "bundle": "release-20260902",
+          "version": 1
+        },
+        {
+          "id": "playground-cookie",
+          "match": { "cookie": { "name": "x-route-env", "regex": "^playground$" } },
+          "bundle": "release-20260902",
+          "version": 1
+        },
+        {
+          "id": "devqa",
+          "match": { "user_agent": { "regex": "devqa-xyne-([A-Za-z0-9_-]+)" } },
+          "bundle": "devqa-xyne-$1",
+          "cache": "never"
+        },
+        {
+          "id": "default",
+          "match": { "path_prefix": "/" },
+          "bundle": "main",
+          "version": 1
+        }
+      ]
+    }

--- a/apps/dashboard-edge/local/.gitignore
+++ b/apps/dashboard-edge/local/.gitignore
@@ -1,0 +1,1 @@
+.bundles/

--- a/apps/dashboard-edge/local/docker-compose.yml
+++ b/apps/dashboard-edge/local/docker-compose.yml
@@ -50,6 +50,15 @@ services:
       minio:
         condition: service_healthy
 
+  # Receives the edges' OTLP metrics and prints them (docker compose logs otel).
+  otel:
+    image: otel/opentelemetry-collector:0.116.1
+    command: ["--config=/etc/otel/config.yaml"]
+    volumes:
+      - ./otel-collector.yaml:/etc/otel/config.yaml:ro
+    ports:
+      - "4318:4318"
+
   edge:
     build:
       context: ../../..
@@ -60,6 +69,8 @@ services:
       STORAGE_ENDPOINT: http://fake-gcs:4443
       STORAGE_AUTH: none
       EDGE_RELOAD_INTERVAL: "2"
+      OTEL_BASE_URL: http://otel:4318
+      OTEL_EXPORT_INTERVAL_MS: "5000"
       LOG_LEVEL: info
     volumes:
       - ./rules.json:/etc/edge/rules/rules.json:ro
@@ -84,6 +95,8 @@ services:
       AWS_ACCESS_KEY_ID: minioadmin
       AWS_SECRET_ACCESS_KEY: minioadmin
       EDGE_RELOAD_INTERVAL: "2"
+      OTEL_BASE_URL: http://otel:4318
+      OTEL_EXPORT_INTERVAL_MS: "5000"
       LOG_LEVEL: info
     volumes:
       - ./rules.json:/etc/edge/rules/rules.json:ro

--- a/apps/dashboard-edge/local/docker-compose.yml
+++ b/apps/dashboard-edge/local/docker-compose.yml
@@ -1,0 +1,94 @@
+# Local run against emulators: fake-gcs-server (GCS backend) and MinIO (S3
+# backend). Two edge instances share the same rules.json.
+#   cd apps/dashboard-edge/local
+#   docker compose up --build -d
+#   ./seed.sh                      # creates buckets and four sample bundles
+#   curl -si localhost:8089/ | head -20     # GCS-backed edge
+#   curl -si localhost:8090/ | head -20     # S3-backed edge (MinIO)
+#   curl -s localhost:8089/_edge/status | jq
+# Edit rules.json; both edges reload it within EDGE_RELOAD_INTERVAL seconds.
+services:
+  fake-gcs:
+    image: mirror.gcr.io/fsouza/fake-gcs-server:latest
+    command: ["-scheme", "http", "-port", "4443", "-external-url", "http://localhost:4443", "-public-host", "fake-gcs:4443"]
+    ports:
+      - "4443:4443"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:4443/storage/v1/b"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+
+  minio:
+    image: quay.io/minio/minio:latest
+    command: ["server", "/data"]
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+
+  # One-shot: copies ./.bundles into MinIO. Run by seed.sh.
+  mc:
+    image: quay.io/minio/mc:latest
+    profiles: ["seed"]
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - >
+        mc alias set local http://minio:9000 minioadmin minioadmin &&
+        mc mb -p local/xyne-frontend-bundles &&
+        mc cp -r /bundles/ local/xyne-frontend-bundles/ &&
+        echo seeded minio
+    volumes:
+      - ./.bundles:/bundles:ro
+    depends_on:
+      minio:
+        condition: service_healthy
+
+  edge:
+    build:
+      context: ../../..
+      dockerfile: apps/dashboard-edge/Dockerfile
+    environment:
+      STORAGE_BACKEND: gcs
+      STORAGE_BUCKET: xyne-frontend-bundles
+      STORAGE_ENDPOINT: http://fake-gcs:4443
+      STORAGE_AUTH: none
+      EDGE_RELOAD_INTERVAL: "2"
+      LOG_LEVEL: info
+    volumes:
+      - ./rules.json:/etc/edge/rules/rules.json:ro
+    ports:
+      - "8089:8080"
+    depends_on:
+      fake-gcs:
+        condition: service_healthy
+
+  edge-s3:
+    build:
+      context: ../../..
+      dockerfile: apps/dashboard-edge/Dockerfile
+    environment:
+      STORAGE_BACKEND: s3
+      STORAGE_BUCKET: xyne-frontend-bundles
+      STORAGE_ENDPOINT: http://minio:9000
+      # STORAGE_AUTH=sdk (default): the credential helper resolves these
+      # through the AWS SDK default chain, the same path IRSA or instance
+      # metadata would take in a cluster.
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      EDGE_RELOAD_INTERVAL: "2"
+      LOG_LEVEL: info
+    volumes:
+      - ./rules.json:/etc/edge/rules/rules.json:ro
+    ports:
+      - "8090:8080"
+    depends_on:
+      minio:
+        condition: service_healthy

--- a/apps/dashboard-edge/local/otel-collector.yaml
+++ b/apps/dashboard-edge/local/otel-collector.yaml
@@ -1,0 +1,18 @@
+# Local OpenTelemetry collector for the compose harness: receives the edge's
+# OTLP/HTTP metrics and prints them, so `docker compose logs otel` shows what
+# the cluster collector would receive.
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [debug]

--- a/apps/dashboard-edge/local/rules.json
+++ b/apps/dashboard-edge/local/rules.json
@@ -1,0 +1,42 @@
+{
+  "rules": [
+    {
+      "id": "sdlc",
+      "match": { "path_prefix": "/sdlc-app/" },
+      "bundle": "main-sdlc",
+      "version": 1,
+      "strip_prefix": "/sdlc-app"
+    },
+    {
+      "id": "playground-header",
+      "match": { "header": { "name": "x-route-env", "exact": "playground" } },
+      "bundle": "release-20260101",
+      "cache": "ttl",
+      "ttl": "30s"
+    },
+    {
+      "id": "playground-cookie",
+      "match": { "cookie": { "name": "x-route-env", "regex": "^playground$" } },
+      "bundle": "release-20260101",
+      "cache": "ttl",
+      "ttl": "30s"
+    },
+    {
+      "id": "missing",
+      "match": { "header": { "name": "x-route-env", "exact": "missing" } },
+      "bundle": "nope"
+    },
+    {
+      "id": "devqa",
+      "match": { "user_agent": { "regex": "devqa-xyne-([A-Za-z0-9_-]+)" } },
+      "bundle": "devqa-xyne-$1",
+      "cache": "never"
+    },
+    {
+      "id": "default",
+      "match": { "path_prefix": "/" },
+      "bundle": "main",
+      "version": 1
+    }
+  ]
+}

--- a/apps/dashboard-edge/local/seed.sh
+++ b/apps/dashboard-edge/local/seed.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Generate sample bundles under ./.bundles and load them into fake-gcs-server
+# and MinIO for the local compose setup.
+set -eu
+cd "$(dirname "$0")"
+HOST="${FAKE_GCS_HOST:-localhost:4443}"
+BUCKET="${STORAGE_BUCKET:-xyne-frontend-bundles}"
+OUT=.bundles
+
+rm -rf "$OUT"
+bundle() { # bundle <prefix> <label>
+  d="$OUT/$1"
+  mkdir -p "$d/assets" "$d/chunks"
+  printf '<!doctype html><title>%s</title><script type=module src=/assets/app.%s.js></script><h1>%s</h1>\n' "$2" "$2" "$2" > "$d/index.html"
+  printf "console.log('%s')\n" "$2" > "$d/assets/app.$2.js"
+  printf 'h1{color:red}\n' > "$d/assets/style.$2.css"
+  printf '{"bundle":"%s"}\n' "$1" > "$d/version.json"
+  printf "self.addEventListener('fetch',()=>{})\n" > "$d/sw.js"
+  printf 'export default 1\n' > "$d/chunks/lazy.$2.mjs"
+}
+# Lane names as the Jenkins pipeline writes them (flat, no commit hashes);
+# the second argument is only a label baked into the sample files.
+bundle main aaa111
+bundle release-20260101 bbb222
+bundle main-sdlc ccc333
+bundle devqa-xyne-feature-x featurex
+
+# --- fake-gcs -------------------------------------------------------------
+until curl -sf "http://${HOST}/storage/v1/b" >/dev/null; do sleep 1; done
+curl -s -X POST "http://${HOST}/storage/v1/b?project=local" \
+  -H "Content-Type: application/json" -d "{\"name\":\"${BUCKET}\"}" >/dev/null || true
+find "$OUT" -type f | while read -r f; do
+  object="${f#$OUT/}"
+  encoded=$(printf '%s' "$object" | sed 's#/#%2F#g')
+  curl -s -X POST "http://${HOST}/upload/storage/v1/b/${BUCKET}/o?uploadType=media&name=${encoded}" \
+    -H "Content-Type: application/octet-stream" --data-binary "@$f" >/dev/null
+done
+echo "seeded fake-gcs: $(find "$OUT" -type f | wc -l | tr -d ' ') objects"
+
+# --- minio ------------------------------------------------------------------
+docker compose --profile seed run --rm mc

--- a/apps/dashboard-edge/nginx/nginx.conf
+++ b/apps/dashboard-edge/nginx/nginx.conf
@@ -1,0 +1,166 @@
+# Dashboard edge. Rendered by docker-entrypoint.sh with envsubst; only the
+# ${VARS} listed there are substituted, everything else is literal nginx.
+#
+# nginx is config only: the loopback edge app (Node) resolves rules and
+# fetches objects; nginx caches and serves.
+worker_processes auto;
+error_log /dev/stderr ${LOG_LEVEL};
+pid /var/run/edge/nginx.pid;
+
+events {
+    worker_connections 4096;
+}
+
+http {
+    default_type application/octet-stream;
+
+    log_format edge escape=json
+        '{"time":"$time_iso8601","remote_addr":"$remote_addr","xff":"$http_x_forwarded_for",'
+        '"method":"$request_method","uri":"$request_uri","status":$status,"bytes":$body_bytes_sent,'
+        '"request_time":$request_time,"upstream_time":"$upstream_response_time","upstream_status":"$upstream_status",'
+        '"rule":"$edge_rule","bundle":"$edge_bundle","object":"$edge_object","cache":"$upstream_cache_status",'
+        '"version":"$edge_version",'
+        '"user_agent":"$http_user_agent"}';
+    access_log /dev/stdout edge;
+    # Same lines into the edge app for per-rule / cache-status metrics.
+    access_log syslog:server=127.0.0.1:${EDGE_SYSLOG_PORT},tag=edge,nohostname edge;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+    server_tokens off;
+
+    # Runs as a non-root user; keep every writable path under /var/run/edge.
+    client_body_temp_path /var/run/edge/client_body;
+    proxy_temp_path /var/run/edge/proxy_temp;
+    fastcgi_temp_path /var/run/edge/fastcgi_temp;
+    uwsgi_temp_path /var/run/edge/uwsgi_temp;
+    scgi_temp_path /var/run/edge/scgi_temp;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_comp_level 5;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        text/javascript
+        application/javascript
+        application/json
+        application/xml+rss
+        application/wasm
+        image/svg+xml;
+
+    upstream edge_app {
+        server 127.0.0.1:${EDGE_APP_PORT};
+        keepalive 32;
+    }
+
+    # Disk cache. Freshness is controlled by the cache key (bundle + version +
+    # origin fingerprint), so entries live long and are evicted by size or
+    # inactivity.
+    proxy_cache_path /var/cache/edge levels=1:2 keys_zone=edge:64m
+        max_size=${CACHE_MAX_SIZE} inactive=${CACHE_INACTIVE} use_temp_path=off;
+
+    # The Istio VirtualService stamps x-original-host on external traffic.
+    map $http_x_original_host $edge_external {
+        default 1;
+        "" 0;
+    }
+
+    server {
+        listen 8080;
+        server_name _;
+        absolute_redirect off;
+
+        # Filled from the resolver's response headers (auth_request_set).
+        set $edge_rule "";
+        set $edge_bundle "";
+        set $edge_version "";
+        set $edge_object "";
+        set $edge_cache_mode "";
+        set $edge_bypass 0;
+        set $edge_spa 0;
+        set $edge_skipped "";
+
+        # Response headers for every location. Location-level add_header
+        # would override these, so none is used below.
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "no-referrer-when-downgrade" always;
+        add_header Content-Security-Policy "default-src 'self' http: https: ws: wss: data: blob: 'unsafe-inline' 'unsafe-eval'; connect-src 'self' http: https: ws: wss:; media-src 'self' blob: https:; img-src 'self' data: https: blob:;" always;
+        add_header X-Edge-Rule $edge_rule always;
+        add_header X-Edge-Bundle $edge_bundle always;
+        add_header X-Edge-Version $edge_version always;
+        add_header X-Edge-Object $edge_object always;
+        add_header X-Edge-Cache $upstream_cache_status always;
+        add_header X-Edge-Skipped $edge_skipped always;
+
+        # auth_request subrequest: which rule / bundle / object serves this?
+        location = /_resolve {
+            internal;
+            proxy_pass http://edge_app/resolve;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_pass_request_body off;
+            proxy_set_header Content-Length "";
+            # $uri here would be /_resolve (the subrequest's own). $request_uri is
+            # the client's raw request line, inherited by subrequests; the app
+            # normalises and decodes it. (A `set` in `location /` would not
+            # survive: subrequests re-run the server-level `set` defaults on
+            # the shared variable table.)
+            proxy_set_header X-Original-URI $request_uri;
+            proxy_set_header X-Original-Method $request_method;
+        }
+
+        # Internal endpoints: cluster-local or port-forward only.
+        location /_edge/ {
+            if ($edge_external) {
+                return 404;
+            }
+            proxy_pass http://edge_app;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+        }
+
+        location / {
+            auth_request /_resolve;
+            auth_request_set $edge_rule $upstream_http_x_edge_rule;
+            auth_request_set $edge_bundle $upstream_http_x_edge_bundle;
+            auth_request_set $edge_version $upstream_http_x_edge_version;
+            auth_request_set $edge_object $upstream_http_x_edge_object;
+            auth_request_set $edge_cache_mode $upstream_http_x_edge_cache_mode;
+            auth_request_set $edge_bypass $upstream_http_x_edge_bypass;
+            auth_request_set $edge_spa $upstream_http_x_edge_spa;
+            auth_request_set $edge_skipped $upstream_http_x_edge_skipped;
+
+            error_page 401 = @norule;
+            error_page 403 = @notready;
+            error_page 404 = @spa;
+            include /var/run/edge/proxy-origin.conf;
+        }
+
+        # Origin said 404: client-side routes get the bundle's index.html.
+        location @spa {
+            if ($edge_spa != 1) {
+                return 404;
+            }
+            set $edge_object index.html;
+            include /var/run/edge/proxy-origin.conf;
+        }
+
+        location @norule {
+            default_type text/plain;
+            return 404 "edge: no rule matched\n";
+        }
+
+        location @notready {
+            default_type text/plain;
+            return 503 "edge: rules not loaded\n";
+        }
+    }
+}

--- a/apps/dashboard-edge/nginx/proxy-origin.conf
+++ b/apps/dashboard-edge/nginx/proxy-origin.conf
@@ -1,0 +1,33 @@
+# Shared by `location /` and `@spa`: fetch one object from the edge app's
+# origin endpoint through the disk cache. $edge_* variables come from the
+# resolver (auth_request_set). The app sets Content-Type and the browser
+# Cache-Control, so the cached copy already carries them.
+proxy_pass http://edge_app/objects/$edge_bundle/$edge_object;
+proxy_http_version 1.1;
+proxy_set_header Connection "";
+proxy_set_header Host edge;
+proxy_set_header X-Edge-Cache-Mode $edge_cache_mode;
+proxy_set_header Cookie "";
+proxy_set_header Authorization "";
+proxy_set_header Accept-Encoding "";
+
+proxy_cache edge;
+proxy_cache_key "$edge_bundle|$edge_version|$edge_object";
+proxy_cache_bypass $edge_bypass;
+proxy_no_cache $edge_bypass;
+proxy_cache_valid 200 ${CACHE_TTL};
+proxy_cache_valid 404 10s;
+proxy_cache_methods GET HEAD;
+proxy_cache_convert_head on;
+proxy_cache_lock on;
+proxy_cache_lock_timeout 10s;
+proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+proxy_cache_background_update on;
+proxy_cache_revalidate on;
+proxy_ignore_headers Cache-Control Expires Set-Cookie X-Accel-Expires Vary;
+
+proxy_intercept_errors on;
+proxy_buffering on;
+proxy_connect_timeout 5s;
+proxy_read_timeout 60s;
+proxy_send_timeout 60s;

--- a/apps/dashboard-edge/package.json
+++ b/apps/dashboard-edge/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "xyne-spaces-dashboard-edge",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Dashboard edge: rule resolver, storage origin and status service behind nginx's disk cache",
+  "type": "module",
+  "main": "dist/main.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch src/main.ts",
+    "start": "node dist/main.js",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint 'src/**/*.ts'",
+    "format": "prettier --write 'src/**/*.ts'",
+    "format:check": "prettier --check 'src/**/*.ts'",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@xyne/storage": "workspace:*",
+    "prom-client": "^15.1.3",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "eslint": "^9.39.4",
+    "prettier": "^3.3.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0",
+    "typescript-eslint": "^8.62.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/apps/dashboard-edge/package.json
+++ b/apps/dashboard-edge/package.json
@@ -19,8 +19,11 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.209.0",
+    "@opentelemetry/sdk-metrics": "2.10.0",
+    "@opentelemetry/sdk-node": "^0.209.0",
     "@xyne/storage": "workspace:*",
-    "prom-client": "^15.1.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/dashboard-edge/rules.example.json
+++ b/apps/dashboard-edge/rules.example.json
@@ -1,0 +1,35 @@
+{
+  "rules": [
+    {
+      "id": "sdlc",
+      "match": { "path_prefix": "/sdlc-app/" },
+      "bundle": "main-sdlc",
+      "version": 1,
+      "strip_prefix": "/sdlc-app"
+    },
+    {
+      "id": "playground-header",
+      "match": { "header": { "name": "x-route-env", "exact": "playground" } },
+      "bundle": "release-20260902",
+      "version": 1
+    },
+    {
+      "id": "playground-cookie",
+      "match": { "cookie": { "name": "x-route-env", "regex": "^playground$" } },
+      "bundle": "release-20260902",
+      "version": 1
+    },
+    {
+      "id": "devqa",
+      "match": { "user_agent": { "regex": "devqa-xyne-([A-Za-z0-9_-]+)" } },
+      "bundle": "devqa-xyne-$1",
+      "cache": "never"
+    },
+    {
+      "id": "default",
+      "match": { "path_prefix": "/" },
+      "bundle": "main",
+      "version": 1
+    }
+  ]
+}

--- a/apps/dashboard-edge/src/config.ts
+++ b/apps/dashboard-edge/src/config.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  STORAGE_BACKEND: z.enum(['gcs', 's3', 'azure', 'http']).default('gcs'),
+  STORAGE_BUCKET: z.string().optional(),
+  STORAGE_ENDPOINT: z.string().optional(),
+  /** sdk: the provider SDK's default credential chain; none: unauthenticated; sas: Azure SAS token. */
+  STORAGE_AUTH: z.enum(['sdk', 'none', 'sas']).default('sdk'),
+  /** http backend only: static Authorization header value sent to the origin. */
+  STORAGE_AUTH_HEADER: z.string().optional(),
+  AWS_REGION: z.string().optional(),
+  GOOGLE_CLOUD_PROJECT: z.string().optional(),
+  AZURE_STORAGE_ACCOUNT: z.string().optional(),
+  AZURE_STORAGE_SAS_TOKEN: z.string().optional(),
+  EDGE_RULES_FILE: z.string().default('/etc/edge/rules/rules.json'),
+  EDGE_RELOAD_INTERVAL: z.coerce.number().positive().default(5),
+  EDGE_HEALTH_INTERVAL: z.coerce.number().positive().default(30),
+  EDGE_APP_ADDR: z.string().default('127.0.0.1'),
+  EDGE_APP_PORT: z.coerce.number().int().positive().default(9101),
+  EDGE_SYSLOG_PORT: z.coerce.number().int().positive().default(9102),
+  LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
+});
+
+export type StorageBackend = 'gcs' | 's3' | 'azure' | 'http';
+export type StorageAuth = 'sdk' | 'none' | 'sas';
+
+export interface Config {
+  storage: {
+    backend: StorageBackend;
+    bucket: string | undefined;
+    endpoint: string | undefined;
+    auth: StorageAuth;
+    authHeader: string | undefined;
+    awsRegion: string | undefined;
+    gcpProject: string | undefined;
+    azureAccount: string | undefined;
+    azureSasToken: string | undefined;
+  };
+  rulesFile: string;
+  reloadIntervalMs: number;
+  healthIntervalMs: number;
+  listen: { addr: string; port: number };
+  syslogPort: number;
+  logLevel: string;
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
+  const parsed = envSchema.safeParse(env);
+  if (!parsed.success) {
+    throw new Error(`invalid configuration: ${parsed.error.message}`);
+  }
+  const e = parsed.data;
+  if (e.STORAGE_BACKEND !== 'http' && !e.STORAGE_BUCKET) {
+    throw new Error(`STORAGE_BUCKET is required for STORAGE_BACKEND=${e.STORAGE_BACKEND}`);
+  }
+  if (e.STORAGE_BACKEND === 'http' && !e.STORAGE_ENDPOINT) {
+    throw new Error('STORAGE_ENDPOINT is required for STORAGE_BACKEND=http');
+  }
+  if (e.STORAGE_AUTH === 'sas' && e.STORAGE_BACKEND !== 'azure') {
+    throw new Error('STORAGE_AUTH=sas is only valid for STORAGE_BACKEND=azure');
+  }
+  return {
+    storage: {
+      backend: e.STORAGE_BACKEND,
+      bucket: e.STORAGE_BUCKET,
+      endpoint: e.STORAGE_ENDPOINT?.replace(/\/+$/, ''),
+      auth: e.STORAGE_AUTH,
+      authHeader: e.STORAGE_AUTH_HEADER,
+      awsRegion: e.AWS_REGION,
+      gcpProject: e.GOOGLE_CLOUD_PROJECT,
+      azureAccount: e.AZURE_STORAGE_ACCOUNT,
+      azureSasToken: e.AZURE_STORAGE_SAS_TOKEN,
+    },
+    rulesFile: e.EDGE_RULES_FILE,
+    reloadIntervalMs: e.EDGE_RELOAD_INTERVAL * 1000,
+    healthIntervalMs: e.EDGE_HEALTH_INTERVAL * 1000,
+    listen: { addr: e.EDGE_APP_ADDR, port: e.EDGE_APP_PORT },
+    syslogPort: e.EDGE_SYSLOG_PORT,
+    logLevel: e.LOG_LEVEL,
+  };
+}

--- a/apps/dashboard-edge/src/config.ts
+++ b/apps/dashboard-edge/src/config.ts
@@ -19,6 +19,11 @@ const envSchema = z.object({
   EDGE_APP_PORT: z.coerce.number().int().positive().default(9101),
   EDGE_SYSLOG_PORT: z.coerce.number().int().positive().default(9102),
   LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
+  /** Same names and defaults as the backend: metrics pushed over OTLP/HTTP to the collector. */
+  ENABLE_OTEL_METRICS: z.enum(['true', 'false', '1', '0']).default('true'),
+  OTEL_BASE_URL: z.string().default('http://localhost:4318'),
+  OTEL_SERVICE_NAME: z.string().default('xyne-spaces-dashboard-edge'),
+  OTEL_EXPORT_INTERVAL_MS: z.coerce.number().int().positive().default(60_000),
 });
 
 export type StorageBackend = 'gcs' | 's3' | 'azure' | 'http';
@@ -42,6 +47,12 @@ export interface Config {
   listen: { addr: string; port: number };
   syslogPort: number;
   logLevel: string;
+  otel: {
+    metricsEnabled: boolean;
+    baseUrl: string;
+    serviceName: string;
+    exportIntervalMs: number;
+  };
 }
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
@@ -77,5 +88,11 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     listen: { addr: e.EDGE_APP_ADDR, port: e.EDGE_APP_PORT },
     syslogPort: e.EDGE_SYSLOG_PORT,
     logLevel: e.LOG_LEVEL,
+    otel: {
+      metricsEnabled: e.ENABLE_OTEL_METRICS === 'true' || e.ENABLE_OTEL_METRICS === '1',
+      baseUrl: e.OTEL_BASE_URL.replace(/\/+$/, ''),
+      serviceName: e.OTEL_SERVICE_NAME,
+      exportIntervalMs: e.OTEL_EXPORT_INTERVAL_MS,
+    },
   };
 }

--- a/apps/dashboard-edge/src/contentType.ts
+++ b/apps/dashboard-edge/src/contentType.ts
@@ -1,0 +1,93 @@
+// Response header policy for objects served to browsers. gsutil guesses most
+// content types, but .mjs and friends come back as octet-stream and the
+// bundle is ours, so types are decided here by extension.
+
+export type CacheMode = 'versioned' | 'never' | 'ttl';
+
+const CONTENT_TYPES: Record<string, string> = {
+  html: 'text/html; charset=utf-8',
+  js: 'application/javascript; charset=utf-8',
+  mjs: 'application/javascript; charset=utf-8',
+  css: 'text/css; charset=utf-8',
+  json: 'application/json; charset=utf-8',
+  map: 'application/json',
+  svg: 'image/svg+xml',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  ico: 'image/x-icon',
+  woff: 'font/woff',
+  woff2: 'font/woff2',
+  ttf: 'font/ttf',
+  eot: 'application/vnd.ms-fontobject',
+  wasm: 'application/wasm',
+  onnx: 'application/octet-stream',
+  txt: 'text/plain; charset=utf-8',
+  xml: 'application/xml',
+  webm: 'video/webm',
+  mp4: 'video/mp4',
+  mp3: 'audio/mpeg',
+  zip: 'application/zip',
+};
+
+const LONG_LIVED = new Set([
+  'js',
+  'mjs',
+  'css',
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'ico',
+  'svg',
+  'webp',
+  'woff',
+  'woff2',
+  'ttf',
+  'eot',
+  'wasm',
+  'onnx',
+  'mp3',
+  'mp4',
+  'webm',
+]);
+
+export const NO_CACHE = 'no-cache, no-store, must-revalidate';
+const IMMUTABLE = 'public, max-age=31536000, immutable';
+const SHORT = 'public, max-age=300';
+
+export function extensionOf(object: string): string {
+  const match = /\.([A-Za-z0-9]+)$/.exec(object);
+  return match?.[1]?.toLowerCase() ?? '';
+}
+
+/** True when the path has no extension, i.e. a client-side route. */
+export function isRouteLike(object: string): boolean {
+  return extensionOf(object) === '';
+}
+
+export function contentTypeFor(object: string, fallback: string | undefined): string {
+  return CONTENT_TYPES[extensionOf(object)] ?? fallback ?? 'application/octet-stream';
+}
+
+/** Browser-facing Cache-Control. The edge's own cache is keyed, not timed. */
+export function cacheControlFor(mode: CacheMode, object: string): string {
+  if (mode === 'never') {
+    return NO_CACHE;
+  }
+  const ext = extensionOf(object);
+  if (
+    ext === 'html' ||
+    object === 'sw.js' ||
+    object === 'version.json' ||
+    object.startsWith('releases/')
+  ) {
+    return NO_CACHE;
+  }
+  if (LONG_LIVED.has(ext)) {
+    return IMMUTABLE;
+  }
+  return SHORT;
+}

--- a/apps/dashboard-edge/src/http/objects.ts
+++ b/apps/dashboard-edge/src/http/objects.ts
@@ -1,0 +1,127 @@
+// GET|HEAD /objects/<bundle>/<object>: stream one object from the origin.
+// nginx caches these responses; browser-facing Cache-Control and Content-Type
+// are decided here so the cached copy already carries them.
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { pipeline } from 'node:stream/promises';
+
+import { cacheControlFor, contentTypeFor, type CacheMode } from '../contentType.js';
+import { log } from '../log.js';
+import { metrics } from '../metrics.js';
+import type { ObjectInfo, Origin } from '../origin/index.js';
+
+const CACHE_MODES = new Set<string>(['versioned', 'never', 'ttl']);
+
+function parseKey(pathname: string): { bundle: string; object: string } | null {
+  const rest = pathname.replace(/^\/objects\//, '');
+  const slash = rest.indexOf('/');
+  if (slash <= 0) {
+    return null;
+  }
+  const decode = (s: string): string => s.split('/').map(decodeURIComponent).join('/');
+  let bundle: string;
+  let object: string;
+  try {
+    bundle = decode(rest.slice(0, slash));
+    object = decode(rest.slice(slash + 1));
+  } catch {
+    return null;
+  }
+  if (bundle === '' || object === '' || `${bundle}/${object}`.split('/').includes('..')) {
+    return null;
+  }
+  return { bundle, object };
+}
+
+function responseHeaders(
+  object: string,
+  mode: CacheMode,
+  info: ObjectInfo,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': contentTypeFor(object, info.contentType),
+    'Cache-Control': cacheControlFor(mode, object),
+  };
+  if (info.etag) {
+    headers['ETag'] = `"${info.etag}"`;
+  }
+  if (info.lastModified) {
+    headers['Last-Modified'] = info.lastModified.toUTCString();
+  }
+  if (info.size !== undefined) {
+    headers['Content-Length'] = String(info.size);
+  }
+  return headers;
+}
+
+function etagMatches(ifNoneMatch: string | undefined, etag: string | undefined): boolean {
+  if (!ifNoneMatch || !etag) {
+    return false;
+  }
+  return ifNoneMatch
+    .split(',')
+    .map((s) => s.trim().replace(/^W\//, '').replace(/"/g, ''))
+    .some((s) => s === '*' || s === etag);
+}
+
+export function makeObjectsHandler(
+  origin: Origin,
+): (req: IncomingMessage, res: ServerResponse, pathname: string) => Promise<void> {
+  return async (req, res, pathname) => {
+    const key = parseKey(pathname);
+    if (!key) {
+      res.writeHead(400, { 'Content-Type': 'text/plain', 'Cache-Control': 'no-store' });
+      res.end('edge: invalid object key\n');
+      return;
+    }
+    const objectKey = `${key.bundle}/${key.object}`;
+    const modeHeader = req.headers['x-edge-cache-mode'];
+    const mode = (
+      typeof modeHeader === 'string' && CACHE_MODES.has(modeHeader) ? modeHeader : 'versioned'
+    ) as CacheMode;
+    const ifNoneMatch = req.headers['if-none-match'];
+
+    try {
+      if (req.method === 'HEAD' || ifNoneMatch) {
+        const info = await origin.head(objectKey);
+        if (!info) {
+          metrics.originRequests.inc({ result: 'not_found' });
+          res.writeHead(404, { 'Content-Type': 'text/plain', 'Cache-Control': 'no-store' });
+          res.end();
+          return;
+        }
+        if (etagMatches(typeof ifNoneMatch === 'string' ? ifNoneMatch : undefined, info.etag)) {
+          metrics.originRequests.inc({ result: 'not_modified' });
+          res.writeHead(304, responseHeaders(key.object, mode, info));
+          res.end();
+          return;
+        }
+        if (req.method === 'HEAD') {
+          metrics.originRequests.inc({ result: 'ok' });
+          res.writeHead(200, responseHeaders(key.object, mode, info));
+          res.end();
+          return;
+        }
+      }
+
+      const read = await origin.get(objectKey);
+      if (!read) {
+        metrics.originRequests.inc({ result: 'not_found' });
+        res.writeHead(404, { 'Content-Type': 'text/plain', 'Cache-Control': 'no-store' });
+        res.end('edge: object not found\n');
+        return;
+      }
+      res.writeHead(200, responseHeaders(key.object, mode, read.info));
+      await pipeline(read.stream, res);
+      metrics.originRequests.inc({ result: 'ok' });
+    } catch (err) {
+      metrics.originRequests.inc({ result: 'error' });
+      log.error('origin fetch failed', { key: objectKey, err });
+      if (!res.headersSent) {
+        res.writeHead(502, { 'Content-Type': 'text/plain', 'Cache-Control': 'no-store' });
+        res.end('edge: origin error\n');
+      } else {
+        res.destroy();
+      }
+    }
+  };
+}

--- a/apps/dashboard-edge/src/http/resolve.ts
+++ b/apps/dashboard-edge/src/http/resolve.ts
@@ -1,0 +1,144 @@
+// GET /resolve: nginx's auth_request subrequest. Answers with the rule,
+// bundle, cache key version and object path as headers, which nginx turns
+// into its cache key and proxy_pass target.
+//
+//   200  matched: X-Edge-* headers set
+//   401  no rule matched           -> nginx error_page 401 = @norule  (404)
+//   403  rules not loaded yet      -> nginx error_page 403 = @notready (503)
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import { isRouteLike } from '../contentType.js';
+import { metrics } from '../metrics.js';
+import { keyVersion, resolve, type RequestView } from '../rules/match.js';
+import type { RulesStore } from '../rules/store.js';
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function parseCookies(header: string | undefined): Record<string, string> {
+  const cookies: Record<string, string> = {};
+  if (!header) {
+    return cookies;
+  }
+  for (const pair of header.split(';')) {
+    const eq = pair.indexOf('=');
+    if (eq <= 0) {
+      continue;
+    }
+    const name = pair.slice(0, eq).trim();
+    if (name !== '' && !(name in cookies)) {
+      cookies[name] = pair.slice(eq + 1).trim();
+    }
+  }
+  return cookies;
+}
+
+/** Header-safe rendering of the skipped list: printable ASCII only. */
+function headerSafe(text: string): string {
+  return text.replace(/[^\x20-\x7e]/g, '?').slice(0, 1024);
+}
+
+function encodeObject(object: string): string {
+  return object.split('/').map(encodeURIComponent).join('/');
+}
+
+/**
+ * nginx passes the raw request line URI ($request_uri). Normalise it the way
+ * nginx's $uri would: drop the query string, percent-decode, collapse
+ * repeated slashes and resolve dot segments. Returns null when the path
+ * cannot be decoded or climbs above the root.
+ */
+export function normalisePath(rawUri: string): string | null {
+  const q = rawUri.indexOf('?');
+  const raw = q >= 0 ? rawUri.slice(0, q) : rawUri;
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    return null;
+  }
+  const segments: string[] = [];
+  for (const segment of decoded.split('/')) {
+    if (segment === '' || segment === '.') {
+      continue;
+    }
+    if (segment === '..') {
+      if (segments.length === 0) {
+        return null;
+      }
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  if (segments.length === 0) {
+    return '/';
+  }
+  const trailing = /\/\.{0,2}$/.test(decoded) ? '/' : '';
+  return `/${segments.join('/')}${trailing}`;
+}
+
+export function buildRequestView(req: IncomingMessage): RequestView | null {
+  const headers: Record<string, string | undefined> = {};
+  for (const [name, value] of Object.entries(req.headers)) {
+    headers[name] = headerValue(value);
+  }
+  const path = normalisePath(headers['x-original-uri'] ?? '/');
+  if (path === null) {
+    return null;
+  }
+  return {
+    path,
+    headers,
+    cookies: parseCookies(headers['cookie']),
+    userAgent: headers['user-agent'] ?? '',
+  };
+}
+
+export function makeResolveHandler(
+  store: RulesStore,
+): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
+  return async (req, res) => {
+    const ruleset = store.current();
+    if (!ruleset) {
+      metrics.resolves.inc({ rule: 'not_ready' });
+      res.writeHead(403, { 'X-Edge-Rule': 'none', 'X-Edge-Error': 'rules not loaded' });
+      res.end();
+      return;
+    }
+
+    const view = buildRequestView(req);
+    if (!view) {
+      metrics.resolves.inc({ rule: 'bad_request' });
+      res.writeHead(401, { 'X-Edge-Rule': 'none', 'X-Edge-Error': 'invalid request path' });
+      res.end();
+      return;
+    }
+    const { resolution, skipped } = await resolve(ruleset.rules, view, (b) => store.exists(b));
+    const headers: Record<string, string> = {};
+    if (skipped.length > 0) {
+      headers['X-Edge-Skipped'] = headerSafe(
+        skipped.map((s) => `${s.id} (${s.reason})`).join('; '),
+      );
+    }
+    if (!resolution) {
+      metrics.resolves.inc({ rule: 'none' });
+      headers['X-Edge-Rule'] = 'none';
+      res.writeHead(401, headers);
+      res.end();
+      return;
+    }
+
+    metrics.resolves.inc({ rule: resolution.rule.id });
+    headers['X-Edge-Rule'] = resolution.rule.id;
+    headers['X-Edge-Bundle'] = resolution.bundle;
+    headers['X-Edge-Version'] = keyVersion(resolution);
+    headers['X-Edge-Object'] = encodeObject(resolution.object);
+    headers['X-Edge-Cache-Mode'] = resolution.cache;
+    headers['X-Edge-Bypass'] = resolution.cache === 'never' ? '1' : '0';
+    headers['X-Edge-Spa'] = isRouteLike(resolution.object) ? '1' : '0';
+    res.writeHead(200, headers);
+    res.end();
+  };
+}

--- a/apps/dashboard-edge/src/http/server.ts
+++ b/apps/dashboard-edge/src/http/server.ts
@@ -1,0 +1,48 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+
+import type { Config } from '../config.js';
+import { log } from '../log.js';
+import type { Origin } from '../origin/index.js';
+import type { RulesStore } from '../rules/store.js';
+import { makeObjectsHandler } from './objects.js';
+import { makeResolveHandler } from './resolve.js';
+import { makeStatusHandlers } from './status.js';
+
+export function createEdgeServer(store: RulesStore, origin: Origin, config: Config): Server {
+  const resolveHandler = makeResolveHandler(store);
+  const objectsHandler = makeObjectsHandler(origin);
+  const statusHandlers = makeStatusHandlers(store, origin, config);
+
+  const route = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+    const pathname = (req.url ?? '/').split('?')[0] ?? '/';
+    if (pathname === '/resolve') {
+      await resolveHandler(req, res);
+      return;
+    }
+    if (pathname.startsWith('/objects/') && (req.method === 'GET' || req.method === 'HEAD')) {
+      await objectsHandler(req, res, pathname);
+      return;
+    }
+    const status = statusHandlers[pathname];
+    if (status && (req.method === 'GET' || req.method === 'HEAD')) {
+      await status(req, res);
+      return;
+    }
+    res.writeHead(404, { 'Content-Type': 'text/plain', 'Cache-Control': 'no-store' });
+    res.end('not found\n');
+  };
+
+  const server = createServer((req, res) => {
+    route(req, res).catch((err: unknown) => {
+      log.error('unhandled request error', { url: req.url, err });
+      if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('edge: internal error\n');
+      } else {
+        res.destroy();
+      }
+    });
+  });
+  server.keepAliveTimeout = 65_000;
+  return server;
+}

--- a/apps/dashboard-edge/src/http/server.ts
+++ b/apps/dashboard-edge/src/http/server.ts
@@ -23,7 +23,9 @@ export function createEdgeServer(store: RulesStore, origin: Origin, config: Conf
       await objectsHandler(req, res, pathname);
       return;
     }
-    const status = statusHandlers[pathname];
+    // Own keys only: a request for /constructor or /__proto__ must not reach
+    // Object.prototype through the lookup.
+    const status = Object.hasOwn(statusHandlers, pathname) ? statusHandlers[pathname] : undefined;
     if (status && (req.method === 'GET' || req.method === 'HEAD')) {
       await status(req, res);
       return;

--- a/apps/dashboard-edge/src/http/server.ts
+++ b/apps/dashboard-edge/src/http/server.ts
@@ -23,10 +23,22 @@ export function createEdgeServer(store: RulesStore, origin: Origin, config: Conf
       await objectsHandler(req, res, pathname);
       return;
     }
-    const status = statusHandlers.get(pathname);
-    if (status && (req.method === 'GET' || req.method === 'HEAD')) {
-      await status(req, res);
-      return;
+    // Static dispatch on purpose: no lookup keyed by the request path, so
+    // the callee is never derived from request data.
+    if (req.method === 'GET' || req.method === 'HEAD') {
+      switch (pathname) {
+        case '/_edge/healthz':
+          await statusHandlers.healthz(req, res);
+          return;
+        case '/_edge/ready':
+          await statusHandlers.ready(req, res);
+          return;
+        case '/_edge/status':
+          await statusHandlers.status(req, res);
+          return;
+        default:
+          break;
+      }
     }
     res.writeHead(404, { 'Content-Type': 'text/plain', 'Cache-Control': 'no-store' });
     res.end('not found\n');

--- a/apps/dashboard-edge/src/http/server.ts
+++ b/apps/dashboard-edge/src/http/server.ts
@@ -23,9 +23,7 @@ export function createEdgeServer(store: RulesStore, origin: Origin, config: Conf
       await objectsHandler(req, res, pathname);
       return;
     }
-    // Own keys only: a request for /constructor or /__proto__ must not reach
-    // Object.prototype through the lookup.
-    const status = Object.hasOwn(statusHandlers, pathname) ? statusHandlers[pathname] : undefined;
+    const status = statusHandlers.get(pathname);
     if (status && (req.method === 'GET' || req.method === 'HEAD')) {
       await status(req, res);
       return;

--- a/apps/dashboard-edge/src/http/status.ts
+++ b/apps/dashboard-edge/src/http/status.ts
@@ -4,7 +4,6 @@ import { hostname } from 'node:os';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import type { Config } from '../config.js';
-import { registry } from '../metrics.js';
 import type { Origin } from '../origin/index.js';
 import type { RulesStore } from '../rules/store.js';
 
@@ -50,12 +49,6 @@ export function makeStatusHandlers(
     };
     res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
     res.end(`${JSON.stringify(body)}\n`);
-  });
-
-  handlers.set('/_edge/metrics', async (_req, res): Promise<void> => {
-    const text = await registry.metrics();
-    res.writeHead(200, { 'Content-Type': registry.contentType, 'Cache-Control': 'no-store' });
-    res.end(text);
   });
 
   return handlers;

--- a/apps/dashboard-edge/src/http/status.ts
+++ b/apps/dashboard-edge/src/http/status.ts
@@ -8,48 +8,55 @@ import { registry } from '../metrics.js';
 import type { Origin } from '../origin/index.js';
 import type { RulesStore } from '../rules/store.js';
 
+export type StatusHandler = (req: IncomingMessage, res: ServerResponse) => Promise<void>;
+
 export function makeStatusHandlers(
   store: RulesStore,
   origin: Origin,
   config: Config,
-): Record<string, (req: IncomingMessage, res: ServerResponse) => Promise<void>> {
-  return {
-    '/_edge/healthz': async (_req, res): Promise<void> => {
-      res.writeHead(200, { 'Content-Type': 'text/plain', 'Cache-Control': 'no-store' });
-      res.end('ok\n');
-    },
-    '/_edge/ready': async (_req, res): Promise<void> => {
-      const state = store.ready();
-      res.writeHead(state.ready ? 200 : 503, {
-        'Content-Type': 'text/plain',
-        'Cache-Control': 'no-store',
-      });
-      res.end(state.ready ? 'ready\n' : `not ready: ${state.reason}\n`);
-    },
-    '/_edge/status': async (_req, res): Promise<void> => {
-      let storage: Record<string, unknown>;
-      try {
-        storage = origin.describe();
-      } catch (err) {
-        storage = { error: (err as Error).message };
-      }
-      const body = {
-        ...store.status(),
-        storage,
-        hostname: hostname(),
-        now: new Date().toISOString(),
-        config: {
-          reload_interval_s: config.reloadIntervalMs / 1000,
-          health_interval_s: config.healthIntervalMs / 1000,
-        },
-      };
-      res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
-      res.end(`${JSON.stringify(body)}\n`);
-    },
-    '/_edge/metrics': async (_req, res): Promise<void> => {
-      const text = await registry.metrics();
-      res.writeHead(200, { 'Content-Type': registry.contentType, 'Cache-Control': 'no-store' });
-      res.end(text);
-    },
-  };
+): Map<string, StatusHandler> {
+  const handlers = new Map<string, StatusHandler>();
+
+  handlers.set('/_edge/healthz', async (_req, res): Promise<void> => {
+    res.writeHead(200, { 'Content-Type': 'text/plain', 'Cache-Control': 'no-store' });
+    res.end('ok\n');
+  });
+
+  handlers.set('/_edge/ready', async (_req, res): Promise<void> => {
+    const state = store.ready();
+    res.writeHead(state.ready ? 200 : 503, {
+      'Content-Type': 'text/plain',
+      'Cache-Control': 'no-store',
+    });
+    res.end(state.ready ? 'ready\n' : `not ready: ${state.reason}\n`);
+  });
+
+  handlers.set('/_edge/status', async (_req, res): Promise<void> => {
+    let storage: Record<string, unknown>;
+    try {
+      storage = origin.describe();
+    } catch (err) {
+      storage = { error: (err as Error).message };
+    }
+    const body = {
+      ...store.status(),
+      storage,
+      hostname: hostname(),
+      now: new Date().toISOString(),
+      config: {
+        reload_interval_s: config.reloadIntervalMs / 1000,
+        health_interval_s: config.healthIntervalMs / 1000,
+      },
+    };
+    res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+    res.end(`${JSON.stringify(body)}\n`);
+  });
+
+  handlers.set('/_edge/metrics', async (_req, res): Promise<void> => {
+    const text = await registry.metrics();
+    res.writeHead(200, { 'Content-Type': registry.contentType, 'Cache-Control': 'no-store' });
+    res.end(text);
+  });
+
+  return handlers;
 }

--- a/apps/dashboard-edge/src/http/status.ts
+++ b/apps/dashboard-edge/src/http/status.ts
@@ -9,47 +9,52 @@ import type { RulesStore } from '../rules/store.js';
 
 export type StatusHandler = (req: IncomingMessage, res: ServerResponse) => Promise<void>;
 
+/** One named handler per endpoint; the router dispatches to them statically. */
+export interface StatusHandlers {
+  healthz: StatusHandler;
+  ready: StatusHandler;
+  status: StatusHandler;
+}
+
 export function makeStatusHandlers(
   store: RulesStore,
   origin: Origin,
   config: Config,
-): Map<string, StatusHandler> {
-  const handlers = new Map<string, StatusHandler>();
+): StatusHandlers {
+  return {
+    healthz: async (_req, res): Promise<void> => {
+      res.writeHead(200, { 'Content-Type': 'text/plain', 'Cache-Control': 'no-store' });
+      res.end('ok\n');
+    },
 
-  handlers.set('/_edge/healthz', async (_req, res): Promise<void> => {
-    res.writeHead(200, { 'Content-Type': 'text/plain', 'Cache-Control': 'no-store' });
-    res.end('ok\n');
-  });
+    ready: async (_req, res): Promise<void> => {
+      const state = store.ready();
+      res.writeHead(state.ready ? 200 : 503, {
+        'Content-Type': 'text/plain',
+        'Cache-Control': 'no-store',
+      });
+      res.end(state.ready ? 'ready\n' : `not ready: ${state.reason}\n`);
+    },
 
-  handlers.set('/_edge/ready', async (_req, res): Promise<void> => {
-    const state = store.ready();
-    res.writeHead(state.ready ? 200 : 503, {
-      'Content-Type': 'text/plain',
-      'Cache-Control': 'no-store',
-    });
-    res.end(state.ready ? 'ready\n' : `not ready: ${state.reason}\n`);
-  });
-
-  handlers.set('/_edge/status', async (_req, res): Promise<void> => {
-    let storage: Record<string, unknown>;
-    try {
-      storage = origin.describe();
-    } catch (err) {
-      storage = { error: (err as Error).message };
-    }
-    const body = {
-      ...store.status(),
-      storage,
-      hostname: hostname(),
-      now: new Date().toISOString(),
-      config: {
-        reload_interval_s: config.reloadIntervalMs / 1000,
-        health_interval_s: config.healthIntervalMs / 1000,
-      },
-    };
-    res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
-    res.end(`${JSON.stringify(body)}\n`);
-  });
-
-  return handlers;
+    status: async (_req, res): Promise<void> => {
+      let storage: Record<string, unknown>;
+      try {
+        storage = origin.describe();
+      } catch (err) {
+        storage = { error: (err as Error).message };
+      }
+      const body = {
+        ...store.status(),
+        storage,
+        hostname: hostname(),
+        now: new Date().toISOString(),
+        config: {
+          reload_interval_s: config.reloadIntervalMs / 1000,
+          health_interval_s: config.healthIntervalMs / 1000,
+        },
+      };
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+      res.end(`${JSON.stringify(body)}\n`);
+    },
+  };
 }

--- a/apps/dashboard-edge/src/http/status.ts
+++ b/apps/dashboard-edge/src/http/status.ts
@@ -1,0 +1,55 @@
+// /_edge/* endpoints. nginx only forwards these for requests that did not
+// come through the Istio gateway (no x-original-host header).
+import { hostname } from 'node:os';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import type { Config } from '../config.js';
+import { registry } from '../metrics.js';
+import type { Origin } from '../origin/index.js';
+import type { RulesStore } from '../rules/store.js';
+
+export function makeStatusHandlers(
+  store: RulesStore,
+  origin: Origin,
+  config: Config,
+): Record<string, (req: IncomingMessage, res: ServerResponse) => Promise<void>> {
+  return {
+    '/_edge/healthz': async (_req, res): Promise<void> => {
+      res.writeHead(200, { 'Content-Type': 'text/plain', 'Cache-Control': 'no-store' });
+      res.end('ok\n');
+    },
+    '/_edge/ready': async (_req, res): Promise<void> => {
+      const state = store.ready();
+      res.writeHead(state.ready ? 200 : 503, {
+        'Content-Type': 'text/plain',
+        'Cache-Control': 'no-store',
+      });
+      res.end(state.ready ? 'ready\n' : `not ready: ${state.reason}\n`);
+    },
+    '/_edge/status': async (_req, res): Promise<void> => {
+      let storage: Record<string, unknown>;
+      try {
+        storage = origin.describe();
+      } catch (err) {
+        storage = { error: (err as Error).message };
+      }
+      const body = {
+        ...store.status(),
+        storage,
+        hostname: hostname(),
+        now: new Date().toISOString(),
+        config: {
+          reload_interval_s: config.reloadIntervalMs / 1000,
+          health_interval_s: config.healthIntervalMs / 1000,
+        },
+      };
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+      res.end(`${JSON.stringify(body)}\n`);
+    },
+    '/_edge/metrics': async (_req, res): Promise<void> => {
+      const text = await registry.metrics();
+      res.writeHead(200, { 'Content-Type': registry.contentType, 'Cache-Control': 'no-store' });
+      res.end(text);
+    },
+  };
+}

--- a/apps/dashboard-edge/src/log.ts
+++ b/apps/dashboard-edge/src/log.ts
@@ -1,0 +1,38 @@
+// JSON-lines logger on stdout, one object per line so the existing log
+// shipping picks the fields up. Level is set from config at startup.
+type Level = 'debug' | 'info' | 'warn' | 'error';
+
+const LEVELS: Record<Level, number> = { debug: 10, info: 20, warn: 30, error: 40 };
+
+let threshold = LEVELS.info;
+
+export function setLogLevel(level: string): void {
+  threshold = LEVELS[level as Level] ?? LEVELS.info;
+}
+
+function serializeError(err: unknown): Record<string, unknown> {
+  if (err instanceof Error) {
+    return { message: err.message, name: err.name, stack: err.stack };
+  }
+  return { message: String(err) };
+}
+
+function write(level: Level, msg: string, fields?: Record<string, unknown>): void {
+  if (LEVELS[level] < threshold) {
+    return;
+  }
+  const record: Record<string, unknown> = { time: new Date().toISOString(), level, msg };
+  if (fields) {
+    for (const [key, value] of Object.entries(fields)) {
+      record[key] = key === 'err' ? serializeError(value) : value;
+    }
+  }
+  process.stdout.write(`${JSON.stringify(record)}\n`);
+}
+
+export const log = {
+  debug: (msg: string, fields?: Record<string, unknown>): void => write('debug', msg, fields),
+  info: (msg: string, fields?: Record<string, unknown>): void => write('info', msg, fields),
+  warn: (msg: string, fields?: Record<string, unknown>): void => write('warn', msg, fields),
+  error: (msg: string, fields?: Record<string, unknown>): void => write('error', msg, fields),
+};

--- a/apps/dashboard-edge/src/main.ts
+++ b/apps/dashboard-edge/src/main.ts
@@ -4,10 +4,13 @@ import { log, setLogLevel } from './log.js';
 import { startSyslogListener } from './metrics.js';
 import { createOrigin } from './origin/index.js';
 import { RulesStore } from './rules/store.js';
+import { initializeOpenTelemetry, shutdownOpenTelemetry } from './telemetry.js';
 
 async function main(): Promise<void> {
   const config = loadConfig();
   setLogLevel(config.logLevel);
+
+  initializeOpenTelemetry(config.otel);
 
   const origin = createOrigin(config.storage);
   log.info('storage origin ready', origin.describe());
@@ -35,8 +38,10 @@ async function main(): Promise<void> {
     log.info('shutting down', { signal });
     store.stop();
     syslog.close();
-    server.close(() => process.exit(0));
-    setTimeout(() => process.exit(0), 5_000).unref();
+    server.close(() => {
+      void shutdownOpenTelemetry().finally(() => process.exit(0));
+    });
+    setTimeout(() => process.exit(0), 10_000).unref();
   };
   process.on('SIGTERM', () => shutdown('SIGTERM'));
   process.on('SIGINT', () => shutdown('SIGINT'));

--- a/apps/dashboard-edge/src/main.ts
+++ b/apps/dashboard-edge/src/main.ts
@@ -1,0 +1,48 @@
+import { loadConfig } from './config.js';
+import { createEdgeServer } from './http/server.js';
+import { log, setLogLevel } from './log.js';
+import { startSyslogListener } from './metrics.js';
+import { createOrigin } from './origin/index.js';
+import { RulesStore } from './rules/store.js';
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  setLogLevel(config.logLevel);
+
+  const origin = createOrigin(config.storage);
+  log.info('storage origin ready', origin.describe());
+
+  const store = new RulesStore({
+    file: config.rulesFile,
+    reloadIntervalMs: config.reloadIntervalMs,
+    healthIntervalMs: config.healthIntervalMs,
+    origin,
+  });
+
+  const server = createEdgeServer(store, origin, config);
+  await new Promise<void>((resolveListen) => {
+    server.listen(config.listen.port, config.listen.addr, () => resolveListen());
+  });
+  log.info('edge app listening', config.listen);
+
+  const syslog = startSyslogListener(config.syslogPort, config.listen.addr);
+
+  // Rules load after the server is up so /_edge/healthz answers immediately;
+  // /_edge/ready stays 503 until the first load has published a rule set.
+  await store.start();
+
+  const shutdown = (signal: string): void => {
+    log.info('shutting down', { signal });
+    store.stop();
+    syslog.close();
+    server.close(() => process.exit(0));
+    setTimeout(() => process.exit(0), 5_000).unref();
+  };
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+}
+
+main().catch((err: unknown) => {
+  log.error('fatal', { err });
+  process.exit(1);
+});

--- a/apps/dashboard-edge/src/metrics.ts
+++ b/apps/dashboard-edge/src/metrics.ts
@@ -1,0 +1,81 @@
+// Prometheus metrics. Cache hit/miss per rule is only known to nginx, so the
+// nginx access log is shipped over local syslog (UDP) into this process and
+// counted here; the resolver and origin count their own traffic directly.
+import { createSocket, type Socket } from 'node:dgram';
+import { Counter, Gauge, Registry } from 'prom-client';
+
+import { log } from './log.js';
+
+export const registry = new Registry();
+
+export const metrics = {
+  requests: new Counter({
+    name: 'edge_requests_total',
+    help: 'Client requests by rule, nginx cache status and HTTP status',
+    labelNames: ['rule', 'cache', 'status'] as const,
+    registers: [registry],
+  }),
+  upstreamErrors: new Counter({
+    name: 'edge_upstream_errors_total',
+    help: 'Origin responses with a 5xx status, by rule',
+    labelNames: ['rule'] as const,
+    registers: [registry],
+  }),
+  resolves: new Counter({
+    name: 'edge_resolve_total',
+    help: 'Rule resolutions by outcome (rule id, none, not_ready)',
+    labelNames: ['rule'] as const,
+    registers: [registry],
+  }),
+  originRequests: new Counter({
+    name: 'edge_origin_requests_total',
+    help: 'Object fetches from the storage origin by result',
+    labelNames: ['result'] as const,
+    registers: [registry],
+  }),
+  ruleHealthy: new Gauge({
+    name: 'edge_rule_healthy',
+    help: '1 when the rule bundle exists at the origin, 0 otherwise',
+    labelNames: ['rule'] as const,
+    registers: [registry],
+  }),
+};
+
+interface AccessLine {
+  rule?: string;
+  cache?: string;
+  status?: number | string;
+  upstream_status?: string;
+}
+
+/** Count one nginx access-log line (the JSON `edge` log_format). */
+export function observeAccessLine(json: string): void {
+  let line: AccessLine;
+  try {
+    line = JSON.parse(json) as AccessLine;
+  } catch {
+    return;
+  }
+  const rule = line.rule && line.rule !== '' ? line.rule : 'none';
+  const cache = line.cache && line.cache !== '' ? line.cache : 'NONE';
+  metrics.requests.inc({ rule, cache, status: String(line.status ?? '0') });
+  const last = /(\d+)\s*$/.exec(line.upstream_status ?? '');
+  if (last && Number(last[1]) >= 500) {
+    metrics.upstreamErrors.inc({ rule });
+  }
+}
+
+/** Listen for nginx's `access_log syslog:server=127.0.0.1:<port>` datagrams. */
+export function startSyslogListener(port: number, addr: string): Socket {
+  const socket = createSocket('udp4');
+  socket.on('message', (msg) => {
+    const text = msg.toString('utf8');
+    const start = text.indexOf('{');
+    if (start >= 0) {
+      observeAccessLine(text.slice(start));
+    }
+  });
+  socket.on('error', (err) => log.error('syslog listener error', { err }));
+  socket.bind(port, addr, () => log.info('syslog metrics listener up', { addr, port }));
+  return socket;
+}

--- a/apps/dashboard-edge/src/metrics.ts
+++ b/apps/dashboard-edge/src/metrics.ts
@@ -1,44 +1,79 @@
-// Prometheus metrics. Cache hit/miss per rule is only known to nginx, so the
-// nginx access log is shipped over local syslog (UDP) into this process and
-// counted here; the resolver and origin count their own traffic directly.
+// OpenTelemetry metrics. Cache hit/miss per rule is only known to nginx, so
+// the nginx access log is shipped over local syslog (UDP) into this process
+// and counted here; the resolver and origin count their own traffic directly.
+// Everything is exported to the collector by telemetry.ts.
 import { createSocket, type Socket } from 'node:dgram';
-import { Counter, Gauge, Registry } from 'prom-client';
+import {
+  type Attributes,
+  type Counter,
+  type Meter,
+  metrics as otelMetrics,
+} from '@opentelemetry/api';
 
 import { log } from './log.js';
 
-export const registry = new Registry();
+const METER_NAME = 'xyne-spaces-dashboard-edge';
+
+interface Instruments {
+  requests: Counter;
+  upstreamErrors: Counter;
+  resolves: Counter;
+  originRequests: Counter;
+}
+
+// Instruments are created on first use, after telemetry.ts has registered the
+// global meter provider; created earlier they would bind to the no-op provider.
+let instruments: Instruments | null = null;
+const ruleHealth = new Map<string, number>();
+
+function getInstruments(): Instruments {
+  if (instruments) {
+    return instruments;
+  }
+  const meter: Meter = otelMetrics.getMeter(METER_NAME);
+  instruments = {
+    requests: meter.createCounter('edge_requests_total', {
+      description: 'Client requests by rule, nginx cache status and HTTP status',
+    }),
+    upstreamErrors: meter.createCounter('edge_upstream_errors_total', {
+      description: 'Origin responses with a 5xx status, by rule',
+    }),
+    resolves: meter.createCounter('edge_resolve_total', {
+      description: 'Rule resolutions by outcome (rule id, none, not_ready, bad_request)',
+    }),
+    originRequests: meter.createCounter('edge_origin_requests_total', {
+      description: 'Object fetches from the storage origin by result',
+    }),
+  };
+  meter
+    .createObservableGauge('edge_rule_healthy', {
+      description: '1 when the rule bundle exists at the origin, 0 otherwise',
+    })
+    .addCallback((result) => {
+      for (const [rule, value] of ruleHealth) {
+        result.observe(value, { rule });
+      }
+    });
+  return instruments;
+}
+
+function counter(name: keyof Instruments): { inc: (attributes?: Attributes) => void } {
+  return {
+    inc: (attributes: Attributes = {}): void => {
+      getInstruments()[name].add(1, attributes);
+    },
+  };
+}
 
 export const metrics = {
-  requests: new Counter({
-    name: 'edge_requests_total',
-    help: 'Client requests by rule, nginx cache status and HTTP status',
-    labelNames: ['rule', 'cache', 'status'] as const,
-    registers: [registry],
-  }),
-  upstreamErrors: new Counter({
-    name: 'edge_upstream_errors_total',
-    help: 'Origin responses with a 5xx status, by rule',
-    labelNames: ['rule'] as const,
-    registers: [registry],
-  }),
-  resolves: new Counter({
-    name: 'edge_resolve_total',
-    help: 'Rule resolutions by outcome (rule id, none, not_ready)',
-    labelNames: ['rule'] as const,
-    registers: [registry],
-  }),
-  originRequests: new Counter({
-    name: 'edge_origin_requests_total',
-    help: 'Object fetches from the storage origin by result',
-    labelNames: ['result'] as const,
-    registers: [registry],
-  }),
-  ruleHealthy: new Gauge({
-    name: 'edge_rule_healthy',
-    help: '1 when the rule bundle exists at the origin, 0 otherwise',
-    labelNames: ['rule'] as const,
-    registers: [registry],
-  }),
+  requests: counter('requests'),
+  upstreamErrors: counter('upstreamErrors'),
+  resolves: counter('resolves'),
+  originRequests: counter('originRequests'),
+  setRuleHealth(rule: string, healthy: boolean): void {
+    getInstruments();
+    ruleHealth.set(rule, healthy ? 1 : 0);
+  },
 };
 
 interface AccessLine {

--- a/apps/dashboard-edge/src/origin/http.ts
+++ b/apps/dashboard-edge/src/origin/http.ts
@@ -1,0 +1,74 @@
+// Plain HTTP(S) origin: any server exposing <STORAGE_ENDPOINT>/<bundle>/<object>.
+// Useful on-prem (an nginx, a MinIO public bucket, an internal file server).
+import { Readable } from 'node:stream';
+
+import type { Config } from '../config.js';
+import type { ObjectInfo, ObjectRead, Origin } from './types.js';
+
+function infoFromHeaders(headers: Headers): ObjectInfo {
+  const info: ObjectInfo = {};
+  const length = headers.get('content-length');
+  if (length !== null && length !== '') {
+    info.size = Number(length);
+  }
+  const type = headers.get('content-type');
+  if (type) {
+    info.contentType = type;
+  }
+  const etag = headers.get('etag');
+  if (etag) {
+    info.etag = etag.replace(/^W\//, '').replace(/"/g, '');
+  }
+  const modified = headers.get('last-modified');
+  if (modified) {
+    info.lastModified = new Date(modified);
+  }
+  return info;
+}
+
+function encodeKey(key: string): string {
+  return key.split('/').map(encodeURIComponent).join('/');
+}
+
+export function createHttpOrigin(cfg: Config['storage']): Origin {
+  const base = cfg.endpoint as string;
+  const headers: Record<string, string> = { 'user-agent': 'xyne-dashboard-edge' };
+  if (cfg.authHeader) {
+    headers.authorization = cfg.authHeader;
+  }
+  const urlFor = (key: string): string => `${base}/${encodeKey(key)}`;
+
+  return {
+    kind: 'http',
+    describe: () => ({
+      backend: 'http',
+      endpoint: base,
+      auth: cfg.authHeader ? 'static-header' : 'none',
+    }),
+    async head(key: string): Promise<ObjectInfo | null> {
+      const res = await fetch(urlFor(key), { method: 'HEAD', headers });
+      if (res.status === 404) {
+        return null;
+      }
+      if (!res.ok) {
+        throw new Error(`origin HEAD ${key} returned ${res.status}`);
+      }
+      return infoFromHeaders(res.headers);
+    },
+    async get(key: string): Promise<ObjectRead | null> {
+      const res = await fetch(urlFor(key), { method: 'GET', headers });
+      if (res.status === 404) {
+        await res.body?.cancel();
+        return null;
+      }
+      if (!res.ok || !res.body) {
+        await res.body?.cancel();
+        throw new Error(`origin GET ${key} returned ${res.status}`);
+      }
+      return {
+        info: infoFromHeaders(res.headers),
+        stream: Readable.fromWeb(res.body as import('node:stream/web').ReadableStream),
+      };
+    },
+  };
+}

--- a/apps/dashboard-edge/src/origin/index.ts
+++ b/apps/dashboard-edge/src/origin/index.ts
@@ -1,0 +1,12 @@
+import type { Config } from '../config.js';
+import { createHttpOrigin } from './http.js';
+import { createStorageOrigin } from './storage.js';
+import type { Origin } from './types.js';
+
+export type { ObjectInfo, ObjectRead, Origin } from './types.js';
+export { fingerprintOf } from './types.js';
+
+export function createOrigin(cfg: Config['storage']): Origin {
+  // gcs, s3 and azure all go through @xyne/storage; http is a plain origin.
+  return cfg.backend === 'http' ? createHttpOrigin(cfg) : createStorageOrigin(cfg);
+}

--- a/apps/dashboard-edge/src/origin/storage.ts
+++ b/apps/dashboard-edge/src/origin/storage.ts
@@ -1,0 +1,79 @@
+// GCS, S3 and Azure Blob through @xyne/storage, the same adapters the backend
+// uses. Each SDK resolves its own credentials (Application Default
+// Credentials, the AWS default provider chain, DefaultAzureCredential), so
+// Workload Identity, IRSA, managed identity, mounted keys and environment
+// variables all work unchanged.
+import { createStorageService, type StorageConfig, type StorageService } from '@xyne/storage';
+
+import type { Config } from '../config.js';
+import type { Origin } from './types.js';
+
+function storageConfigFor(cfg: Config['storage'], bucketName: string): StorageConfig {
+  switch (cfg.backend) {
+    case 's3':
+      return {
+        provider: 's3',
+        s3: {
+          region: cfg.awsRegion ?? process.env.AWS_DEFAULT_REGION ?? 'us-east-1',
+          bucketName,
+          ...(cfg.endpoint ? { endpoint: cfg.endpoint } : {}),
+        },
+      };
+    case 'azure': {
+      const endpoint =
+        cfg.endpoint ??
+        (cfg.azureAccount ? `https://${cfg.azureAccount}.blob.core.windows.net` : undefined);
+      if (!endpoint) {
+        throw new Error(
+          'AZURE_STORAGE_ACCOUNT or STORAGE_ENDPOINT is required for STORAGE_BACKEND=azure',
+        );
+      }
+      const sasToken = cfg.auth === 'sas' ? (cfg.azureSasToken ?? '').replace(/^\?/, '') : '';
+      if (cfg.auth === 'sas' && !sasToken) {
+        throw new Error('AZURE_STORAGE_SAS_TOKEN is required for STORAGE_AUTH=sas');
+      }
+      return {
+        provider: 'azure',
+        azure: {
+          containerName: bucketName,
+          endpoint,
+          ...(sasToken ? { sasToken } : {}),
+          ...(cfg.auth === 'none' ? { anonymous: true } : {}),
+        },
+      };
+    }
+    default:
+      return {
+        provider: 'gcs',
+        gcs: {
+          bucketName,
+          ...(cfg.gcpProject ? { projectId: cfg.gcpProject } : {}),
+          ...(cfg.endpoint ? { apiEndpoint: cfg.endpoint } : {}),
+        },
+      };
+  }
+}
+
+export function createStorageOrigin(cfg: Config['storage']): Origin {
+  const bucketName = cfg.bucket as string;
+  const storageConfig = storageConfigFor(cfg, bucketName);
+  const service: StorageService = createStorageService(storageConfig, bucketName);
+
+  const endpoint =
+    storageConfig.azure?.endpoint ??
+    cfg.endpoint ??
+    (cfg.backend === 's3' ? 'aws default' : 'https://storage.googleapis.com');
+
+  return {
+    kind: cfg.backend,
+    describe: () => ({
+      backend: cfg.backend,
+      bucket: bucketName,
+      endpoint,
+      auth: cfg.auth,
+      ...(cfg.backend === 's3' ? { region: storageConfig.s3?.region } : {}),
+    }),
+    head: (key) => service.headObject(key),
+    get: (key) => service.getObject(key),
+  };
+}

--- a/apps/dashboard-edge/src/origin/types.ts
+++ b/apps/dashboard-edge/src/origin/types.ts
@@ -1,0 +1,25 @@
+import type { ObjectInfo, ObjectRead } from '@xyne/storage';
+
+export type { ObjectInfo, ObjectRead };
+
+/** Where bundles live. One object key is "<bundle>/<object>". */
+export interface Origin {
+  kind: string;
+  describe(): Record<string, unknown>;
+  /** Metadata for one object, or null when it does not exist. Errors propagate. */
+  head(key: string): Promise<ObjectInfo | null>;
+  /** Stream one object with its metadata, or null when it does not exist. Errors propagate. */
+  get(key: string): Promise<ObjectRead | null>;
+}
+
+/** Short stable fingerprint of an object at the origin, for the cache key. */
+export function fingerprintOf(info: ObjectInfo): string {
+  const raw = info.etag ?? `${info.lastModified?.toISOString() ?? ''}|${info.size ?? ''}`;
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < raw.length; i += 1) {
+    hash ^= raw.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  // FNV-1a over the raw value plus its length keeps the key short and stable.
+  return `${hash.toString(16).padStart(8, '0')}${(raw.length & 0xffff).toString(16).padStart(4, '0')}`;
+}

--- a/apps/dashboard-edge/src/rules/match.test.ts
+++ b/apps/dashboard-edge/src/rules/match.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  expandBundle,
+  keyVersion,
+  matchRule,
+  objectPath,
+  resolve,
+  type RequestView,
+} from './match.js';
+import { parseRules } from './schema.js';
+
+function view(overrides: Partial<RequestView> = {}): RequestView {
+  return { path: '/', headers: {}, cookies: {}, userAgent: '', ...overrides };
+}
+
+function rulesFrom(
+  json: unknown,
+): ReturnType<typeof parseRules> extends infer R
+  ? R extends { ok: true; rules: infer Rules }
+    ? Rules
+    : never
+  : never {
+  const parsed = parseRules(JSON.stringify(json));
+  if (!parsed.ok) {
+    throw new Error(parsed.error);
+  }
+  return parsed.rules;
+}
+
+describe('objectPath', () => {
+  it('maps root and trailing slashes to index.html and strips the rule prefix', () => {
+    expect(objectPath({}, '/')).toBe('index.html');
+    expect(objectPath({}, '/assets/app.js')).toBe('assets/app.js');
+    expect(objectPath({}, '/settings/')).toBe('settings/index.html');
+    expect(objectPath({ stripPrefix: '/sdlc-app' }, '/sdlc-app/assets/x.js')).toBe('assets/x.js');
+    expect(objectPath({ stripPrefix: '/sdlc-app' }, '/sdlc-app')).toBe('index.html');
+    expect(objectPath({}, '/a/../b')).toBeNull();
+  });
+});
+
+describe('matchRule', () => {
+  const rules = rulesFrom({
+    rules: [
+      { id: 'hdr', match: { header: { name: 'X-Route-Env', exact: 'playground' } }, bundle: 'p' },
+      { id: 'ck', match: { cookie: { name: 'x-route-env', regex: '^play' } }, bundle: 'p' },
+      {
+        id: 'ua',
+        match: { user_agent: { regex: 'devqa-xyne-([A-Za-z0-9_-]+)' } },
+        bundle: 'devqa-xyne-$1',
+      },
+      {
+        id: 'both',
+        match: { path_prefix: '/api/', header: { name: 'x', exact: 'y' } },
+        bundle: 'b',
+      },
+      { id: 'default', match: { path_prefix: '/' }, bundle: 'main' },
+    ],
+  });
+  const byId = Object.fromEntries(rules.map((r) => [r.id, r]));
+
+  it('matches headers case-insensitively by name and cookies by regex', () => {
+    expect(matchRule(byId.hdr!, view({ headers: { 'x-route-env': 'playground' } })).ok).toBe(true);
+    expect(matchRule(byId.hdr!, view({ headers: { 'x-route-env': 'onyx' } })).ok).toBe(false);
+    expect(matchRule(byId.ck!, view({ cookies: { 'x-route-env': 'playground' } })).ok).toBe(true);
+  });
+
+  it('returns captures from the user agent and requires every matcher', () => {
+    const ua = matchRule(byId.ua!, view({ userAgent: 'Mozilla devqa-xyne-picaf-2878 Chrome' }));
+    expect(ua).toEqual({ ok: true, captures: ['picaf-2878'] });
+    expect(expandBundle(byId.ua!.bundle, ua.captures)).toBe('devqa-xyne-picaf-2878');
+    expect(matchRule(byId.both!, view({ path: '/api/x', headers: { x: 'y' } })).ok).toBe(true);
+    expect(matchRule(byId.both!, view({ path: '/api/x' })).ok).toBe(false);
+  });
+});
+
+describe('resolve', () => {
+  const rules = rulesFrom({
+    rules: [
+      {
+        id: 'ua',
+        match: { user_agent: { regex: 'devqa-xyne-([a-z0-9-]+)' } },
+        bundle: 'devqa-xyne-$1',
+        cache: 'never',
+      },
+      { id: 'default', match: { path_prefix: '/' }, bundle: 'main', version: 7 },
+    ],
+  });
+
+  it('falls through to the next rule with a reason when a dynamic bundle is missing', async () => {
+    const exists = async (
+      bundle: string,
+    ): Promise<{ exists: true; fingerprint: string } | { exists: false }> =>
+      bundle === 'devqa-xyne-ok'
+        ? ({ exists: true, fingerprint: 'abc' } as const)
+        : ({ exists: false } as const);
+    const missing = await resolve(rules, view({ userAgent: 'devqa-xyne-nope' }), exists);
+    expect(missing.resolution?.rule.id).toBe('default');
+    expect(missing.skipped).toEqual([{ id: 'ua', reason: 'bundle not found: devqa-xyne-nope' }]);
+
+    const found = await resolve(rules, view({ userAgent: 'devqa-xyne-ok', path: '/x/y' }), exists);
+    expect(found.resolution).toMatchObject({
+      bundle: 'devqa-xyne-ok',
+      object: 'x/y',
+      cache: 'never',
+      fingerprint: 'abc',
+    });
+  });
+
+  it('builds the cache key version from version, fingerprint and ttl bucket', () => {
+    const base = { rule: rules[1]!, bundle: 'main', version: '7', object: 'index.html' };
+    expect(keyVersion({ ...base, cache: 'versioned' })).toBe('7');
+    expect(keyVersion({ ...base, cache: 'versioned', fingerprint: 'f1' })).toBe('7-f1');
+    expect(keyVersion({ ...base, cache: 'ttl', ttl: 30, fingerprint: 'f1' }, 95)).toBe('7-f1.3');
+  });
+});
+
+describe('parseRules', () => {
+  it('rejects a file whose last rule is not the catch-all default', () => {
+    const r = parseRules(
+      JSON.stringify({ rules: [{ id: 'a', match: { path_prefix: '/x/' }, bundle: 'b' }] }),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.ok ? '' : r.error).toMatch(/last rule/);
+  });
+
+  it('rejects capture references without a regex matcher and bad regexes', () => {
+    const noRegex = parseRules(
+      JSON.stringify({ rules: [{ id: 'a', match: { path_prefix: '/' }, bundle: 'x-$1' }] }),
+    );
+    expect(noRegex.ok ? '' : noRegex.error).toMatch(/no regex matcher/);
+    const bad = parseRules(
+      JSON.stringify({
+        rules: [
+          { id: 'a', match: { path_regex: '(' }, bundle: 'x' },
+          { id: 'd', match: { path_prefix: '/' }, bundle: 'm' },
+        ],
+      }),
+    );
+    expect(bad.ok ? '' : bad.error).toMatch(/bad regex/);
+  });
+
+  it('normalises version, ttl and strip_prefix', () => {
+    const r = parseRules(
+      JSON.stringify({
+        rules: [
+          {
+            id: 's',
+            match: { path_prefix: '/sdlc-app/' },
+            bundle: 'sdlc',
+            strip_prefix: '/sdlc-app/',
+            cache: 'ttl',
+            ttl: '5m',
+            version: 3,
+          },
+          { id: 'd', match: { path_prefix: '/' }, bundle: 'main' },
+        ],
+      }),
+    );
+    expect(r.ok && r.rules[0]).toMatchObject({
+      version: '3',
+      ttl: 300,
+      stripPrefix: '/sdlc-app',
+      cache: 'ttl',
+    });
+  });
+});
+
+describe('normalisePath', () => {
+  it('drops the query, resolves dot segments, collapses slashes and decodes', async () => {
+    const { normalisePath } = await import('../http/resolve.js');
+    expect(normalisePath('/assets/app.js?v=1')).toBe('/assets/app.js');
+    expect(normalisePath('/a/./b/../c')).toBe('/a/c');
+    expect(normalisePath('//x///y')).toBe('/x/y');
+    expect(normalisePath('/settings/?tab=1')).toBe('/settings/');
+    expect(normalisePath('/caf%C3%A9/x')).toBe('/café/x');
+    expect(normalisePath('/')).toBe('/');
+    expect(normalisePath('/..')).toBeNull();
+    expect(normalisePath('/%zz')).toBeNull();
+  });
+});

--- a/apps/dashboard-edge/src/rules/match.ts
+++ b/apps/dashboard-edge/src/rules/match.ts
@@ -1,0 +1,193 @@
+// Pure request-to-bundle matching: rules x request -> bundle + object.
+import type { CacheMode } from '../contentType.js';
+import { isDynamicBundle, type Rule, type ValueMatcher } from './schema.js';
+
+export interface RequestView {
+  /** Normalised, decoded request path (nginx's $uri). */
+  path: string;
+  /** Header names lower-cased. */
+  headers: Record<string, string | undefined>;
+  cookies: Record<string, string>;
+  userAgent: string;
+}
+
+export interface Resolution {
+  rule: Rule;
+  bundle: string;
+  version: string;
+  fingerprint?: string;
+  object: string;
+  cache: CacheMode;
+  ttl?: number;
+}
+
+export interface Skipped {
+  id: string;
+  reason: string;
+}
+
+export type Existence =
+  | { exists: true; fingerprint: string }
+  | { exists: false }
+  | { error: string };
+
+export type ExistsFn = (bundle: string) => Promise<Existence>;
+
+/**
+ * Turn a request path into the object key inside a bundle prefix.
+ * strip_prefix is removed first, "/" and "" become index.html, and a trailing
+ * "/" gets index.html appended. Parent segments are refused.
+ */
+export function objectPath(rule: Pick<Rule, 'stripPrefix'>, path: string): string | null {
+  let p = path || '/';
+  const prefix = rule.stripPrefix;
+  if (prefix) {
+    if (p === prefix) {
+      p = '/';
+    } else if (p.startsWith(`${prefix}/`)) {
+      p = p.slice(prefix.length);
+    }
+  }
+  if (p.split('/').includes('..')) {
+    return null;
+  }
+  if (p.endsWith('/')) {
+    p += 'index.html';
+  }
+  p = p.replace(/^\/+/, '');
+  return p === '' ? 'index.html' : p;
+}
+
+function regexCaptures(subject: string | undefined, regex: RegExp, captures: string[]): boolean {
+  if (subject === undefined) {
+    return false;
+  }
+  const m = regex.exec(subject);
+  if (!m) {
+    return false;
+  }
+  for (let i = 1; i < m.length; i += 1) {
+    captures.push(m[i] ?? '');
+  }
+  return true;
+}
+
+function valueMatches(
+  subject: string | undefined,
+  spec: ValueMatcher,
+  captures: string[],
+): boolean {
+  if (spec.exact !== undefined) {
+    return subject === spec.exact;
+  }
+  return spec.regex !== undefined && regexCaptures(subject, spec.regex, captures);
+}
+
+/**
+ * Every matcher present in the rule must hold. Captures are the numbered
+ * groups of every regex matcher in the order path_regex, header, cookie,
+ * user_agent.
+ */
+export function matchRule(rule: Rule, req: RequestView): { ok: boolean; captures: string[] } {
+  const m = rule.match;
+  const captures: string[] = [];
+  if (m.pathPrefix !== undefined && !req.path.startsWith(m.pathPrefix)) {
+    return { ok: false, captures };
+  }
+  if (m.pathRegex !== undefined && !regexCaptures(req.path, m.pathRegex, captures)) {
+    return { ok: false, captures };
+  }
+  if (m.header !== undefined && !valueMatches(req.headers[m.header.name], m.header, captures)) {
+    return { ok: false, captures };
+  }
+  if (m.cookie !== undefined && !valueMatches(req.cookies[m.cookie.name], m.cookie, captures)) {
+    return { ok: false, captures };
+  }
+  if (m.userAgent !== undefined && !regexCaptures(req.userAgent, m.userAgent.regex, captures)) {
+    return { ok: false, captures };
+  }
+  return { ok: true, captures };
+}
+
+/** "$1".."$9" in a bundle template refer to regex captures. */
+export function expandBundle(template: string, captures: string[]): string {
+  return template.replace(/\$(\d)/g, (_all, n: string) => captures[Number(n) - 1] ?? '');
+}
+
+/**
+ * Walk the rules in order and return the first usable match. Rules that
+ * matched but could not be used are reported in `skipped` with the reason.
+ * `exists` is consulted only for dynamic bundles (regex captures); static
+ * ones are checked when the rules file is loaded.
+ */
+export async function resolve(
+  rules: Rule[],
+  req: RequestView,
+  exists: ExistsFn,
+): Promise<{ resolution: Resolution | null; skipped: Skipped[] }> {
+  const skipped: Skipped[] = [];
+  for (const rule of rules) {
+    const { ok, captures } = matchRule(rule, req);
+    if (!ok) {
+      continue;
+    }
+    const bundle = expandBundle(rule.bundle, captures);
+    let fingerprint = rule.fingerprint;
+    let reason: string | undefined;
+    if (!rule.enabled) {
+      reason = rule.error ?? 'rule disabled';
+    } else if (isDynamicBundle(rule.bundle)) {
+      const existence = await exists(bundle);
+      if ('error' in existence) {
+        reason = `bundle check failed: ${existence.error}`;
+      } else if (!existence.exists) {
+        reason = `bundle not found: ${bundle}`;
+      } else {
+        fingerprint = existence.fingerprint;
+      }
+    }
+    if (reason !== undefined) {
+      skipped.push({ id: rule.id, reason });
+      continue;
+    }
+    const object = objectPath(rule, req.path);
+    if (object === null) {
+      skipped.push({ id: rule.id, reason: 'invalid path' });
+      continue;
+    }
+    const resolution: Resolution = {
+      rule,
+      bundle,
+      version: rule.version,
+      object,
+      cache: rule.cache,
+    };
+    if (fingerprint !== undefined) {
+      resolution.fingerprint = fingerprint;
+    }
+    if (rule.ttl !== undefined) {
+      resolution.ttl = rule.ttl;
+    }
+    return { resolution, skipped };
+  }
+  return { resolution: null, skipped };
+}
+
+/**
+ * Cache key version: the rule version, the origin fingerprint of the bundle's
+ * index.html (so an in-place re-upload invalidates by itself) and, for ttl
+ * mode, a time bucket so entries roll over on a timer.
+ */
+export function keyVersion(
+  res: Resolution,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): string {
+  let v = res.version;
+  if (res.fingerprint !== undefined) {
+    v += `-${res.fingerprint}`;
+  }
+  if (res.cache === 'ttl' && res.ttl !== undefined) {
+    v += `.${Math.floor(nowSeconds / res.ttl)}`;
+  }
+  return v;
+}

--- a/apps/dashboard-edge/src/rules/schema.ts
+++ b/apps/dashboard-edge/src/rules/schema.ts
@@ -1,0 +1,280 @@
+// Rules file: JSON shape, validation and normalisation into Rule objects.
+import { z } from 'zod';
+
+import type { CacheMode } from '../contentType.js';
+
+const valueMatcherSchema = z
+  .object({
+    name: z.string().min(1),
+    exact: z.string().optional(),
+    regex: z.string().min(1).optional(),
+  })
+  .strict();
+
+const userAgentMatcherSchema = z.object({ regex: z.string().min(1) }).strict();
+
+const matchSchema = z
+  .object({
+    path_prefix: z.string().startsWith('/').optional(),
+    path_regex: z.string().min(1).optional(),
+    header: valueMatcherSchema.optional(),
+    cookie: valueMatcherSchema.optional(),
+    user_agent: userAgentMatcherSchema.optional(),
+  })
+  .strict();
+
+const ruleSchema = z
+  .object({
+    id: z.string().regex(/^[A-Za-z0-9_.-]+$/, 'id must match [A-Za-z0-9_.-]+'),
+    match: matchSchema,
+    bundle: z.string().min(1),
+    version: z.union([z.string(), z.number()]).optional(),
+    cache: z.enum(['versioned', 'never', 'ttl']).default('versioned'),
+    ttl: z.union([z.string(), z.number()]).optional(),
+    strip_prefix: z.string().optional(),
+  })
+  .strict();
+
+const rulesFileSchema = z.object({ rules: z.array(ruleSchema).min(1) }).strict();
+
+export type RawRule = z.infer<typeof ruleSchema>;
+export type RawMatch = z.infer<typeof matchSchema>;
+
+export interface ValueMatcher {
+  name: string;
+  exact?: string;
+  regex?: RegExp;
+}
+
+export interface Matchers {
+  pathPrefix?: string;
+  pathRegex?: RegExp;
+  header?: ValueMatcher;
+  cookie?: ValueMatcher;
+  userAgent?: { regex: RegExp };
+}
+
+export interface Rule {
+  id: string;
+  match: Matchers;
+  /** The match block as written, for /_edge/status. */
+  matchSpec: RawMatch;
+  bundle: string;
+  version: string;
+  cache: CacheMode;
+  ttl?: number;
+  stripPrefix?: string;
+  /** False when the bundle is missing and there was no previous target to keep. */
+  enabled: boolean;
+  healthy: boolean;
+  error?: string;
+  /** Origin fingerprint of <bundle>/index.html; part of the cache key. */
+  fingerprint?: string;
+}
+
+export type ParseResult = { ok: true; rules: Rule[] } | { ok: false; error: string };
+
+export function isDynamicBundle(template: string): boolean {
+  return /\$\d/.test(template);
+}
+
+function parseDuration(value: string | number): number | undefined {
+  if (typeof value === 'number') {
+    return value;
+  }
+  const match = /^(\d+)([smh]?)$/.exec(value);
+  if (!match) {
+    return undefined;
+  }
+  const n = Number(match[1]);
+  switch (match[2]) {
+    case 'm':
+      return n * 60;
+    case 'h':
+      return n * 3600;
+    default:
+      return n;
+  }
+}
+
+function compileRegex(source: string, where: string): RegExp | string {
+  try {
+    return new RegExp(source);
+  } catch (err) {
+    return `${where}: bad regex ${JSON.stringify(source)}: ${(err as Error).message}`;
+  }
+}
+
+function normaliseValueMatcher(
+  spec: z.infer<typeof valueMatcherSchema>,
+  where: string,
+): ValueMatcher | string {
+  if (spec.exact === undefined && spec.regex === undefined) {
+    return `${where} needs exact or regex`;
+  }
+  const out: ValueMatcher = { name: spec.name };
+  if (spec.exact !== undefined) {
+    out.exact = spec.exact;
+  }
+  if (spec.regex !== undefined) {
+    const re = compileRegex(spec.regex, where);
+    if (typeof re === 'string') {
+      return re;
+    }
+    out.regex = re;
+  }
+  return out;
+}
+
+function normaliseRule(raw: RawRule): Rule | string {
+  const where = `rule ${raw.id}`;
+  const m = raw.match;
+  if (Object.keys(m).length === 0) {
+    return `${where}: match needs at least one matcher`;
+  }
+
+  const match: Matchers = {};
+  if (m.path_prefix !== undefined) {
+    match.pathPrefix = m.path_prefix;
+  }
+  if (m.path_regex !== undefined) {
+    const re = compileRegex(m.path_regex, `${where}: path_regex`);
+    if (typeof re === 'string') {
+      return re;
+    }
+    match.pathRegex = re;
+  }
+  if (m.header !== undefined) {
+    const vm = normaliseValueMatcher(
+      { ...m.header, name: m.header.name.toLowerCase() },
+      `${where}: header`,
+    );
+    if (typeof vm === 'string') {
+      return vm;
+    }
+    match.header = vm;
+  }
+  if (m.cookie !== undefined) {
+    const vm = normaliseValueMatcher(m.cookie, `${where}: cookie`);
+    if (typeof vm === 'string') {
+      return vm;
+    }
+    match.cookie = vm;
+  }
+  if (m.user_agent !== undefined) {
+    const re = compileRegex(m.user_agent.regex, `${where}: user_agent`);
+    if (typeof re === 'string') {
+      return re;
+    }
+    match.userAgent = { regex: re };
+  }
+
+  const bundle = raw.bundle;
+  if (
+    !/^[A-Za-z0-9._$/-]+$/.test(bundle) ||
+    bundle.includes('..') ||
+    bundle.startsWith('/') ||
+    bundle.endsWith('/')
+  ) {
+    return `${where}: bundle ${JSON.stringify(bundle)} is not a valid bucket prefix`;
+  }
+  const refs = [...bundle.matchAll(/\$(\d)/g)].map((x) => Number(x[1]));
+  if (refs.length > 0) {
+    const hasRegex =
+      match.pathRegex !== undefined ||
+      match.header?.regex !== undefined ||
+      match.cookie?.regex !== undefined ||
+      match.userAgent !== undefined;
+    if (!hasRegex) {
+      return `${where}: bundle uses $${Math.max(...refs)} but no regex matcher provides captures`;
+    }
+  }
+
+  let version = '1';
+  if (typeof raw.version === 'number') {
+    version = String(Math.floor(raw.version));
+  } else if (typeof raw.version === 'string') {
+    if (!/^[A-Za-z0-9._-]+$/.test(raw.version)) {
+      return `${where}: version must be a number or [A-Za-z0-9._-]+`;
+    }
+    version = raw.version;
+  }
+
+  const rule: Rule = {
+    id: raw.id,
+    match,
+    matchSpec: m,
+    bundle,
+    version,
+    cache: raw.cache,
+    enabled: true,
+    healthy: true,
+  };
+
+  if (raw.cache === 'ttl') {
+    const ttl = raw.ttl === undefined ? undefined : parseDuration(raw.ttl);
+    if (ttl === undefined || ttl <= 0) {
+      return `${where}: cache ttl needs ttl like 60, "60s" or "5m"`;
+    }
+    rule.ttl = ttl;
+  }
+
+  if (raw.strip_prefix !== undefined) {
+    if (!raw.strip_prefix.startsWith('/')) {
+      return `${where}: strip_prefix must start with /`;
+    }
+    const trimmed = raw.strip_prefix.replace(/\/+$/, '');
+    if (trimmed !== '') {
+      rule.stripPrefix = trimmed;
+    }
+  }
+
+  return rule;
+}
+
+function isCatchAll(rule: Rule): boolean {
+  const keys = Object.keys(rule.matchSpec);
+  return keys.length === 1 && rule.match.pathPrefix === '/';
+}
+
+/** Parse and validate the rules file text. */
+export function parseRules(text: string): ParseResult {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(text);
+  } catch (err) {
+    return { ok: false, error: `rules file is not valid JSON: ${(err as Error).message}` };
+  }
+  const parsed = rulesFileSchema.safeParse(doc);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const path = issue?.path.join('.') ?? '';
+    return {
+      ok: false,
+      error: `rules file invalid at ${path || '<root>'}: ${issue?.message ?? 'unknown'}`,
+    };
+  }
+
+  const rules: Rule[] = [];
+  const seen = new Set<string>();
+  for (const raw of parsed.data.rules) {
+    const rule = normaliseRule(raw);
+    if (typeof rule === 'string') {
+      return { ok: false, error: rule };
+    }
+    if (seen.has(rule.id)) {
+      return { ok: false, error: `duplicate rule id ${JSON.stringify(rule.id)}` };
+    }
+    seen.add(rule.id);
+    rules.push(rule);
+  }
+
+  const last = rules[rules.length - 1] as Rule;
+  if (!isCatchAll(last) || isDynamicBundle(last.bundle)) {
+    return {
+      ok: false,
+      error: `last rule (${last.id}) must be the default: match only path_prefix "/" with a static bundle`,
+    };
+  }
+  return { ok: true, rules };
+}

--- a/apps/dashboard-edge/src/rules/store.ts
+++ b/apps/dashboard-edge/src/rules/store.ts
@@ -1,0 +1,341 @@
+// Rules file: loading, validation, health checks, origin fingerprints and hot
+// reload. The file (a mounted ConfigMap key) is re-read on a timer. When its
+// content changes it is parsed and validated, every static bundle is checked
+// at the origin, and the result becomes the active set. Static bundles are
+// re-checked on a second timer even when the file is unchanged, so an
+// in-place re-upload gets a new fingerprint (and cache key) by itself.
+//
+// A rule whose bundle is missing keeps the target it previously served (if
+// any) and is reported unhealthy; with nothing to fall back to it is disabled
+// and requests fall through to later rules.
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+
+import { log } from '../log.js';
+import { metrics } from '../metrics.js';
+import { fingerprintOf, type Origin } from '../origin/index.js';
+import type { Existence } from './match.js';
+import { isDynamicBundle, parseRules, type Rule } from './schema.js';
+
+export interface RuleSet {
+  rules: Rule[];
+  generation: number;
+  loadedAt: number;
+}
+
+export interface RulesStoreOptions {
+  file: string;
+  reloadIntervalMs: number;
+  healthIntervalMs: number;
+  origin: Origin;
+  /** Positive existence cache for dynamic bundles, ms. */
+  existsTtlMs?: number;
+  /** Negative existence cache for dynamic bundles, ms. */
+  missingTtlMs?: number;
+}
+
+interface ExistenceEntry {
+  value: Existence;
+  expiresAt: number;
+}
+
+export interface RuleStatus {
+  id: string;
+  match: Rule['matchSpec'];
+  bundle: string;
+  version: string;
+  fingerprint?: string;
+  cache: Rule['cache'];
+  ttl?: number;
+  strip_prefix?: string;
+  healthy: boolean;
+  enabled: boolean;
+  error?: string;
+}
+
+export interface StoreStatus {
+  file: string;
+  generation: number;
+  loaded_at?: string;
+  last_error?: string;
+  last_health_check?: string;
+  reload_interval_s: number;
+  health_interval_s: number;
+  rules: RuleStatus[];
+}
+
+const EXISTS_TTL_MS = 60_000;
+const MISSING_TTL_MS = 15_000;
+
+export class RulesStore {
+  private active: RuleSet | null = null;
+  private generation = 0;
+  private hash = '';
+  private lastError: string | undefined;
+  private lastHealthCheck = 0;
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private stopped = false;
+  private readonly existence = new Map<string, ExistenceEntry>();
+
+  constructor(private readonly opts: RulesStoreOptions) {}
+
+  /** Load once (awaited), then keep polling. */
+  async start(): Promise<void> {
+    await this.tick(true);
+    this.schedule();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  current(): RuleSet | null {
+    return this.active;
+  }
+
+  ready(): { ready: boolean; reason?: string } {
+    if (!this.active) {
+      return { ready: false, reason: 'rules not loaded' };
+    }
+    const last = this.active.rules[this.active.rules.length - 1] as Rule;
+    if (!last.enabled) {
+      return {
+        ready: false,
+        reason: `default rule ${last.id} disabled: ${last.error ?? 'unknown'}`,
+      };
+    }
+    return { ready: true };
+  }
+
+  status(): StoreStatus {
+    const out: StoreStatus = {
+      file: this.opts.file,
+      generation: this.active?.generation ?? 0,
+      reload_interval_s: this.opts.reloadIntervalMs / 1000,
+      health_interval_s: this.opts.healthIntervalMs / 1000,
+      rules: [],
+    };
+    if (this.active) {
+      out.loaded_at = new Date(this.active.loadedAt).toISOString();
+    }
+    if (this.lastError !== undefined) {
+      out.last_error = this.lastError;
+    }
+    if (this.lastHealthCheck > 0) {
+      out.last_health_check = new Date(this.lastHealthCheck).toISOString();
+    }
+    for (const r of this.active?.rules ?? []) {
+      const rs: RuleStatus = {
+        id: r.id,
+        match: r.matchSpec,
+        bundle: r.bundle,
+        version: r.version,
+        cache: r.cache,
+        healthy: r.healthy,
+        enabled: r.enabled,
+      };
+      if (r.fingerprint !== undefined) {
+        rs.fingerprint = r.fingerprint;
+      }
+      if (r.ttl !== undefined) {
+        rs.ttl = r.ttl;
+      }
+      if (r.stripPrefix !== undefined) {
+        rs.strip_prefix = r.stripPrefix;
+      }
+      if (r.error !== undefined) {
+        rs.error = r.error;
+      }
+      out.rules.push(rs);
+    }
+    return out;
+  }
+
+  /** Existence + fingerprint for a dynamic bundle (regex captures), cached briefly. */
+  async exists(bundle: string): Promise<Existence> {
+    const now = Date.now();
+    const cached = this.existence.get(bundle);
+    if (cached && cached.expiresAt > now) {
+      return cached.value;
+    }
+    let value: Existence;
+    try {
+      const info = await this.opts.origin.head(`${bundle}/index.html`);
+      value = info ? { exists: true, fingerprint: fingerprintOf(info) } : { exists: false };
+    } catch (err) {
+      value = { error: (err as Error).message };
+    }
+    if (!('error' in value)) {
+      const ttl = value.exists
+        ? (this.opts.existsTtlMs ?? EXISTS_TTL_MS)
+        : (this.opts.missingTtlMs ?? MISSING_TTL_MS);
+      this.existence.set(bundle, { value, expiresAt: now + ttl });
+    }
+    return value;
+  }
+
+  /** Force a reload now (used by tests and the initial load). */
+  async reload(force = true): Promise<void> {
+    await this.tick(force);
+  }
+
+  private schedule(): void {
+    if (this.stopped) {
+      return;
+    }
+    this.timer = setTimeout(() => {
+      void this.tick(false).finally(() => this.schedule());
+    }, this.opts.reloadIntervalMs);
+  }
+
+  private async tick(force: boolean): Promise<void> {
+    if (this.running) {
+      return;
+    }
+    this.running = true;
+    try {
+      await this.load(force);
+    } catch (err) {
+      log.error('rules reload failed', { err });
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private recheckDue(): boolean {
+    if (this.lastError !== undefined || !this.active) {
+      return false;
+    }
+    return Date.now() - this.lastHealthCheck >= this.opts.healthIntervalMs;
+  }
+
+  private async load(force: boolean): Promise<void> {
+    let text: string;
+    try {
+      text = await readFile(this.opts.file, 'utf8');
+    } catch (err) {
+      this.lastError = `cannot read ${this.opts.file}: ${(err as Error).message}`;
+      log.error('cannot read rules file', { file: this.opts.file, err });
+      return;
+    }
+    const hash = createHash('sha256').update(text).digest('hex');
+    const unchanged = hash === this.hash;
+    if (!force && unchanged && !this.recheckDue()) {
+      return;
+    }
+
+    const parsed = parseRules(text);
+    if (!parsed.ok) {
+      this.lastError = parsed.error;
+      this.hash = hash; // do not re-log the same broken file every tick
+      log.error('rules file rejected, keeping last good set', { error: parsed.error });
+      return;
+    }
+
+    const changed = await this.healthCheck(parsed.rules, this.active);
+    this.lastHealthCheck = Date.now();
+    if (unchanged && !force && !changed) {
+      return;
+    }
+
+    this.generation += 1;
+    this.active = { rules: parsed.rules, generation: this.generation, loadedAt: Date.now() };
+    this.hash = hash;
+    this.lastError = undefined;
+    for (const r of parsed.rules) {
+      metrics.ruleHealthy.set({ rule: r.id }, r.healthy ? 1 : 0);
+    }
+    log.info('rules loaded', {
+      file: this.opts.file,
+      generation: this.generation,
+      rules: parsed.rules.length,
+      unhealthy: parsed.rules.filter((r) => !r.healthy).map((r) => r.id),
+    });
+  }
+
+  /**
+   * HEAD every static bundle and record its fingerprint. Returns true when
+   * anything differs from `previous` (health, target or fingerprint).
+   */
+  private async healthCheck(rules: Rule[], previous: RuleSet | null): Promise<boolean> {
+    const prevById = new Map((previous?.rules ?? []).map((r) => [r.id, r]));
+    let changed = previous === null || previous.rules.length !== rules.length;
+
+    for (const rule of rules) {
+      const prev = prevById.get(rule.id);
+      if (!isDynamicBundle(rule.bundle)) {
+        let info: Awaited<ReturnType<Origin['head']>>;
+        let failure: string | undefined;
+        try {
+          info = await this.opts.origin.head(`${rule.bundle}/index.html`);
+        } catch (err) {
+          info = null;
+          failure = `bundle check failed: ${(err as Error).message}`;
+        }
+        if (info) {
+          rule.fingerprint = fingerprintOf(info);
+          if (
+            prev?.healthy &&
+            prev.bundle === rule.bundle &&
+            prev.fingerprint !== undefined &&
+            prev.fingerprint !== rule.fingerprint
+          ) {
+            log.info('bundle changed at origin, cache invalidated', {
+              rule: rule.id,
+              bundle: rule.bundle,
+              fingerprint: rule.fingerprint,
+            });
+          }
+        } else {
+          const reason = failure ?? `bundle not found: ${rule.bundle}`;
+          rule.healthy = false;
+          rule.error = reason;
+          if (prev && prev.enabled) {
+            rule.bundle = prev.bundle;
+            rule.version = prev.version;
+            rule.cache = prev.cache;
+            if (prev.ttl !== undefined) {
+              rule.ttl = prev.ttl;
+            }
+            if (prev.stripPrefix !== undefined) {
+              rule.stripPrefix = prev.stripPrefix;
+            }
+            if (prev.fingerprint !== undefined) {
+              rule.fingerprint = prev.fingerprint;
+            }
+            rule.error = `${reason} (serving previous ${prev.bundle})`;
+            if (prev.error === undefined) {
+              log.warn('rule unhealthy, serving previous bundle', {
+                rule: rule.id,
+                error: rule.error,
+              });
+            }
+          } else {
+            rule.enabled = false;
+            if (!prev || prev.enabled) {
+              log.error('rule disabled', { rule: rule.id, error: reason });
+            }
+          }
+        }
+      }
+      if (!changed) {
+        changed =
+          prev === undefined ||
+          prev.bundle !== rule.bundle ||
+          prev.version !== rule.version ||
+          prev.fingerprint !== rule.fingerprint ||
+          prev.healthy !== rule.healthy ||
+          prev.enabled !== rule.enabled ||
+          prev.cache !== rule.cache ||
+          prev.ttl !== rule.ttl ||
+          prev.stripPrefix !== rule.stripPrefix;
+      }
+    }
+    return changed;
+  }
+}

--- a/apps/dashboard-edge/src/rules/store.ts
+++ b/apps/dashboard-edge/src/rules/store.ts
@@ -248,7 +248,7 @@ export class RulesStore {
     this.hash = hash;
     this.lastError = undefined;
     for (const r of parsed.rules) {
-      metrics.ruleHealthy.set({ rule: r.id }, r.healthy ? 1 : 0);
+      metrics.setRuleHealth(r.id, r.healthy);
     }
     log.info('rules loaded', {
       file: this.opts.file,

--- a/apps/dashboard-edge/src/telemetry.ts
+++ b/apps/dashboard-edge/src/telemetry.ts
@@ -1,0 +1,44 @@
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
+import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+
+import type { Config } from './config.js';
+import { log } from './log.js';
+
+let sdk: NodeSDK | null = null;
+
+export function initializeOpenTelemetry(otel: Config['otel']): void {
+  if (!otel.metricsEnabled) {
+    log.info('otel metrics disabled (ENABLE_OTEL_METRICS=false)');
+    return;
+  }
+  const endpoint = `${otel.baseUrl}/v1/metrics`;
+  try {
+    const metricReader = new PeriodicExportingMetricReader({
+      exporter: new OTLPMetricExporter({ url: endpoint, timeoutMillis: 10_000 }),
+      exportIntervalMillis: otel.exportIntervalMs,
+    });
+    sdk = new NodeSDK({ serviceName: otel.serviceName, metricReader });
+    sdk.start();
+    log.info('otel metrics started', {
+      service: otel.serviceName,
+      endpoint,
+      exportIntervalMs: otel.exportIntervalMs,
+    });
+  } catch (err) {
+    log.error('otel initialisation failed', { err });
+  }
+}
+
+export async function shutdownOpenTelemetry(): Promise<void> {
+  if (!sdk) {
+    return;
+  }
+  try {
+    await sdk.shutdown();
+    log.info('otel metrics shut down');
+  } catch (err) {
+    log.error('otel shutdown failed', { err });
+  }
+  sdk = null;
+}

--- a/apps/dashboard-edge/tsconfig.json
+++ b/apps/dashboard-edge/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "types": ["node"],
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -93,6 +93,11 @@ RUN apt-get update && apt-get install -y zip && \
     mkdir -p /repo/apps/dashboard/releases && \
     cd /repo/apps/dashboard/dist && zip -r ../releases/dashboard.zip .
 
+
+FROM scratch AS bundle
+COPY --from=builder /repo/apps/dashboard/dist /
+COPY --from=builder /repo/apps/dashboard/releases /releases
+
 # Production image with nginx
 FROM nginx:alpine AS runner
 

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -2,7 +2,7 @@
   "name": "@xyne/storage",
   "version": "1.0.0",
   "type": "module",
-  "description": "Provider-agnostic object storage (GCS or S3, selected by config) shared by backend and claw apps",
+  "description": "Provider-agnostic object storage (GCS, S3 or Azure Blob, selected by config) shared by the backend, claw and dashboard-edge apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -21,6 +21,8 @@
     "@aws-sdk/client-s3": "^3.1017.0",
     "@aws-sdk/lib-storage": "3.1017.0",
     "@aws-sdk/s3-request-presigner": "^3.1017.0",
+    "@azure/identity": "^4.10.0",
+    "@azure/storage-blob": "^12.26.0",
     "@google-cloud/storage": "^7.7.0",
     "uuid": "^11.1.1"
   },

--- a/packages/storage/src/azureBlobStorageService.ts
+++ b/packages/storage/src/azureBlobStorageService.ts
@@ -40,9 +40,8 @@ function stripTrailingSlashes(value: string): string {
   return value.slice(0, end);
 }
 
-/** Paths and filenames are caller input; keep log lines to one line each. */
 function logSafe(value: string): string {
-  return value.replace(/[\r\n]+/g, ' ');
+  return String(value).replace(/\n/g, ' ').replace(/\r/g, ' ');
 }
 
 /**
@@ -118,11 +117,11 @@ export class AzureBlobStorageService implements StorageService {
     if (!options.path) throw new Error('Path is required');
     if (!options.contentType) throw new Error('Content type is required');
 
-    logger.info(`Uploading to Azure Blob: ${options.path}`, { contentType: options.contentType, size: buffer.length });
+    logger.info(`Uploading to Azure Blob: ${logSafe(options.path)}`, { contentType: options.contentType, size: buffer.length });
 
     await this.uploadBody(Readable.from(buffer), options.path, options.contentType, options.metadata, options.cacheControl, options.ifNotExists);
 
-    logger.info(`File uploaded to Azure Blob: ${options.path}`);
+    logger.info(`File uploaded to Azure Blob: ${logSafe(options.path)}`);
     return { filename: options.path, path: options.path, size: buffer.length };
   }
 
@@ -134,7 +133,7 @@ export class AzureBlobStorageService implements StorageService {
     const { body, size } = this.countingBody(stream);
     await this.uploadBody(body, options.path, options.contentType, options.metadata, undefined, options.ifNotExists, options.chunkSize);
 
-    logger.info(`Stream uploaded to Azure Blob at exact path: ${options.path}`, { size: size() });
+    logger.info(`Stream uploaded to Azure Blob at exact path: ${logSafe(options.path)}`, { size: size() });
     return { filename: options.path, path: options.path, size: size() };
   }
 

--- a/packages/storage/src/azureBlobStorageService.ts
+++ b/packages/storage/src/azureBlobStorageService.ts
@@ -41,7 +41,7 @@ function stripTrailingSlashes(value: string): string {
 }
 
 function logSafe(value: string): string {
-  return String(value).replace(/\n/g, ' ').replace(/\r/g, ' ');
+  return JSON.stringify(String(value));
 }
 
 /**

--- a/packages/storage/src/azureBlobStorageService.ts
+++ b/packages/storage/src/azureBlobStorageService.ts
@@ -31,6 +31,20 @@ const UPLOAD_CONCURRENCY = 4;
 /** User delegation keys (OAuth-signed SAS) are valid for at most seven days. */
 const MAX_DELEGATION_HOURS = 7 * 24;
 
+/** Trailing-slash trim without a regex: an endpoint is caller input and `/\/+$/` backtracks. */
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
+/** Paths and filenames are caller input; keep log lines to one line each. */
+function logSafe(value: string): string {
+  return value.replace(/[\r\n]+/g, ' ');
+}
+
 /**
  * Azure Blob Storage through the official SDK. Credentials come from, in order:
  * a connection string, a SAS token, anonymous (public container), or
@@ -48,9 +62,9 @@ export class AzureBlobStorageService implements StorageService {
     if (cfg.connectionString) {
       this.service = BlobServiceClient.fromConnectionString(cfg.connectionString);
     } else {
-      const endpoint = (
-        cfg.endpoint ?? (cfg.accountName ? `https://${cfg.accountName}.blob.core.windows.net` : undefined)
-      )?.replace(/\/+$/, '');
+      const rawEndpoint =
+        cfg.endpoint ?? (cfg.accountName ? `https://${cfg.accountName}.blob.core.windows.net` : undefined);
+      const endpoint = rawEndpoint === undefined ? undefined : stripTrailingSlashes(rawEndpoint);
       if (!endpoint) throw new Error('AzureStorageConfig needs accountName, endpoint or connectionString');
 
       if (cfg.sasToken) {
@@ -73,11 +87,11 @@ export class AzureBlobStorageService implements StorageService {
     if (!options.contentType) throw new Error('Content type is required');
 
     const filePath = generateFilePath(options);
-    logger.info(`Uploading to Azure Blob: ${filePath}`, { contentType: options.contentType, size: buffer.length });
+    logger.info(`Uploading to Azure Blob: ${logSafe(filePath)}`, { contentType: options.contentType, size: buffer.length });
 
     await this.uploadBody(Readable.from(buffer), filePath, options.contentType, options.metadata, 'public, max-age=31536000');
 
-    logger.info(`File uploaded to Azure Blob: ${filePath}`);
+    logger.info(`File uploaded to Azure Blob: ${logSafe(filePath)}`);
     return { filename: filePath, path: filePath, size: buffer.length };
   }
 
@@ -88,11 +102,11 @@ export class AzureBlobStorageService implements StorageService {
 
     const filePath = generateFilePath(options);
     const { body, size } = this.countingBody(stream);
-    logger.info(`Streaming upload to Azure Blob: ${filePath}`, { contentType: options.contentType });
+    logger.info(`Streaming upload to Azure Blob: ${logSafe(filePath)}`, { contentType: options.contentType });
 
     await this.uploadBody(body, filePath, options.contentType, options.metadata, 'public, max-age=31536000');
 
-    logger.info(`Stream uploaded to Azure Blob: ${filePath}`, { size: size() });
+    logger.info(`Stream uploaded to Azure Blob: ${logSafe(filePath)}`, { size: size() });
     return { filename: filePath, path: filePath, size: size() };
   }
 
@@ -129,10 +143,10 @@ export class AzureBlobStorageService implements StorageService {
 
     const resp = await this.container.getBlobClient(filename).deleteIfExists();
     if (!resp.succeeded) {
-      logger.warn(`File does not exist in Azure Blob: ${filename}`);
+      logger.warn(`File does not exist in Azure Blob: ${logSafe(filename)}`);
       return { filename, deleted: false };
     }
-    logger.info(`File deleted from Azure Blob: ${filename}`);
+    logger.info(`File deleted from Azure Blob: ${logSafe(filename)}`);
     return { filename, deleted: true };
   }
 
@@ -229,7 +243,7 @@ export class AzureBlobStorageService implements StorageService {
     try {
       return await this.container.getBlobClient(filename).exists();
     } catch (error) {
-      logger.error(`Failed to check file existence: ${filename}`, error);
+      logger.error(`Failed to check file existence: ${logSafe(filename)}`, error);
       return false;
     }
   }
@@ -253,14 +267,14 @@ export class AzureBlobStorageService implements StorageService {
         if (!path) throw new Error('Path is required for file content retrieval');
 
         const buffer = await this.container.getBlobClient(path).downloadToBuffer();
-        if (attempt > 1) logger.info(`Successfully fetched file from Azure Blob after ${attempt} attempts: ${path}`);
+        if (attempt > 1) logger.info(`Successfully fetched file from Azure Blob after ${attempt} attempts: ${logSafe(path)}`);
         return buffer;
       } catch (error) {
         lastError = error instanceof Error ? error : new Error('Unknown error');
         if (attempt === maxRetries) break;
 
         const delay = initialDelay * Math.pow(2, attempt - 1);
-        logger.warn(`Attempt ${attempt}/${maxRetries} failed to fetch from Azure Blob: ${path}. Retrying in ${delay}ms...`);
+        logger.warn(`Attempt ${attempt}/${maxRetries} failed to fetch from Azure Blob: ${logSafe(path)}. Retrying in ${delay}ms...`);
         await new Promise(resolve => setTimeout(resolve, delay));
       }
     }
@@ -273,7 +287,7 @@ export class AzureBlobStorageService implements StorageService {
     if (!localPath) throw new Error('Local path is required');
 
     await this.container.getBlobClient(remotePath).downloadToFile(localPath);
-    logger.info(`File downloaded from Azure Blob: ${remotePath} to ${localPath}`);
+    logger.info(`File downloaded from Azure Blob: ${logSafe(remotePath)} to ${logSafe(localPath)}`);
   }
 
   async createReadStream(path: string, options?: { start?: number; end?: number }): Promise<NodeJS.ReadableStream> {
@@ -325,11 +339,11 @@ export class AzureBlobStorageService implements StorageService {
     try {
       await source.delete();
     } catch (error) {
-      logger.warn(`File copied to ${destinationPath} but failed to delete source ${sourcePath} — file exists in both locations`, error);
+      logger.warn(`File copied to ${logSafe(destinationPath)} but failed to delete source ${logSafe(sourcePath)} — file exists in both locations`, error);
       throw error;
     }
 
-    logger.info(`File moved in Azure Blob: ${sourcePath} -> ${destinationPath}`);
+    logger.info(`File moved in Azure Blob: ${logSafe(sourcePath)} -> ${logSafe(destinationPath)}`);
   }
 
   async ensureBucketExists(): Promise<void> {

--- a/packages/storage/src/azureBlobStorageService.ts
+++ b/packages/storage/src/azureBlobStorageService.ts
@@ -1,0 +1,410 @@
+import { DefaultAzureCredential } from '@azure/identity';
+import {
+  BlobSASPermissions,
+  BlobServiceClient,
+  RestError,
+  generateBlobSASQueryParameters,
+  type BlobHTTPHeaders,
+  type BlockBlobUploadStreamOptions,
+  type ContainerClient,
+} from '@azure/storage-blob';
+import { PassThrough, Readable } from 'stream';
+
+import { logger } from './logger.js';
+import { generateFilePath } from './pathUtils.js';
+import type {
+  AzureStorageConfig,
+  DeleteResult,
+  FileMetadata,
+  ListedFile,
+  ObjectInfo,
+  ObjectRead,
+  StorageService,
+  UploadOptions,
+  UploadResult,
+  UploadToPathOptions,
+} from './types.js';
+
+/** Block size for streamed uploads; Azure allows up to 4000 MiB per block, 4 MiB keeps buffering small. */
+const DEFAULT_BLOCK_SIZE = 4 * 1024 * 1024;
+const UPLOAD_CONCURRENCY = 4;
+/** User delegation keys (OAuth-signed SAS) are valid for at most seven days. */
+const MAX_DELEGATION_HOURS = 7 * 24;
+
+/**
+ * Azure Blob Storage through the official SDK. Credentials come from, in order:
+ * a connection string, a SAS token, anonymous (public container), or
+ * DefaultAzureCredential (env vars, workload identity, managed identity, CLI).
+ */
+export class AzureBlobStorageService implements StorageService {
+  private readonly service: BlobServiceClient;
+  private readonly container: ContainerClient;
+  private readonly containerName: string;
+  private readonly credential: DefaultAzureCredential | undefined;
+
+  constructor(cfg: AzureStorageConfig, containerName?: string) {
+    this.containerName = containerName || cfg.containerName;
+
+    if (cfg.connectionString) {
+      this.service = BlobServiceClient.fromConnectionString(cfg.connectionString);
+    } else {
+      const endpoint = (
+        cfg.endpoint ?? (cfg.accountName ? `https://${cfg.accountName}.blob.core.windows.net` : undefined)
+      )?.replace(/\/+$/, '');
+      if (!endpoint) throw new Error('AzureStorageConfig needs accountName, endpoint or connectionString');
+
+      if (cfg.sasToken) {
+        this.service = new BlobServiceClient(`${endpoint}?${cfg.sasToken.replace(/^\?/, '')}`);
+      } else if (cfg.anonymous) {
+        this.service = new BlobServiceClient(endpoint);
+      } else {
+        this.credential = new DefaultAzureCredential();
+        this.service = new BlobServiceClient(endpoint, this.credential);
+      }
+    }
+
+    this.container = this.service.getContainerClient(this.containerName);
+    logger.info(`Azure Blob Storage Service initialized for container: ${this.containerName}`);
+  }
+
+  async uploadFile(buffer: Buffer, options: UploadOptions): Promise<UploadResult> {
+    if (!buffer || buffer.length === 0) throw new Error('File buffer is empty or invalid');
+    if (!options.filename) throw new Error('Filename is required');
+    if (!options.contentType) throw new Error('Content type is required');
+
+    const filePath = generateFilePath(options);
+    logger.info(`Uploading to Azure Blob: ${filePath}`, { contentType: options.contentType, size: buffer.length });
+
+    await this.uploadBody(Readable.from(buffer), filePath, options.contentType, options.metadata, 'public, max-age=31536000');
+
+    logger.info(`File uploaded to Azure Blob: ${filePath}`);
+    return { filename: filePath, path: filePath, size: buffer.length };
+  }
+
+  async uploadStream(stream: NodeJS.ReadableStream, options: UploadOptions): Promise<UploadResult> {
+    if (!stream) throw new Error('File stream is empty or invalid');
+    if (!options.filename) throw new Error('Filename is required');
+    if (!options.contentType) throw new Error('Content type is required');
+
+    const filePath = generateFilePath(options);
+    const { body, size } = this.countingBody(stream);
+    logger.info(`Streaming upload to Azure Blob: ${filePath}`, { contentType: options.contentType });
+
+    await this.uploadBody(body, filePath, options.contentType, options.metadata, 'public, max-age=31536000');
+
+    logger.info(`Stream uploaded to Azure Blob: ${filePath}`, { size: size() });
+    return { filename: filePath, path: filePath, size: size() };
+  }
+
+  async uploadFileV2(
+    buffer: Buffer,
+    options: { path: string; contentType: string; cacheControl?: string; metadata?: Record<string, string>; ifNotExists?: boolean; timeoutMs?: number }
+  ): Promise<UploadResult> {
+    if (!buffer || buffer.length === 0) throw new Error('File buffer is empty or invalid');
+    if (!options.path) throw new Error('Path is required');
+    if (!options.contentType) throw new Error('Content type is required');
+
+    logger.info(`Uploading to Azure Blob: ${options.path}`, { contentType: options.contentType, size: buffer.length });
+
+    await this.uploadBody(Readable.from(buffer), options.path, options.contentType, options.metadata, options.cacheControl, options.ifNotExists);
+
+    logger.info(`File uploaded to Azure Blob: ${options.path}`);
+    return { filename: options.path, path: options.path, size: buffer.length };
+  }
+
+  async uploadStreamToPath(stream: NodeJS.ReadableStream, options: UploadToPathOptions): Promise<UploadResult> {
+    if (!stream) throw new Error('File stream is empty or invalid');
+    if (!options.path) throw new Error('Path is required');
+    if (!options.contentType) throw new Error('Content type is required');
+
+    const { body, size } = this.countingBody(stream);
+    await this.uploadBody(body, options.path, options.contentType, options.metadata, undefined, options.ifNotExists, options.chunkSize);
+
+    logger.info(`Stream uploaded to Azure Blob at exact path: ${options.path}`, { size: size() });
+    return { filename: options.path, path: options.path, size: size() };
+  }
+
+  async deleteFile(filename: string): Promise<DeleteResult> {
+    if (!filename) throw new Error('Filename is required for deletion');
+
+    const resp = await this.container.getBlobClient(filename).deleteIfExists();
+    if (!resp.succeeded) {
+      logger.warn(`File does not exist in Azure Blob: ${filename}`);
+      return { filename, deleted: false };
+    }
+    logger.info(`File deleted from Azure Blob: ${filename}`);
+    return { filename, deleted: true };
+  }
+
+  /**
+   * Read URL for one blob. With a SAS token or anonymous access the client URL
+   * already carries what is needed; with OAuth a user delegation SAS is minted
+   * (valid for at most seven days).
+   */
+  async generateSignedUrl(filename: string, expirationHours: number = 24): Promise<string> {
+    if (!filename) throw new Error('Filename is required for signed URL generation');
+
+    const blob = this.container.getBlobClient(filename);
+    const exists = await blob.exists();
+    if (!exists) throw new Error(`File does not exist: ${filename}`);
+
+    if (!this.credential) {
+      return blob.url;
+    }
+
+    const hours = Math.min(expirationHours, MAX_DELEGATION_HOURS);
+    const startsOn = new Date(Date.now() - 5 * 60 * 1000);
+    const expiresOn = new Date(Date.now() + hours * 3600 * 1000);
+    const delegationKey = await this.service.getUserDelegationKey(startsOn, expiresOn);
+    const sas = generateBlobSASQueryParameters(
+      {
+        containerName: this.containerName,
+        blobName: filename,
+        permissions: BlobSASPermissions.parse('r'),
+        startsOn,
+        expiresOn,
+      },
+      delegationKey,
+      this.service.accountName
+    ).toString();
+    return `${blob.url}?${sas}`;
+  }
+
+  private static isNotFound(error: unknown): boolean {
+    return error instanceof RestError && error.statusCode === 404;
+  }
+
+  private static toObjectInfo(props: {
+    contentLength?: number;
+    contentType?: string;
+    etag?: string;
+    lastModified?: Date;
+  }): ObjectInfo {
+    const info: ObjectInfo = {};
+    if (props.contentLength !== undefined) {
+      info.size = props.contentLength;
+    }
+    if (props.contentType) {
+      info.contentType = props.contentType;
+    }
+    if (props.etag) {
+      info.etag = props.etag.replace(/^W\//, '').replace(/"/g, '');
+    }
+    if (props.lastModified) {
+      info.lastModified = props.lastModified;
+    }
+    return info;
+  }
+
+  /** Metadata for one object, or null when it does not exist. */
+  async headObject(path: string): Promise<ObjectInfo | null> {
+    try {
+      const props = await this.container.getBlobClient(path).getProperties();
+      return AzureBlobStorageService.toObjectInfo(props);
+    } catch (error) {
+      if (AzureBlobStorageService.isNotFound(error)) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /** Stream one object with its metadata, or null when it does not exist. */
+  async getObject(path: string): Promise<ObjectRead | null> {
+    try {
+      const resp = await this.container.getBlobClient(path).download();
+      if (!resp.readableStreamBody) {
+        throw new Error(`Azure Blob download returned no body: ${path}`);
+      }
+      return { info: AzureBlobStorageService.toObjectInfo(resp), stream: resp.readableStreamBody };
+    } catch (error) {
+      if (AzureBlobStorageService.isNotFound(error)) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async fileExists(filename: string): Promise<boolean> {
+    try {
+      return await this.container.getBlobClient(filename).exists();
+    } catch (error) {
+      logger.error(`Failed to check file existence: ${filename}`, error);
+      return false;
+    }
+  }
+
+  async getFileMetadata(filename: string): Promise<FileMetadata> {
+    const props = await this.container.getBlobClient(filename).getProperties();
+    return {
+      contentType: props.contentType,
+      size: props.contentLength,
+      metadata: props.metadata,
+      lastModified: props.lastModified,
+    };
+  }
+
+  async getFileBuffer(path: string, maxRetries: number = 3): Promise<Buffer> {
+    const initialDelay = 1000;
+    let lastError: Error | undefined;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        if (!path) throw new Error('Path is required for file content retrieval');
+
+        const buffer = await this.container.getBlobClient(path).downloadToBuffer();
+        if (attempt > 1) logger.info(`Successfully fetched file from Azure Blob after ${attempt} attempts: ${path}`);
+        return buffer;
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error('Unknown error');
+        if (attempt === maxRetries) break;
+
+        const delay = initialDelay * Math.pow(2, attempt - 1);
+        logger.warn(`Attempt ${attempt}/${maxRetries} failed to fetch from Azure Blob: ${path}. Retrying in ${delay}ms...`);
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
+    }
+
+    throw new Error(`Azure Blob read failed after ${maxRetries} attempts: ${lastError?.message}`);
+  }
+
+  async downloadFile(remotePath: string, localPath: string): Promise<void> {
+    if (!remotePath) throw new Error('Remote path is required');
+    if (!localPath) throw new Error('Local path is required');
+
+    await this.container.getBlobClient(remotePath).downloadToFile(localPath);
+    logger.info(`File downloaded from Azure Blob: ${remotePath} to ${localPath}`);
+  }
+
+  async createReadStream(path: string, options?: { start?: number; end?: number }): Promise<NodeJS.ReadableStream> {
+    if (!path) throw new Error('Path is required for creating read stream');
+
+    const offset = options?.start ?? 0;
+    const count = options?.end !== undefined ? options.end - offset + 1 : undefined;
+    const resp = await this.container.getBlobClient(path).download(offset, count);
+    if (!resp.readableStreamBody) {
+      throw new Error(`Azure Blob download returned no body: ${path}`);
+    }
+    return resp.readableStreamBody;
+  }
+
+  async listFiles(prefix: string): Promise<ListedFile[]> {
+    const results: ListedFile[] = [];
+    for await (const item of this.container.listBlobsFlat({ prefix })) {
+      results.push({
+        name: item.name,
+        ...(item.properties.contentType ? { contentType: item.properties.contentType } : {}),
+        ...(item.properties.contentLength !== undefined ? { size: item.properties.contentLength } : {}),
+        ...(item.properties.lastModified ? { updated: item.properties.lastModified } : {}),
+      });
+    }
+    return results;
+  }
+
+  /**
+   * Copy then delete. The copy streams through this process rather than using
+   * the server-side copy, which needs a separately authorised source URL and
+   * has different limits per auth mode; the callers move small objects.
+   */
+  async moveFile(sourcePath: string, destinationPath: string): Promise<void> {
+    const source = this.container.getBlobClient(sourcePath);
+    const props = await source.getProperties();
+    const download = await source.download();
+    if (!download.readableStreamBody) {
+      throw new Error(`Azure Blob download returned no body: ${sourcePath}`);
+    }
+
+    await this.uploadBody(
+      this.asReadable(download.readableStreamBody),
+      destinationPath,
+      props.contentType ?? 'application/octet-stream',
+      props.metadata,
+      props.cacheControl
+    );
+
+    try {
+      await source.delete();
+    } catch (error) {
+      logger.warn(`File copied to ${destinationPath} but failed to delete source ${sourcePath} — file exists in both locations`, error);
+      throw error;
+    }
+
+    logger.info(`File moved in Azure Blob: ${sourcePath} -> ${destinationPath}`);
+  }
+
+  async ensureBucketExists(): Promise<void> {
+    const resp = await this.container.createIfNotExists();
+    if (resp.succeeded) {
+      logger.info(`Azure Blob container created: ${this.containerName}`);
+    } else {
+      logger.info(`Azure Blob container exists: ${this.containerName}`);
+    }
+  }
+
+  async checkBucketExists(): Promise<void> {
+    const exists = await this.container.exists().catch(() => false);
+    if (!exists) {
+      throw new Error(`Azure Blob container does not exist: ${this.containerName}`);
+    }
+    logger.info(`Azure Blob container exists: ${this.containerName}`);
+  }
+
+  public getBucketName(): string {
+    return this.containerName;
+  }
+
+  buildStorageUri(path: string): string {
+    return `az://${this.containerName}/${path}`;
+  }
+
+  /** Azure metadata keys must be C# identifiers and values ASCII. */
+  private sanitizeMetadata(metadata?: Record<string, string>): Record<string, string> | undefined {
+    if (!metadata) return undefined;
+    return Object.fromEntries(
+      Object.entries(metadata).map(([k, v]) => {
+        const key = k.replace(/[^A-Za-z0-9_]/g, '_').replace(/^(\d)/, '_$1');
+        return [key, v.replace(/[^\x20-\x7E]/g, '_')];
+      })
+    );
+  }
+
+  private asReadable(stream: NodeJS.ReadableStream): Readable {
+    if (stream instanceof Readable) return stream;
+    const pass = new PassThrough();
+    stream.on('error', (error) => pass.destroy(error));
+    stream.pipe(pass);
+    return pass;
+  }
+
+  private countingBody(stream: NodeJS.ReadableStream): { body: Readable; size: () => number } {
+    let size = 0;
+    const counting = new PassThrough();
+    counting.on('data', (chunk: Buffer | string) => {
+      size += Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(chunk);
+    });
+    stream.on('error', (error) => counting.destroy(error));
+    stream.pipe(counting);
+    return { body: counting, size: () => size };
+  }
+
+  private async uploadBody(
+    body: Readable,
+    filePath: string,
+    contentType: string,
+    metadata?: Record<string, string>,
+    cacheControl: string = 'public, max-age=31536000',
+    ifNotExists?: boolean,
+    blockSize?: number
+  ): Promise<void> {
+    const headers: BlobHTTPHeaders = { blobContentType: contentType, blobCacheControl: cacheControl };
+    const options: BlockBlobUploadStreamOptions = {
+      blobHTTPHeaders: headers,
+      metadata: this.sanitizeMetadata(metadata),
+      // If-None-Match: * fails with 409 BlobAlreadyExists when the blob is there; see isPreconditionFailed.
+      ...(ifNotExists ? { conditions: { ifNoneMatch: '*' } } : {}),
+    };
+    await this.container
+      .getBlockBlobClient(filePath)
+      .uploadStream(body, blockSize ?? DEFAULT_BLOCK_SIZE, UPLOAD_CONCURRENCY, options);
+  }
+}

--- a/packages/storage/src/factory.ts
+++ b/packages/storage/src/factory.ts
@@ -1,3 +1,4 @@
+import { AzureBlobStorageService } from './azureBlobStorageService.js';
 import { GCSService } from './gcsService.js';
 import { GCSAdapter } from './gcsAdapter.js';
 import { S3StorageService } from './s3StorageService.js';
@@ -7,6 +8,10 @@ export function createStorageService(cfg: StorageConfig, bucketName?: string): S
   if (cfg.provider === 's3') {
     if (!cfg.s3) throw new Error('StorageConfig.provider is "s3" but no s3 config was provided');
     return new S3StorageService(cfg.s3, bucketName);
+  }
+  if (cfg.provider === 'azure') {
+    if (!cfg.azure) throw new Error('StorageConfig.provider is "azure" but no azure config was provided');
+    return new AzureBlobStorageService(cfg.azure, bucketName);
   }
   if (!cfg.gcs) throw new Error('StorageConfig.provider is "gcs" but no gcs config was provided');
   return new GCSAdapter(new GCSService(cfg.gcs, bucketName));

--- a/packages/storage/src/gcsAdapter.ts
+++ b/packages/storage/src/gcsAdapter.ts
@@ -1,5 +1,5 @@
 import { GCSService } from './gcsService.js';
-import type { StorageService, UploadOptions, UploadResult, UploadToPathOptions, DeleteResult, FileMetadata, ListedFile } from './types.js';
+import type { StorageService, UploadOptions, UploadResult, UploadToPathOptions, DeleteResult, FileMetadata, ListedFile, ObjectInfo, ObjectRead } from './types.js';
 
 export class GCSAdapter implements StorageService {
   constructor(private gcs: GCSService) {}
@@ -60,6 +60,14 @@ export class GCSAdapter implements StorageService {
 
   async createReadStream(path: string, options?: { start?: number; end?: number }): Promise<NodeJS.ReadableStream> {
     return this.gcs.createReadStream(path, options);
+  }
+
+  async headObject(path: string): Promise<ObjectInfo | null> {
+    return this.gcs.headObject(path);
+  }
+
+  async getObject(path: string): Promise<ObjectRead | null> {
+    return this.gcs.getObject(path);
   }
 
   async listFiles(prefix: string): Promise<ListedFile[]> {

--- a/packages/storage/src/gcsService.ts
+++ b/packages/storage/src/gcsService.ts
@@ -3,6 +3,7 @@ import { isPreconditionFailed, type GcsStorageConfig } from './types.js';
 
 import { logger } from './logger.js';
 import { v4 as uuidv4 } from 'uuid';
+import type { ObjectInfo, ObjectRead } from './types.js';
 
 export interface GCSUploadOptions {
   filename: string;
@@ -394,6 +395,56 @@ export class GCSService {
 
       throw new Error('Signed URL generation failed: Unknown error');
     }
+  }
+
+  private static isNotFound(error: unknown): boolean {
+    const e = error as { code?: unknown; status?: unknown };
+    return e?.code === 404 || e?.status === 404;
+  }
+
+  private static toObjectInfo(metadata: {
+    size?: string | number;
+    contentType?: string;
+    etag?: string;
+    updated?: string;
+  }): ObjectInfo {
+    const info: ObjectInfo = {};
+    const size = typeof metadata.size === 'string' ? Number(metadata.size) : metadata.size;
+    if (size !== undefined && Number.isFinite(size)) {
+      info.size = size;
+    }
+    if (metadata.contentType) {
+      info.contentType = metadata.contentType;
+    }
+    if (metadata.etag) {
+      info.etag = metadata.etag.replace(/^W\//, '').replace(/"/g, '');
+    }
+    if (metadata.updated) {
+      info.lastModified = new Date(metadata.updated);
+    }
+    return info;
+  }
+
+  /** Metadata for one object, or null when it does not exist. */
+  async headObject(path: string): Promise<ObjectInfo | null> {
+    try {
+      const [metadata] = await this.bucket.file(path).getMetadata();
+      return GCSService.toObjectInfo(metadata);
+    } catch (error) {
+      if (GCSService.isNotFound(error)) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /** Stream one object with its metadata, or null when it does not exist. */
+  async getObject(path: string): Promise<ObjectRead | null> {
+    const info = await this.headObject(path);
+    if (!info) {
+      return null;
+    }
+    return { info, stream: this.bucket.file(path).createReadStream() };
   }
 
   async fileExists(filename: string): Promise<boolean> {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -5,3 +5,4 @@ export { generateFilePath, normalizeStoragePath, sanitizeFilename } from './path
 export { GCSService } from './gcsService.js';
 export { GCSAdapter } from './gcsAdapter.js';
 export { S3StorageService } from './s3StorageService.js';
+export { AzureBlobStorageService } from './azureBlobStorageService.js';

--- a/packages/storage/src/pathUtils.ts
+++ b/packages/storage/src/pathUtils.ts
@@ -20,7 +20,7 @@ export function generateFilePath(options: UploadOptions): string {
 }
 
 export function normalizeStoragePath(url: string): string {
-  const match = url.match(/^(?:gs|s3):\/\/[^/]+\/(.+)$/);
+  const match = url.match(/^(?:gs|s3|az):\/\/[^/]+\/(.+)$/);
   return match ? match[1] : url;
 }
 

--- a/packages/storage/src/s3StorageService.ts
+++ b/packages/storage/src/s3StorageService.ts
@@ -18,7 +18,7 @@ import { Readable } from 'stream';
 
 import { logger } from './logger.js';
 import { generateFilePath } from './pathUtils.js';
-import type { StorageService, S3StorageConfig, UploadOptions, UploadResult, DeleteResult, FileMetadata } from './types.js';
+import type { StorageService, S3StorageConfig, UploadOptions, UploadResult, DeleteResult, FileMetadata, ObjectInfo, ObjectRead } from './types.js';
 
 export class S3StorageService implements StorageService {
   private client: S3Client;
@@ -179,6 +179,59 @@ export class S3StorageService implements StorageService {
       new GetObjectCommand({ Bucket: this.bucketName, Key: filename }),
       { expiresIn: expirationHours * 3600 }
     );
+  }
+
+  private static isNotFound(error: unknown): boolean {
+    const e = error as { name?: string; $metadata?: { httpStatusCode?: number } };
+    return e?.name === 'NotFound' || e?.name === 'NoSuchKey' || e?.$metadata?.httpStatusCode === 404;
+  }
+
+  private static toObjectInfo(resp: {
+    ContentLength?: number;
+    ContentType?: string;
+    ETag?: string;
+    LastModified?: Date;
+  }): ObjectInfo {
+    const info: ObjectInfo = {};
+    if (resp.ContentLength !== undefined) {
+      info.size = resp.ContentLength;
+    }
+    if (resp.ContentType) {
+      info.contentType = resp.ContentType;
+    }
+    if (resp.ETag) {
+      info.etag = resp.ETag.replace(/^W\//, '').replace(/"/g, '');
+    }
+    if (resp.LastModified) {
+      info.lastModified = resp.LastModified;
+    }
+    return info;
+  }
+
+  /** Metadata for one object, or null when it does not exist. */
+  async headObject(path: string): Promise<ObjectInfo | null> {
+    try {
+      const resp = await this.client.send(new HeadObjectCommand({ Bucket: this.bucketName, Key: path }));
+      return S3StorageService.toObjectInfo(resp);
+    } catch (error) {
+      if (S3StorageService.isNotFound(error)) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /** Stream one object with its metadata, or null when it does not exist. */
+  async getObject(path: string): Promise<ObjectRead | null> {
+    try {
+      const resp = await this.client.send(new GetObjectCommand({ Bucket: this.bucketName, Key: path }));
+      return { info: S3StorageService.toObjectInfo(resp), stream: resp.Body as NodeJS.ReadableStream };
+    } catch (error) {
+      if (S3StorageService.isNotFound(error)) {
+        return null;
+      }
+      throw error;
+    }
   }
 
   async fileExists(filename: string): Promise<boolean> {

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -14,11 +14,21 @@ export interface S3StorageConfig {
   secretAccessKey?: string;
 }
 
+export interface AzureStorageConfig {
+  accountName?: string;
+  endpoint?: string;
+  connectionString?: string;
+  containerName: string;
+  sasToken?: string;
+  anonymous?: boolean;
+}
+
 /** Provider is selected by config (STORAGE_PROVIDER env in each app). */
 export interface StorageConfig {
-  provider: 'gcs' | 's3';
+  provider: 'gcs' | 's3' | 'azure';
   gcs?: GcsStorageConfig;
   s3?: S3StorageConfig;
+  azure?: AzureStorageConfig;
 }
 
 export interface UploadOptions {
@@ -46,6 +56,20 @@ export interface FileMetadata {
   size?: number | string;
   metadata?: Record<string, string>;
   lastModified?: Date;
+}
+
+/** Read-path metadata for one object, as returned by headObject / getObject. */
+export interface ObjectInfo {
+  size?: number;
+  contentType?: string;
+  etag?: string;
+  lastModified?: Date;
+}
+
+/** One object's metadata plus a readable stream of its content. */
+export interface ObjectRead {
+  info: ObjectInfo;
+  stream: NodeJS.ReadableStream;
 }
 
 export interface ListedFile {
@@ -80,6 +104,8 @@ export interface StorageService {
   getFileBuffer(path: string, maxRetries?: number): Promise<Buffer>;
   downloadFile(remotePath: string, localPath: string): Promise<void>;
   createReadStream(path: string, options?: { start?: number; end?: number }): Promise<NodeJS.ReadableStream>;
+  headObject(path: string): Promise<ObjectInfo | null>;
+  getObject(path: string): Promise<ObjectRead | null>;
   listFiles(prefix: string): Promise<ListedFile[]>;
   moveFile(sourcePath: string, destinationPath: string): Promise<void>;
   ensureBucketExists(): Promise<void>;
@@ -100,6 +126,7 @@ export function isPreconditionFailed(err: unknown): boolean {
     e?.status === 412 ||
     e?.statusCode === 412 ||
     e?.$metadata?.httpStatusCode === 412 ||
-    e?.name === 'PreconditionFailed'
+    e?.name === 'PreconditionFailed' ||
+    e?.code === 'BlobAlreadyExists'
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1340,6 +1340,40 @@ importers:
         specifier: ^3.1.4
         version: 3.4.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
 
+  apps/dashboard-edge:
+    dependencies:
+      '@xyne/storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.5(jiti@2.7.0)
+      prettier:
+        specifier: ^3.3.0
+        version: 3.8.0
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.1
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.62.0
+        version: 8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.20.1)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(sass@1.51.0)
+
   apps/dashboard-external:
     dependencies:
       '@livekit/components-react':
@@ -2053,13 +2087,13 @@ importers:
         version: 16.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.20.1)
+        version: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
       prettier:
         specifier: 3.5.3
         version: 3.5.3
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.12(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.20.1))(typescript@5.8.3)
+        version: 29.4.12(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3)))(typescript@5.8.3)
       tsx:
         specifier: ^4.20.4
         version: 4.23.1
@@ -2183,6 +2217,12 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1017.0
         version: 3.1097.0
+      '@azure/identity':
+        specifier: ^4.10.0
+        version: 4.13.2
+      '@azure/storage-blob':
+        specifier: ^12.26.0
+        version: 12.33.0
       '@google-cloud/storage':
         specifier: ^7.7.0
         version: 7.21.0
@@ -2657,6 +2697,85 @@ packages:
   '@aws/lambda-invoke-store@0.3.0':
     resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
+
+  '@azure/abort-controller@2.2.0':
+    resolution: {integrity: sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-auth@1.11.0':
+    resolution: {integrity: sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-client@1.11.0':
+    resolution: {integrity: sha512-JjQWO6akOck45PH/XBrxzsQGAiKrfFl4m5iggJ0ItMIz5omRufOXWpqCPpdjKN3vKDzlSUvFjaMb7Zwf0gvAdA==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-http-compat@2.5.0':
+    resolution: {integrity: sha512-BoSmXPx2er1Ai+wKlDvj29jIQespCNBwEmKyZVHO2kEFsWbGjAjwMCGzug3DJM5/QYIV3vej0S1zcU5bq9fa8w==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      '@azure/core-client': ^1.10.0
+      '@azure/core-rest-pipeline': ^1.22.0
+
+  '@azure/core-lro@2.7.2':
+    resolution: {integrity: sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-paging@1.7.0':
+    resolution: {integrity: sha512-7GEAoIsaoBr6KELNRb8nypowCqvk8dnCHFCYg4XD4lOQGY2GqjQg5IhkRjyBFRO18CGSMq05PaNqSOE9GQro3g==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-process@1.0.0':
+    resolution: {integrity: sha512-/shnJ+ooO8WPxDhPEeI/2oRQuubn16gZ6CvlbpWbEswZfzwI9tI/sMAHmF3x1LuQ9yZYXfLW3TjzGMLEC5blKg==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-rest-pipeline@1.25.0':
+    resolution: {integrity: sha512-bMs8ekJLjX8wPV+9IPBges1SLPyuDtE9g5gLDWOpxzKcoOFQnpLGkbcT1tdw3FaAmDS1gnPmMmJ6y/T5B96kIA==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-tracing@1.4.0':
+    resolution: {integrity: sha512-eGwxD0AtncrxeBM4tG8R55Pc3rdX1hNW2WibJAgYpCVA6E93mvvVH+LcssoVjOBrSKWS55yEIHsk0X8ctHmfOQ==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-util@1.14.0':
+    resolution: {integrity: sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/core-xml@1.6.0':
+    resolution: {integrity: sha512-e7lX/dk//F6Qf7BB6PTY4+p2yuOQtyOeHGyapYHNwqSp2OnYpwQt49A/Nin2XmKBQ69pwagR4k/lQBq8lbHQkA==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/identity@4.13.2':
+    resolution: {integrity: sha512-NXL2/pCJctLxgw8bvrwwgge743kEq8LBT+O1pmV0vyUwetzFPH9auP6jhkU/cgZCPPtWoewAe3ncaGCgPo07fA==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/logger@1.4.0':
+    resolution: {integrity: sha512-rbAE25KUfjU/s3XHUdJgceoCP5dEOpMx85J04kF+QMdta73XkuG9JGHHinch+XIoKpBdqljin+KqURpJriSzLA==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/msal-browser@5.21.0':
+    resolution: {integrity: sha512-80OcuXDErmcEDAIH9pBtSqBsed2sPT/IWmbG3xHLoPMl5zc8TINd6SlJAbVSmN5huGa3xGAg5qR7VnpaIEK0Zw==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-common@16.13.0':
+    resolution: {integrity: sha512-rOAy0KUcyBbdwVJ+f3uPpthXatFLLZN+/KWAsTLzk1aB23Xl9DRmmXYwSvBFOZyXj4jUQQ5FKxxRkhAFW1fOow==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-common@16.14.0':
+    resolution: {integrity: sha512-A4rb55hI86Q9tBl/+jBj7TMz7iX2RFgQs/nExFzcAtoI/BFRVdaH5SL/MivrYD7qvweMpN8AgVvVMHV8UBYxew==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-node@5.6.0':
+    resolution: {integrity: sha512-uFY9NxrWHw8PwZx7gAX6PDn+9vdfS05+levc/kwkx77IkjfaldnQbbcQzzDIZ5Hq5Zdr6/z92oAIoRWKp6MnOA==}
+    engines: {node: '>=20'}
+
+  '@azure/storage-blob@12.33.0':
+    resolution: {integrity: sha512-2SX8oP8PyblUcAFZSg39c8Ls+tFjavM6sBeV+qpw33mRzRhI/5hrFJmJ/x0H9xx5l6ECPvgSP8uPxqTeVbHNIA==}
+    engines: {node: '>=22.0.0'}
+
+  '@azure/storage-common@12.5.0':
+    resolution: {integrity: sha512-bttzuhQiCIwrkzjPDA+AtAR7dg19L/CC6ztcqJ5LfvWpXuys9mHp0UQ0udYnoUvv9SCT9KTR5kqFvFr0e6k0lQ==}
+    engines: {node: '>=22.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -10019,6 +10138,10 @@ packages:
     resolution: {integrity: sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typespec/ts-http-runtime@0.3.8':
+    resolution: {integrity: sha512-bLMpVcWZNzq6lYOybwFwOAR1IXKcHnhUNqYeHjl1bET/qE3jFPFH+p8Wrh3rU4xwdnifPxmKNESBYnvnmc75aA==}
+    engines: {node: '>=22.0.0'}
+
   '@uiw/codemirror-extensions-basic-setup@4.25.11':
     resolution: {integrity: sha512-otyFa+n9IOYtEjaKOxPedHkj15fTPUF21wdR9pv0GpZPfuGl27cvmcv6+tognbRu9VvEcsHKE+ESoszeo3KfTw==}
     peerDependencies:
@@ -10846,6 +10969,9 @@ packages:
 
   binary@0.3.0:
     resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -16592,6 +16718,10 @@ packages:
   open-color@1.9.1:
     resolution: {integrity: sha512-vCseG/EQ6/RcvxhUcGJiHViOgrtz4x0XbZepXvKik66TMGkvbmjeJrKFyBEx6daG5rNyyd14zYXhz0hZVwQFOw==}
 
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
@@ -17363,6 +17493,11 @@ packages:
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+    deprecated: prom-client has been replaced by @prometheus-io/client
 
   promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
@@ -19118,6 +19253,9 @@ packages:
     resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
     engines: {node: '>=18'}
 
+  tdigest@0.1.3:
+    resolution: {integrity: sha512-zbRt+lT+/H4fRItHshczHErVCQnitJk8MfMT24MqFJf3YL7SJJPqGIGeuOdvxXxM/AHFzKBl7WoyaYwqO9s3Kw==}
+
   teeny-request@10.1.4:
     resolution: {integrity: sha512-R1Cg4Vu0UULeDfHL/kjABLaTW++9yD/B6n2g48y5dJ04hsEaxcfmAqbNDzNsbqAYJyIpZafjklLG9YxRu9uzOg==}
     engines: {node: '>=18'}
@@ -20291,6 +20429,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
@@ -20962,6 +21104,151 @@ snapshots:
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.3.0': {}
+
+  '@azure/abort-controller@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-auth@1.11.0':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-util': 1.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-client@1.11.0':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
+      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-tracing': 1.4.0
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-http-compat@2.5.0(@azure/core-client@1.11.0)(@azure/core-rest-pipeline@1.25.0)':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-client': 1.11.0
+      '@azure/core-rest-pipeline': 1.25.0
+
+  '@azure/core-lro@2.7.2':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-paging@1.7.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-process@1.0.0': {}
+
+  '@azure/core-rest-pipeline@1.25.0':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
+      '@azure/core-tracing': 1.4.0
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
+      '@typespec/ts-http-runtime': 0.3.8
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-tracing@1.4.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-util@1.14.0':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@typespec/ts-http-runtime': 0.3.8
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-xml@1.6.0':
+    dependencies:
+      fast-xml-parser: 5.10.1
+      tslib: 2.8.1
+
+  '@azure/identity@4.13.2':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
+      '@azure/core-client': 1.11.0
+      '@azure/core-process': 1.0.0
+      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-tracing': 1.4.0
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
+      '@azure/msal-browser': 5.21.0
+      '@azure/msal-node': 5.6.0
+      open: 10.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/logger@1.4.0':
+    dependencies:
+      '@typespec/ts-http-runtime': 0.3.8
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/msal-browser@5.21.0':
+    dependencies:
+      '@azure/msal-common': 16.14.0
+
+  '@azure/msal-common@16.13.0': {}
+
+  '@azure/msal-common@16.14.0': {}
+
+  '@azure/msal-node@5.6.0':
+    dependencies:
+      '@azure/msal-common': 16.13.0
+      jsonwebtoken: 9.0.3
+
+  '@azure/storage-blob@12.33.0':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
+      '@azure/core-client': 1.11.0
+      '@azure/core-http-compat': 2.5.0(@azure/core-client@1.11.0)(@azure/core-rest-pipeline@1.25.0)
+      '@azure/core-lro': 2.7.2
+      '@azure/core-paging': 1.7.0
+      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-tracing': 1.4.0
+      '@azure/core-util': 1.14.0
+      '@azure/core-xml': 1.6.0
+      '@azure/logger': 1.4.0
+      '@azure/storage-common': 12.5.0(@azure/core-client@1.11.0)
+      events: 3.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/storage-common@12.5.0(@azure/core-client@1.11.0)':
+    dependencies:
+      '@azure/abort-controller': 2.2.0
+      '@azure/core-auth': 1.11.0
+      '@azure/core-http-compat': 2.5.0(@azure/core-client@1.11.0)(@azure/core-rest-pipeline@1.25.0)
+      '@azure/core-rest-pipeline': 1.25.0
+      '@azure/core-tracing': 1.4.0
+      '@azure/core-util': 1.14.0
+      '@azure/logger': 1.4.0
+      events: 3.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@azure/core-client'
+      - supports-color
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -23341,14 +23628,49 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.43
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -23373,7 +23695,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -23483,7 +23805,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -28187,11 +28509,11 @@ snapshots:
 
   '@slack/logger@4.0.1':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@slack/logger@5.0.0':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@slack/types@2.22.0': {}
 
@@ -28201,7 +28523,7 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/types': 2.22.0
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       '@types/retry': 0.12.0
       axios: 1.18.1(debug@4.4.3)
       eventemitter3: 5.0.4
@@ -28219,7 +28541,7 @@ snapshots:
     dependencies:
       '@slack/logger': 5.0.0
       '@slack/types': 3.0.0
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       '@types/retry': 0.12.0
       eventemitter3: 5.0.4
       p-queue: 6.6.2
@@ -28982,7 +29304,7 @@ snapshots:
   '@types/compression@1.8.1':
     dependencies:
       '@types/express': 4.17.25
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/connect@3.4.38':
     dependencies:
@@ -28996,7 +29318,7 @@ snapshots:
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/css-font-loading-module@0.0.7': {}
 
@@ -29149,7 +29471,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.9':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -29198,7 +29520,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/ioredis@5.0.0':
     dependencies:
@@ -29234,7 +29556,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/jszip@3.4.1':
     dependencies:
@@ -29288,7 +29610,7 @@ snapshots:
 
   '@types/morgan@1.9.10':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/ms@2.1.0': {}
 
@@ -29302,12 +29624,12 @@ snapshots:
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       form-data: 4.0.6
 
   '@types/node-rsa@1.1.4':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/node@10.17.60':
     optional: true
@@ -29336,7 +29658,7 @@ snapshots:
 
   '@types/nodemailer@8.0.1':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -29348,19 +29670,19 @@ snapshots:
 
   '@types/papaparse@5.5.2':
     dependencies:
-      '@types/node': 24.13.3
+      '@types/node': 20.19.43
 
   '@types/pdf-parse@1.1.5':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/pdfkit@0.13.9':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/pdfkit@0.17.6':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/pg-pool@2.0.7':
     dependencies:
@@ -29368,7 +29690,7 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
@@ -29377,11 +29699,11 @@ snapshots:
 
   '@types/pixelmatch@5.2.6':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/pngjs@6.0.5':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/prismjs@1.26.6': {}
 
@@ -29407,11 +29729,11 @@ snapshots:
 
   '@types/readdir-glob@1.1.5':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/redis@2.8.32':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/request@2.48.13':
     dependencies:
@@ -29439,7 +29761,7 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/serve-static@1.15.10':
     dependencies:
@@ -29469,7 +29791,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       form-data: 4.0.6
 
   '@types/supertest@2.0.16':
@@ -29478,7 +29800,7 @@ snapshots:
 
   '@types/tar@6.1.13':
     dependencies:
-      '@types/node': 24.13.3
+      '@types/node': 20.19.43
       minipass: 4.2.8
 
   '@types/tedious@4.0.14':
@@ -29509,7 +29831,7 @@ snapshots:
 
   '@types/unzipper@0.10.11':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/use-sync-external-store@0.0.6': {}
 
@@ -29528,13 +29850,13 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/xlsx@0.0.35': {}
 
   '@types/xxhashjs@0.2.4':
     dependencies:
-      '@types/node': 24.13.3
+      '@types/node': 20.19.43
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -29544,7 +29866,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -30062,6 +30384,14 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.65.0
       eslint-visitor-keys: 5.0.1
+
+  '@typespec/ts-http-runtime@0.3.8':
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@uiw/codemirror-extensions-basic-setup@4.25.11(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.4)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/view@6.43.7)':
     dependencies:
@@ -31016,6 +31346,8 @@ snapshots:
     dependencies:
       buffers: 0.1.1
       chainsaw: 0.1.0
+
+  bintrees@1.0.2: {}
 
   bl@4.1.0:
     dependencies:
@@ -32010,13 +32342,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.20.1):
+  create-jest@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -32907,7 +33239,7 @@ snapshots:
   engine.io@6.6.9:
     dependencies:
       '@types/cors': 2.8.19
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       '@types/ws': 8.18.1
       accepts: 1.3.8
       base64id: 2.0.0
@@ -35034,7 +35366,7 @@ snapshots:
 
   happy-dom@20.8.9:
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       entities: 7.0.1
@@ -36027,16 +36359,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.20.1):
+  jest-cli@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.20.1)
+      create-jest: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.3
@@ -36077,7 +36409,38 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3)):
+  jest-config@29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.19.43
+      ts-node: 10.9.2(@types/node@22.20.1)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/test-sequencer': 29.7.0
@@ -36103,7 +36466,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.20.1
-      ts-node: 10.9.2(@types/node@20.19.43)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@22.20.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -36181,7 +36544,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -36335,12 +36698,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.20.1):
+  jest@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.20.1)
+      jest-cli: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -38472,6 +38835,13 @@ snapshots:
 
   open-color@1.9.1: {}
 
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
   open@11.0.0:
     dependencies:
       default-browser: 5.5.0
@@ -39320,6 +39690,11 @@ snapshots:
   process@0.11.10: {}
 
   progress@2.0.3: {}
+
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.3
 
   promise-retry@2.0.1:
     dependencies:
@@ -41620,6 +41995,10 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
+  tdigest@0.1.3:
+    dependencies:
+      bintrees: 1.0.2
+
   teeny-request@10.1.4:
     dependencies:
       http-proxy-agent: 7.0.2
@@ -41912,12 +42291,12 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.29.7)
       jest-util: 29.7.0
 
-  ts-jest@29.4.12(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.20.1))(typescript@5.8.3):
+  ts-jest@29.4.12(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3)))(typescript@5.8.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 29.7.0(@types/node@22.20.1)
+      jest: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -41972,6 +42351,25 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.20.1
+      acorn: 8.18.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.8.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   ts-node@10.9.2(@types/node@24.13.3)(typescript@5.9.3):
     dependencies:
@@ -42947,6 +43345,10 @@ snapshots:
       signal-exit: 3.0.7
 
   ws@8.21.1: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
 
   wsl-utils@0.3.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1278,7 +1278,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^5.0.2
-        version: 5.2.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 5.2.0(vite@7.3.6(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.5.4(postcss@8.5.23)
@@ -1335,19 +1335,28 @@ importers:
         version: 1.0.7(tailwindcss@3.4.19(tsx@4.23.1)(yaml@2.9.0))
       vite:
         specifier: ^7.1.5
-        version: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
+        version: 7.3.6(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-static-copy:
         specifier: ^3.1.4
-        version: 3.4.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 3.4.0(vite@7.3.6(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/dashboard-edge:
     dependencies:
+      '@opentelemetry/api':
+        specifier: 1.9.1
+        version: 1.9.1
+      '@opentelemetry/exporter-metrics-otlp-http':
+        specifier: 0.209.0
+        version: 0.209.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics':
+        specifier: 2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node':
+        specifier: 0.217.0
+        version: 0.217.0(@opentelemetry/api@1.9.1)
       '@xyne/storage':
         specifier: workspace:*
         version: link:../../packages/storage
-      prom-client:
-        specifier: ^15.1.3
-        version: 15.1.3
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1436,7 +1445,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^5.0.2
-        version: 5.2.0(vite@7.3.6(@types/node@22.20.1)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 5.2.0(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.5.4(postcss@8.5.23)
@@ -1445,10 +1454,10 @@ importers:
         version: 17.4.3
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7))
+        version: 2.32.0(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react-hooks:
         specifier: 4.6.2
-        version: 4.6.2(eslint@9.39.5(jiti@1.21.7))
+        version: 4.6.2(eslint@9.39.5(jiti@2.7.0))
       globals:
         specifier: 13.24.0
         version: 13.24.0
@@ -1463,10 +1472,10 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 8.53.0
-        version: 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
+        version: 8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       vite:
         specifier: ^7.1.5
-        version: 7.3.6(@types/node@22.20.1)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
+        version: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
 
   apps/electron:
     dependencies:
@@ -10970,9 +10979,6 @@ packages:
   binary@0.3.0:
     resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
 
-  bintrees@1.0.2:
-    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
-
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -17494,11 +17500,6 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
-  prom-client@15.1.3:
-    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
-    engines: {node: ^16 || ^18 || >=20}
-    deprecated: prom-client has been replaced by @prometheus-io/client
-
   promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
@@ -19252,9 +19253,6 @@ packages:
   tar@7.5.21:
     resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
     engines: {node: '>=18'}
-
-  tdigest@0.1.3:
-    resolution: {integrity: sha512-zbRt+lT+/H4fRItHshczHErVCQnitJk8MfMT24MqFJf3YL7SJJPqGIGeuOdvxXxM/AHFzKBl7WoyaYwqO9s3Kw==}
 
   teeny-request@10.1.4:
     resolution: {integrity: sha512-R1Cg4Vu0UULeDfHL/kjABLaTW++9yD/B6n2g48y5dJ04hsEaxcfmAqbNDzNsbqAYJyIpZafjklLG9YxRu9uzOg==}
@@ -22846,11 +22844,6 @@ snapshots:
   '@eslint-community/eslint-utils@4.10.1(eslint@8.57.1)':
     dependencies:
       eslint: 8.57.1
-      eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/eslint-utils@4.10.1(eslint@9.39.5(jiti@1.21.7))':
-    dependencies:
-      eslint: 9.39.5(jiti@1.21.7)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/eslint-utils@4.10.1(eslint@9.39.5(jiti@2.7.0))':
@@ -28104,7 +28097,7 @@ snapshots:
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
-  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.3)(redux@5.0.1))(react@19.2.3)':
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@standard-schema/utils': 0.3.0
@@ -29939,15 +29932,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.53.0
-      '@typescript-eslint/type-utils': 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.53.0
-      eslint: 9.39.5(jiti@1.21.7)
+      eslint: 9.39.5(jiti@2.7.0)
       ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -30021,14 +30014,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.53.0
       '@typescript-eslint/types': 8.53.0
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.53.0
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.5(jiti@1.21.7)
+      eslint: 9.39.5(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -30168,13 +30161,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.53.0
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.5(jiti@1.21.7)
+      eslint: 9.39.5(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -30338,13 +30331,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.53.0
       '@typescript-eslint/types': 8.53.0
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.9.3)
-      eslint: 9.39.5(jiti@1.21.7)
+      eslint: 9.39.5(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -30556,7 +30549,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@22.20.1)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -30564,11 +30557,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.6(@types/node@22.20.1)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -30576,7 +30569,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -31346,8 +31339,6 @@ snapshots:
     dependencies:
       buffers: 0.1.1
       chainsaw: 0.1.0
-
-  bintrees@1.0.2: {}
 
   bl@4.1.0:
     dependencies:
@@ -33651,16 +33642,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5(jiti@1.21.7)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.5(jiti@1.21.7)
-      eslint-import-resolver-node: 0.3.10
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
@@ -33740,35 +33721,6 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.39.5(jiti@1.21.7)
-      eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5(jiti@1.21.7))
-      hasown: 2.0.4
-      is-core-module: 2.16.2
-      is-glob: 4.0.3
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.10
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
   eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
@@ -33781,6 +33733,33 @@ snapshots:
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-module-utils: 2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      hasown: 2.0.4
+      is-core-module: 2.16.2
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.10
+      tsconfig-paths: 3.15.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.5(jiti@2.7.0)
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -33853,9 +33832,9 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  eslint-plugin-react-hooks@4.6.2(eslint@9.39.5(jiti@1.21.7)):
+  eslint-plugin-react-hooks@4.6.2(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
-      eslint: 9.39.5(jiti@1.21.7)
+      eslint: 9.39.5(jiti@2.7.0)
 
   eslint-plugin-react-hooks@7.1.1(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
@@ -33976,47 +33955,6 @@ snapshots:
       optionator: 0.9.4
       strip-ansi: 6.0.1
       text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint@9.39.5(jiti@1.21.7):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5(jiti@1.21.7))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.6
-      '@eslint/js': 9.39.5
-      '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.8
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.9
-      ajv: 6.14.0
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
-      escape-string-regexp: 4.0.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.5
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 1.21.7
     transitivePeerDependencies:
       - supports-color
 
@@ -39691,11 +39629,6 @@ snapshots:
 
   progress@2.0.3: {}
 
-  prom-client@15.1.3:
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      tdigest: 0.1.3
-
   promise-retry@2.0.1:
     dependencies:
       err-code: 2.0.3
@@ -40466,7 +40399,7 @@ snapshots:
 
   recharts@3.10.1(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react-is@18.3.1)(react@19.2.3)(redux@5.0.1):
     dependencies:
-      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       clsx: 2.1.1
       decimal.js-light: 2.5.1
       es-toolkit: 1.50.0
@@ -41995,10 +41928,6 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
-  tdigest@0.1.3:
-    dependencies:
-      bintrees: 1.0.2
-
   teeny-request@10.1.4:
     dependencies:
       http-proxy-agent: 7.0.2
@@ -42591,13 +42520,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript-eslint@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3):
+  typescript-eslint@8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.5(jiti@1.21.7)
+      '@typescript-eslint/utils': 8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.5(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -43016,13 +42945,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-static-copy@3.4.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vite-plugin-static-copy@3.4.0(vite@7.3.6(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.6
       picocolors: 1.1.1
       tinyglobby: 0.2.17
-      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
 
   vite@5.4.21(@types/node@22.20.1)(lightningcss@1.32.0)(sass@1.51.0):
     dependencies:
@@ -43070,7 +42999,7 @@ snapshots:
       yaml: 2.9.0
     optional: true
 
-  vite@7.3.6(@types/node@22.20.1)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0):
+  vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
@@ -43081,12 +43010,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.20.1
       fsevents: 2.3.3
-      jiti: 1.21.7
+      jiti: 2.7.0
       lightningcss: 1.32.0
       tsx: 4.23.1
       yaml: 2.9.0
 
-  vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0):
+  vite@7.3.6(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
@@ -43097,7 +43026,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.3
       fsevents: 2.3.3
-      jiti: 2.7.0
+      jiti: 1.21.7
       lightningcss: 1.32.0
       tsx: 4.23.1
       yaml: 2.9.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ packages:
   - apps/backend/eslint-rules
   - apps/dashboard
   - apps/dashboard-external
+  - apps/dashboard-edge
   - apps/electron
   - apps/site
   - apps/xyne-claw


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
