### PR TITLE
fix: XYNE-62985 raise app size/count limits

### DIFF
--- a/packages/xyne-claw-shared/src/tools/react-artifact/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/react-artifact/tools.ts
@@ -36,9 +36,9 @@ const MANIFEST_END = "REACT_ARTIFACT_END";
 /** Bumped when the on-disk artifact payload shape changes. */
 const ARTIFACT_VERSION = 1;
 
-const MAX_FILES = 20;
-const MAX_FILE_BYTES = 64 * 1024;
-const MAX_TOTAL_BYTES = 256 * 1024;
+const MAX_FILES = 50;
+const MAX_FILE_BYTES = 256 * 1024;
+const MAX_TOTAL_BYTES = 2 * 1024 * 1024;
 /** The summary is the only part the model re-reads; keep it well under the 32KB inline cap. */
 const MAX_SUMMARY_CHARS = 1000;
 const MAX_TITLE_CHARS = 120;


### PR DESCRIPTION
Raises the `buildReactArtifact` validator limits (`packages/xyne-claw-shared/src/tools/react-artifact/tools.ts`) so larger vendored artifact apps publish without hitting the ceiling.

| Limit | Before | After |
|---|---|---|
| `MAX_FILES` | 20 | **50** |
| `MAX_FILE_BYTES` | 64 KB | **256 KB** |
| `MAX_TOTAL_BYTES` | 256 KB | **2 MB** |

**Why:** vendored apps (e.g. the Spaces CLI scaffold's bundled `@xyne/*` SDKs plus components/assets) can exceed the old 64 KB/file and 256 KB total. `MAX_TOTAL_BYTES` is raised to 2 MB to give headroom for ~50 files / several 256 KB bundles without being too large for Sandpack to bundle.

The agent-facing "Limits:" hint string reads from these constants, so it updates automatically — no doc/string change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)