### PR TITLE
feat: add outputMode 'thread' to automation agent node (RUN_AGENT)

### DIFF
--- a/apps/backend/src/automations/services/claw-client.ts
+++ b/apps/backend/src/automations/services/claw-client.ts
@@ -33,6 +33,13 @@ export interface RunAgentRequest {
   context?: string;
   conversationId?: string;
   channelId?: string;
+  /**
+   * When true, claw-auth posts the agent's final answer into the bound
+   * conversation (channelId + conversationId) instead of only forwarding a
+   * captured { result } back to the workflow step. The completion callback
+   * still fires so the step resumes.
+   */
+  deliverToThread?: boolean;
 }
 
 export interface RunAgentResponse {
@@ -96,6 +103,7 @@ class ClawClient {
       ...(req.context ? { context: req.context } : {}),
       ...(req.conversationId ? { conversationId: req.conversationId } : {}),
       ...(req.channelId ? { channelId: req.channelId } : {}),
+      ...(req.deliverToThread ? { deliverToThread: true } : {}),
     };
     const body = JSON.stringify(payload);
     const signature = signWebhookPayload(body, signingSecret);

--- a/apps/backend/src/automations/steps/run-agent.step.ts
+++ b/apps/backend/src/automations/steps/run-agent.step.ts
@@ -35,6 +35,12 @@ const RunAgentConfigSchema = z.object({
     .max(10)
     .optional()
     .describe('How many times to retry the agent if its response fails schema validation. Default 3.'),
+  outputMode: z
+    .enum(['capture', 'thread'])
+    .default('capture')
+    .describe(
+      "How the agent's result is delivered. 'capture' (default) parses the response into { result } JSON that downstream steps can read. 'thread' posts the agent's final answer back into the conversation that triggered the automation and skips output-schema validation; it requires a trigger that carries a conversation (message/ticket), and downstream steps cannot read a result from a thread-mode node.",
+    ),
 });
 
 export type RunAgentConfig = z.infer<typeof RunAgentConfigSchema>;
@@ -75,6 +81,12 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
     const runUserId = await resolveRunUserId(spacesAppId, context.automation.createdById);
     const identityContext = await resolveHeadlessIdentityContext(runUserId, context.automation.workspaceId);
     const visibleContext = resolveVisibleConversationContext(context);
+    const deliverToThread = cfg.outputMode === 'thread';
+    if (deliverToThread && !visibleContext) {
+      throw new Error(
+        "[RUN_AGENT] outputMode 'thread' requires a trigger that carries a conversation (channelId + conversationId); this automation has none. Use outputMode 'capture', or trigger the automation from a message/ticket.",
+      );
+    }
 
     logger.info(
       `[RUN_AGENT] firing — executionId=${store.runId} stepIndex=${currentIndex} agentSlug=${agentSlug} sessionId=${sessionId} userId=${runUserId}`,
@@ -90,6 +102,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
         ...identityContext,
         callbackUrl,
         ...(visibleContext ? visibleContext : {}),
+        ...(deliverToThread ? { deliverToThread: true } : {}),
       });
     } catch (err) {
       logger.error(
@@ -116,6 +129,21 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
       const envErr =
         (agentRawResult as { error?: unknown }).error ?? `agent run ${String(envelopeStatus)}`;
       throw new Error(`[RUN_AGENT] claw run status=${String(envelopeStatus)}: ${String(envErr)}`);
+    }
+
+    // Thread-output mode: the agent's answer was posted into the trigger
+    // conversation by claw-auth. There is no { result } JSON to validate or hand
+    // to downstream steps — just record that delivery happened and advance.
+    if (cfg.outputMode === 'thread') {
+      const threadAttachments = parseAgentAttachments(
+        (agentRawResult as { attachments?: unknown }).attachments,
+      );
+      logger.info(
+        `[RUN_AGENT] thread delivery — result posted to the trigger conversation; skipping output-schema capture (attachments=${threadAttachments.length})`,
+      );
+      return (threadAttachments.length
+        ? { delivered: true, attachments: threadAttachments }
+        : { delivered: true }) as RunAgentOutput;
     }
 
     const declaredSchema = (cfg.outputSchema ?? {}) as Record<string, unknown>;

--- a/apps/xyne-claw-auth/backend/src/lib/session-context.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/session-context.ts
@@ -126,6 +126,15 @@ export interface SessionContext {
    */
   resolveMentions?: boolean;
   /**
+   * True when a Spaces automation "agent node" runs in thread-output mode.
+   * /webhook/result then ALSO posts the agent's final answer into the bound
+   * conversation (channelId + conversationId) before forwarding the completion
+   * to the automation callback, so the workflow step still resumes. Only set by
+   * handleAutomationWebhook when the trigger carries a conversation. Fail-open:
+   * a failed thread post never blocks the step from advancing.
+   */
+  deliverResultToThread?: boolean;
+  /**
    * True when this session was dispatched by the Spaces automation webhook
    * (app-user run, no human in the thread). This is the EXPLICIT gate the
    * MCP layer uses to serve Spaces tools in app mode (routes/mcp.ts injects

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -3948,6 +3948,7 @@ export async function handleAutomationWebhook(
     channelId?: string | null;
     channelName?: string | null;
     workspaceId?: string | null;
+    deliverToThread?: boolean;
     allowWriteInReadOnlyJob?: boolean;
     executionProfile?: "sdlc";
     sdlcOperation?: "baseline" | "work" | "wiki";
@@ -4186,6 +4187,13 @@ export async function handleAutomationWebhook(
       // MCP swap on this (not on the resolveMentions proxy).
       isAutomation: true,
       triggerSource: "automation",
+      // Thread-output agent node: in addition to forwarding the completion (so
+      // the workflow step resumes), post the agent's final answer into the
+      // conversation that triggered the automation. Requires a bound
+      // conversation; otherwise falls back to capture-only behavior.
+      ...(payload.deliverToThread && payload.conversationId && payload.channelId
+        ? { deliverResultToThread: true }
+        : {}),
       // Forward the resolved result to the automation's original callback (so
       // step-1.output.result carries clickable mentions) instead of posting a
       // bot message, and turn on mention resolution for that forward.
@@ -5665,6 +5673,32 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     // self-heals instead of its caller receiving a blank and nobody retrying.
     if (payload.emptyReason === "provider_capacity" && !forwardText.trim()) {
       await scheduleCapacityRetryIfNeeded(ctx, payload, false).catch(() => false);
+    }
+    // Thread-output automation node: post the agent's final answer into the
+    // conversation that triggered the automation, in addition to forwarding the
+    // completion below so the workflow step still resumes. Guarded on
+    // deliverResultToThread + a bound conversation; fail-open so a post failure
+    // never blocks the step from advancing.
+    if (
+      ctx.deliverResultToThread &&
+      ctx.conversationId &&
+      ctx.channelId &&
+      ctx.appToken &&
+      forwardText.trim()
+    ) {
+      await spacesAppFetch(
+        "/chat/postMessage",
+        {
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          markdownText: forwardText,
+          userId: ctx.spacesAppUserId,
+          metadata: { contentFormat: "markdown" },
+        },
+        ctx.appToken,
+      ).catch((err) =>
+        log.warn(`[webhook/result] thread-output post failed sessionId=${sessionId}: ${errMsg(err)}`),
+      );
     }
     await forwardResult(ctx.resultForwardUrl, payload, forwardText);
     return;


### PR DESCRIPTION
## Summary

The automation **agent node** (`RUN_AGENT` step) previously forced every agent run into **capture mode**: the agent's response was parsed into a fixed `{ result }` JSON envelope for downstream steps, and nothing was posted back to the conversation that triggered the automation. Teams that just want the agent's answer delivered into the originating thread had to add a separate `REPLY_ON_MESSAGE` step wired to `step.output.result`.

This PR adds an **`outputMode`** toggle on the node:

- **`capture`** (default, unchanged) — parse the response into `{ result }` JSON, validate against `outputSchema`, retry on mismatch. Existing behavior, byte-for-byte.
- **`thread`** — claw-auth *also* posts the agent's final answer into the bound conversation (`channelId` + `conversationId`), then still forwards the completion so the workflow step resumes. Output-schema validation and the empty-result retry are skipped; the node returns `{ delivered: true }` (plus any attachments), and downstream steps cannot read a result from it.

## How it works

| Layer | Change |
|---|---|
| `apps/backend/src/automations/steps/run-agent.step.ts` | New `outputMode` config field. `execute()` requires a conversation-bearing trigger in thread mode and passes `deliverToThread` to claw. `onResume()` short-circuits before schema capture in thread mode and returns `{ delivered: true }`. |
| `apps/backend/src/automations/services/claw-client.ts` | Threads `deliverToThread` through `RunAgentRequest` into the signed `/app/:spacesAppId` payload. |
| `apps/xyne-claw-auth/backend/src/lib/session-context.ts` | New optional `SessionContext.deliverResultToThread`. |
| `apps/xyne-claw-auth/backend/src/routes/webhook.ts` | `handleAutomationWebhook` sets `deliverResultToThread` only when a conversation is bound. The existing `/webhook/result` result-forward branch posts the resolved final answer (mentions already expanded) into the thread as the agent bot — fail-open — before forwarding the completion callback. |

`resultForwardUrl` is intentionally **kept set** in thread mode so the step still resumes reliably; this also avoids the `EXTERNAL_WAIT` hang a forward-less conversation run would cause. The thread post reuses the exact `spacesAppFetch("/chat/postMessage", ...)` shape already used elsewhere in the same handler.

## Blast radius

Additive and guarded. `outputMode` defaults to `capture`, so **existing automations are completely unaffected**. The only new behavior fires when a node is explicitly set to `thread` **and** the trigger carries a conversation.

## Testing needed (please run in CI / a real env)

- The **backend** package typechecks clean locally (`tsc --noEmit`, exit 0).
- **claw-auth** full `tsc` could not complete in the dev sandbox because `prisma generate` needs network access to fetch engine binaries (offline sandbox), which produces the pre-existing `@prisma/client has no exported member 'Prisma'` cascade unrelated to this diff. My changed lines produce **zero** type errors. Please confirm `apps/xyne-claw-auth/backend` typecheck is green in CI.
- **End-to-end not verified in-sandbox** — needs a live run: build an automation whose agent node is set to `outputMode: thread`, trigger it from a message/ticket, and confirm (a) the agent's final answer is posted into the trigger thread as the agent bot with resolved mentions, and (b) the workflow step resumes (does not hang in `EXTERNAL_WAIT`). Also verify the guard error fires when `thread` mode is used on a trigger with no conversation.

## Explicitly out of scope (follow-up)

Live token-by-token streaming into the thread and interactive mid-run question cards are **not** included — automation runs are headless (no SSE), so those need separate runtime work. This PR delivers the agent's **final** answer to the thread.