### PR TITLE
fix: XYNE-61571 open the discussion with a newly created artifact

### DIFF
--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -1222,10 +1222,11 @@ export default function SdlcScreen(): ReactElement {
     resetArtifactDialog();
     const newCanvasId = response.data.artifact.canvasId;
     setRelatedSourceId(null);
-    navigateWithinSdlc(
-      `/sdlc/${channelId}/artifacts`,
-      `?type=${encodeURIComponent(folder.id)}&canvas=${encodeURIComponent(newCanvasId)}`,
-    );
+    // Same search as opening an artifact from the list, so a new artifact lands
+    // with its discussion open rather than only doing so once reopened.
+    const search = canvasSearch(newCanvasId, true);
+    search.set('type', folder.id);
+    navigateWithinSdlc(`/sdlc/${channelId}/artifacts`, `?${search.toString()}`);
   };
 
   const createArtifactType = async (): Promise<void> => {


### PR DESCRIPTION
Port of #1484 to `release-20260904`.

Cherry-picked from its merge commit on `main` (`05d09b1d9`), applied with no conflicts — one file, +5/-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zcCxPptiyCEbXXyZKRNCG
