### PR TITLE
feat: XYNE-61559 one canvas upload item instead of four

### DIFF
--- a/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
@@ -37,7 +37,7 @@ import { getMentionSuggestionMenuItems, insertGroupMention } from 'blocknote-lay
 import { asBlockNoteEditorForView } from 'blocknote-layout-extensions';
 import { buildMentionProps, CanvasMentionContext } from '../CanvasMentionSpec';
 import { useCanvasBlockShortcuts, withBlockShortcutBadges } from '../canvasBlockShortcuts';
-import { withHeadingsTogether } from '../canvasSlashMenu';
+import { withHeadingsTogether, withUnifiedUpload } from '../canvasSlashMenu';
 import { CanvasLinkToolbar, CanvasPastedLinkToolbar } from '../CanvasLinkToolbar';
 import { CanvasFilePanel } from '../CanvasFilePanel/CanvasFilePanel';
 import {
@@ -234,7 +234,9 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
     const allSlashItems = useMemo(() => {
       if (!editor) return [];
       const defaultItems = getDefaultReactSlashMenuItems(asBlockNoteEditorForView(editor));
-      return withBlockShortcutBadges(withHeadingsTogether([...defaultItems, ...customSlashItems]));
+      return withBlockShortcutBadges(
+        withHeadingsTogether([...withUnifiedUpload(defaultItems), ...customSlashItems]),
+      );
     }, [editor, customSlashItems]);
 
     const getSlashMenuItems = useCallback(

--- a/apps/dashboard/src/components/Canvas/CanvasFileBlockSpec.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasFileBlockSpec.tsx
@@ -1,8 +1,17 @@
 import { defaultBlockSpecs } from '@blocknote/core';
-import { AddFileButton, createReactBlockSpec, FileBlockWrapper } from '@blocknote/react';
+import {
+  AddFileButton,
+  AudioBlock,
+  createReactBlockSpec,
+  FileBlockWrapper,
+  ImageBlock,
+  useResolveUrl,
+  useUploadLoading,
+  VideoBlock,
+} from '@blocknote/react';
 import axios from 'axios';
-import { Download, FileText } from 'lucide-react';
-import type { ReactElement } from 'react';
+import { Download, FileText, Loader2 } from 'lucide-react';
+import type { ComponentProps, ReactElement } from 'react';
 import { toast } from 'sonner';
 
 const fileConfig = defaultBlockSpecs.file.config;
@@ -37,6 +46,12 @@ async function downloadFile(url: string, name: string): Promise<void> {
 }
 
 function FileCard({ url, name }: { url: string; name: string }): ReactElement {
+  // props.url holds an attachment id, not a url. The image, video and audio blocks
+  // resolve it through the editor; without doing the same the download fetches a
+  // relative path and hands back the app's own HTML. Resolved here rather than in
+  // the caller so it never runs for a block that has nothing to resolve yet.
+  const resolved = useResolveUrl(url);
+  const downloadUrl = (resolved.loadingState === 'loading' ? url : resolved.downloadUrl) || url;
   const label = name || url;
 
   return (
@@ -62,11 +77,32 @@ function FileCard({ url, name }: { url: string; name: string }): ReactElement {
           // The editor reclaims the selection on mouseup, so a click never lands.
           event.preventDefault();
           event.stopPropagation();
-          void downloadFile(url, label);
+          void downloadFile(downloadUrl, label);
         }}
       >
         <Download size={16} />
       </button>
+    </div>
+  );
+}
+
+function UploadingCard({ name }: { name: string }): ReactElement {
+  return (
+    <div
+      contentEditable={false}
+      className='canvas-file-card my-1 flex w-full items-center gap-3 rounded-lg border border-dashed border-border bg-muted/20 p-3'
+      role='status'
+      aria-live='polite'
+    >
+      <span className='grid size-10 shrink-0 place-items-center rounded-md bg-background text-muted-foreground'>
+        <Loader2 size={18} className='animate-spin' />
+      </span>
+      <span className='min-w-0 flex-1'>
+        <span className='block truncate text-sm font-medium text-foreground' title={name}>
+          {name}
+        </span>
+        <span className='block text-xs text-muted-foreground'>Uploading…</span>
+      </span>
     </div>
   );
 }
@@ -77,24 +113,76 @@ function FileCard({ url, name }: { url: string; name: string }): ReactElement {
  * BlockNote renders an uploaded file as an icon and its name and nothing else,
  * with no way to get the file back out. Before anything is uploaded this defers
  * to BlockNote's own add-file button, so the upload flow is untouched.
+ *
+ * While an upload is running the card is rendered without FileBlockWrapper, which
+ * would otherwise show its own bare "Loading..." for any block with no url yet.
  */
+type FileBlockViewProps = Pick<ComponentProps<typeof FileBlockWrapper>, 'block' | 'editor'>;
+
+function FileBlockView({ block, editor }: FileBlockViewProps): ReactElement {
+  const url = String(block.props.url ?? '');
+  const name = String(block.props.name ?? '');
+  const isUploading = useUploadLoading(block.id);
+
+  if (isUploading) {
+    return (
+      <div className='bn-file-block-content-wrapper w-full'>
+        <UploadingCard name={name} />
+      </div>
+    );
+  }
+
+  return (
+    <FileBlockWrapper block={block} editor={editor}>
+      {url ? <FileCard url={url} name={name} /> : <AddFileButton block={block} editor={editor} />}
+    </FileBlockWrapper>
+  );
+}
+
 export const canvasFileBlockSpec = createReactBlockSpec(
   fileConfig,
   {
-    render: ({ block, editor }) => {
-      const url = String(block.props.url ?? '');
-      const name = String(block.props.name ?? '');
-
-      return (
-        <FileBlockWrapper block={block} editor={editor}>
-          {url ? (
-            <FileCard url={url} name={name} />
-          ) : (
-            <AddFileButton block={block} editor={editor} />
-          )}
-        </FileBlockWrapper>
-      );
-    },
+    render: ({ block, editor }) => <FileBlockView block={block} editor={editor} />,
   },
   defaultBlockSpecs.file.extensions,
+)();
+
+/**
+ * The same uploading card for BlockNote's own image, video and audio blocks.
+ *
+ * Dragging or pasting a file creates one of those directly rather than a file
+ * block, so without this those routes still show the bare "Loading..." that the
+ * file block no longer does.
+ */
+function withUploadingCard<P extends { block: { id: string; props: { name: string } } }>(
+  Block: (props: P) => ReactElement,
+): (props: P) => ReactElement {
+  return function MediaBlock(props: P): ReactElement {
+    const isUploading = useUploadLoading(props.block.id);
+    if (!isUploading) return <Block {...props} />;
+
+    return (
+      <div className='bn-file-block-content-wrapper w-full'>
+        <UploadingCard name={props.block.props.name} />
+      </div>
+    );
+  };
+}
+
+export const canvasImageBlockSpec = createReactBlockSpec(
+  defaultBlockSpecs.image.config,
+  { render: withUploadingCard(ImageBlock) },
+  defaultBlockSpecs.image.extensions,
+)();
+
+export const canvasVideoBlockSpec = createReactBlockSpec(
+  defaultBlockSpecs.video.config,
+  { render: withUploadingCard(VideoBlock) },
+  defaultBlockSpecs.video.extensions,
+)();
+
+export const canvasAudioBlockSpec = createReactBlockSpec(
+  defaultBlockSpecs.audio.config,
+  { render: withUploadingCard(AudioBlock) },
+  defaultBlockSpecs.audio.extensions,
 )();

--- a/apps/dashboard/src/components/Canvas/CanvasFilePanel/CanvasFilePanel.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasFilePanel/CanvasFilePanel.tsx
@@ -1,6 +1,9 @@
 import { type FilePanelProps, useBlockNoteEditor } from '@blocknote/react';
+import { NodeSelection, Selection } from '@tiptap/pm/state';
+import { classifyMediaKind } from '@xyne/shared';
 import { type FC, useEffect, useRef } from 'react';
 import { toast } from 'sonner';
+import { editorView } from '../canvasEditorView';
 
 const ACCEPT_BY_BLOCK: Readonly<Record<string, string>> = {
   file: '*/*',
@@ -41,9 +44,25 @@ interface CanvasBlock {
 interface UploadingEditor {
   uploadFile?: (file: File, blockId?: string) => Promise<string | Record<string, unknown>>;
   getBlock: (blockId: string) => CanvasBlock | undefined;
-  updateBlock: (blockId: string, update: { props: Record<string, unknown> }) => void;
+  updateBlock: (blockId: string, update: { type?: string; props: Record<string, unknown> }) => void;
   removeBlocks: (blockIds: string[]) => void;
 }
+
+/**
+ * Moves the cursor off the block the panel selected.
+ *
+ * The panel leaves a node selection on the block; replacing the node under it
+ * makes Yjs throw when it later tries to restore that selection.
+ */
+const releaseNodeSelection = (editor: unknown, blockId: string): void => {
+  const view = editorView(editor);
+  if (!view) return;
+  const { selection } = view.state;
+  // Only this block's own selection: by now the upload may have taken long enough
+  // for the reader to have selected something else, which is not ours to move.
+  if (!(selection instanceof NodeSelection) || selection.node.attrs['id'] !== blockId) return;
+  view.dispatch(view.state.tr.setSelection(Selection.near(selection.$to, 1)));
+};
 
 /** An empty file block is only ever a placeholder for the picker, so drop it. */
 const discardIfEmpty = (api: UploadingEditor, blockId: string): void => {
@@ -62,6 +81,9 @@ const discardIfEmpty = (api: UploadingEditor, blockId: string): void => {
  * block, so with embed gone the dialog was a panel whose only content was a button
  * that opened the picker. Being the panel rather than a separate watcher covers
  * every way BlockNote asks for a file: inserting the block, and its add-file button.
+ *
+ * With one Upload item rather than four, the block becomes whatever the chosen
+ * file turns out to be; a block that already knows its type keeps it.
  */
 export const CanvasFilePanel: FC<FilePanelProps> = ({ blockId }): null => {
   const editor = useBlockNoteEditor();
@@ -79,11 +101,28 @@ export const CanvasFilePanel: FC<FilePanelProps> = ({ blockId }): null => {
         discardIfEmpty(api, blockId);
         return;
       }
+
       try {
+        // Named before the upload starts so the uploading card can show which file.
+        api.updateBlock(blockId, { props: { name: file.name } });
+
         const uploaded = await upload(file, blockId);
         const url = typeof uploaded === 'string' ? uploaded : uploaded['url'];
         if (typeof url !== 'string' || !url) throw new Error('upload returned no url');
-        api.updateBlock(blockId, { props: { url, name: file.name } });
+
+        // Read again rather than reusing the type from before the picker: an upload
+        // is long enough for a collaborator to have changed the block underneath.
+        const blockType = api.getBlock(blockId)?.type ?? '';
+        // Only the generic block is undecided.
+        const kind = blockType === 'file' ? classifyMediaKind(file.type, file.name) : blockType;
+        const converts = kind !== blockType;
+
+        if (converts) releaseNodeSelection(editor, blockId);
+
+        api.updateBlock(blockId, {
+          ...(converts ? { type: kind } : {}),
+          props: { url, name: file.name },
+        });
       } catch {
         toast.error('Upload failed', { description: file.name });
         discardIfEmpty(api, blockId);

--- a/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
@@ -63,7 +63,7 @@ import { getWhiteboardSlashMenuItems } from 'blocknote-layout-extensions';
 import { insertGroupMention } from 'blocknote-layout-extensions';
 import { buildMentionProps, CanvasMentionContext } from '../CanvasMentionSpec';
 import { useCanvasBlockShortcuts, withBlockShortcutBadges } from '../canvasBlockShortcuts';
-import { withHeadingsTogether } from '../canvasSlashMenu';
+import { withHeadingsTogether, withUnifiedUpload } from '../canvasSlashMenu';
 import { canvasSchema, canvasTableOptions, canvasTiptapOptions } from '../canvasSchema';
 import { createElement } from 'react';
 import { RiGroupLine } from 'react-icons/ri';
@@ -342,7 +342,9 @@ export const CollaborativeCanvasEditor = forwardRef<
       const defaultItems = getDefaultReactSlashMenuItems(
         editor as unknown as BlockNoteEditor<BlockSchema, InlineContentSchema, StyleSchema>,
       );
-      return withBlockShortcutBadges(withHeadingsTogether([...defaultItems, ...customSlashItems]));
+      return withBlockShortcutBadges(
+        withHeadingsTogether([...withUnifiedUpload(defaultItems), ...customSlashItems]),
+      );
     }, [editor, customSlashItems]);
 
     const getSlashMenuItems = useCallback(

--- a/apps/dashboard/src/components/Canvas/canvasBlockShortcuts.ts
+++ b/apps/dashboard/src/components/Canvas/canvasBlockShortcuts.ts
@@ -11,7 +11,7 @@ import { editorView } from './canvasEditorView';
  *
  *   Mod-Alt-Shift-N  inserted blocks, numbered down the menu. 1 to 3 are the
  *                    toggle headings, mirroring Mod-Alt-1 to 3 for the headings
- *                    themselves; 4 to 7 are the Media group in its own order.
+ *                    themselves; 4 is Upload, what the Media group became.
  *   Mod-Shift-N      joins the list blocks, which hold 6 to 9, at the free end.
  *   Mod-Alt-<letter> joins Mod-Alt-C for code and Mod-Alt-Q for quote: a block
  *                    with a name rather than a place in a series.
@@ -37,10 +37,9 @@ export const BLOCK_SHORTCUTS: Readonly<Record<string, string>> = {
   'Toggle Heading 2': 'Mod-Alt-Shift-2',
   'Toggle Heading 3': 'Mod-Alt-Shift-3',
 
-  Image: 'Mod-Alt-Shift-4',
-  Video: 'Mod-Alt-Shift-5',
-  Audio: 'Mod-Alt-Shift-6',
-  File: 'Mod-Alt-Shift-7',
+  // Keeps 4 so the old image key still works; 5 to 7 left free rather than
+  // renumbering Diagram and Whiteboard.
+  Upload: 'Mod-Alt-Shift-4',
 
   Diagram: 'Mod-Alt-Shift-8',
   Whiteboard: 'Mod-Alt-Shift-9',
@@ -108,7 +107,15 @@ export function useCanvasBlockShortcuts(
 
       event.preventDefault();
       event.stopPropagation();
-      item.onItemClick?.();
+      try {
+        item.onItemClick?.();
+      } catch (error) {
+        // A block that holds no text, an image say, has nothing to insert into, so
+        // the key does nothing. Any other failure is real and still surfaces.
+        if (!(error instanceof Error) || !error.message.includes("doesn't contain content")) {
+          throw error;
+        }
+      }
     };
 
     dom.addEventListener('keydown', onKeyDown, true);

--- a/apps/dashboard/src/components/Canvas/canvasSchema.ts
+++ b/apps/dashboard/src/components/Canvas/canvasSchema.ts
@@ -13,7 +13,12 @@ import { knownBlockTypesOf } from '../../utils/canvasUtils';
 import { canvasCommentThreadStyleSpec } from './CanvasCommentStyleSpec/CanvasCommentStyleSpec';
 import { canvasCodeBlockSpec } from './CanvasCodeBlockSpec';
 import { CANVAS_EMBED_TYPE, canvasEmbedSpec } from './CanvasEmbedSpec';
-import { canvasFileBlockSpec } from './CanvasFileBlockSpec';
+import {
+  canvasAudioBlockSpec,
+  canvasFileBlockSpec,
+  canvasImageBlockSpec,
+  canvasVideoBlockSpec,
+} from './CanvasFileBlockSpec';
 import { canvasLinkShortcutsExtension } from './canvasLinkShortcuts';
 import { canvasPastedLinkExtension } from './canvasPastedLink';
 import { canvasTableShortcutsExtension } from './canvasTableShortcuts';
@@ -31,6 +36,9 @@ function createCanvasSchema() {
       codeBlock: canvasCodeBlockSpec,
       [CANVAS_EMBED_TYPE]: canvasEmbedSpec,
       file: canvasFileBlockSpec,
+      image: canvasImageBlockSpec,
+      video: canvasVideoBlockSpec,
+      audio: canvasAudioBlockSpec,
     }),
   } as Parameters<typeof BlockNoteSchema.create>[0]).extend({
     inlineContentSpecs: {

--- a/apps/dashboard/src/components/Canvas/canvasSlashMenu.ts
+++ b/apps/dashboard/src/components/Canvas/canvasSlashMenu.ts
@@ -1,6 +1,47 @@
+import { en } from '@blocknote/core/locales';
 import type { DefaultReactSuggestionItem } from '@blocknote/react';
 
 const HEADING_TITLE = /^Heading (\d)$/;
+
+/**
+ * One Upload item in place of Image, Video, Audio and File: the file item is
+ * relabelled and the other three dropped. CanvasFilePanel picks the real type.
+ */
+export function withUnifiedUpload(
+  items: DefaultReactSuggestionItem[],
+): DefaultReactSuggestionItem[] {
+  const droppedTitles = new Set(
+    [en.slash_menu.image, en.slash_menu.video, en.slash_menu.audio].map(entry => entry.title),
+  );
+
+  return items.flatMap(item => {
+    if (droppedTitles.has(item.title)) return [];
+    if (item.title !== en.slash_menu.file.title) return [item];
+
+    return [
+      {
+        ...item,
+        title: 'Upload',
+        subtext: 'Image, video, audio or any other file',
+        // Replacing rather than extending the defaults: those still carry 'embed'
+        // and 'url' from the embed-by-url flow, which this item cannot do.
+        aliases: [
+          'upload',
+          'file',
+          'attachment',
+          'image',
+          'img',
+          'photo',
+          'picture',
+          'video',
+          'audio',
+          'sound',
+          'media',
+        ],
+      },
+    ];
+  });
+}
 
 const headingLevel = (item: DefaultReactSuggestionItem): number =>
   Number(HEADING_TITLE.exec(item.title)?.[1] ?? 0);

--- a/packages/shared/src/utils/fileTypes.ts
+++ b/packages/shared/src/utils/fileTypes.ts
@@ -23,3 +23,50 @@ export const DANGEROUS_EXTENSIONS = [
   '.asp',
   '.jsp',
 ] as const;
+
+/** How a file should be presented. Names match the canvas block types. */
+export type MediaKind = 'image' | 'video' | 'audio' | 'file';
+
+// Only what a browser will actually render. A format it cannot decode has to stay
+// a plain file: image, video and audio blocks have no download button, so promoting
+// one would leave a broken element and no way to get the file back out.
+const EXTENSIONS_BY_KIND: Readonly<Record<Exclude<MediaKind, 'file'>, readonly string[]>> = {
+  image: ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.bmp', '.ico', '.avif'],
+  video: ['.mp4', '.webm', '.ogv', '.mov', '.m4v'],
+  audio: ['.mp3', '.wav', '.ogg', '.oga', '.m4a', '.aac', '.flac', '.opus'],
+};
+
+// These carry a media mimetype but no browser renders them, so the prefix match
+// below would otherwise promote them past the extension list.
+const UNRENDERABLE_MIMETYPES: ReadonlySet<string> = new Set([
+  'image/heic',
+  'image/heif',
+  'video/x-matroska',
+  'video/x-msvideo',
+  'video/avi',
+  'video/x-ms-wmv',
+  'video/mpeg',
+  'audio/x-ms-wma',
+]);
+
+/** Classifies by mimetype, falling back to the extension when it says nothing. */
+export function classifyMediaKind(mimeType?: string | null, fileName?: string | null): MediaKind {
+  const mime = (mimeType ?? '').toLowerCase();
+
+  if (!UNRENDERABLE_MIMETYPES.has(mime)) {
+    if (mime.startsWith('image/')) return 'image';
+    if (mime.startsWith('video/')) return 'video';
+    if (mime.startsWith('audio/')) return 'audio';
+  }
+
+  const name = (fileName ?? '').toLowerCase();
+  const dot = name.lastIndexOf('.');
+  const extension = dot < 0 ? '' : name.slice(dot);
+  if (extension) {
+    for (const [kind, extensions] of Object.entries(EXTENSIONS_BY_KIND)) {
+      if (extensions.includes(extension)) return kind as Exclude<MediaKind, 'file'>;
+    }
+  }
+
+  return 'file';
+}


### PR DESCRIPTION
Port of #1482 to `release-20260904`.

Cherry-picked from its merge commit on `main` (`db7383df2`), applied with no conflicts — 8 files, +265/-31.

## Known issue carried with it

The commit *"show the uploading card for dragged and pasted files"* rebuilds the image, video and audio block specs as `createReactBlockSpec(config, { render }, extensions)`. BlockNote decides what a pasted or dropped file becomes by scanning every spec's `implementation.meta.fileBlockAccept`, so passing only a `render` drops `["image/*"]`, `["video/*"]` and `["audio/*"]`. Nothing then matches and its loop falls back to its default, which is literally `"file"` — so a pasted image arrives as a file block.

Carrying `meta: defaultBlockSpecs.image.implementation.meta` (and the video/audio/file equivalents) alongside the `render` fixes it. Not done here so this stays a faithful port; worth its own ticket. The same specs also lose `parse` and `toExternalHTML`, which affects HTML paste and export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zcCxPptiyCEbXXyZKRNCG
