### PR TITLE
fix: XYNE-61503 canvas blocks behave as objects, and reach Ask AI and comments

### DIFF
--- a/apps/backend/src/controllers/canvasController.ts
+++ b/apps/backend/src/controllers/canvasController.ts
@@ -14,8 +14,13 @@ import { getGroupMembersForNotification } from '../utils/mentionUtils.js';
 import { getSlackRecipientEmails } from '../utils/notificationHelper.js';
 import { cleanupProxiedFile } from '../utils/attachmentUtils';
 import { v4 as uuidv4 } from 'uuid';
-import {initializeYSweetDoc, syncToYSweet} from '../utils/ysweetUtils.js';
-import { convertMarkdownToBlockNote, convertBlockNoteToMarkdown, getCanvasUrl, getCanvasById } from '../services/canvasService.js';
+import { initializeYSweetDoc, readFromYSweetStrict, syncToYSweet } from '../utils/ysweetUtils.js';
+import {
+  convertMarkdownToBlockNote,
+  convertBlockNoteToMarkdown,
+  getCanvasUrl,
+  getCanvasById,
+} from '../services/canvasService.js';
 
 export class CanvasController {
   private messageAttachmentRepository: MessageAttachmentRepository;
@@ -489,7 +494,22 @@ export class CanvasController {
         return;
       }
 
-      const blocks = await convertMarkdownToBlockNote(markdown);
+      // The markdown cannot carry a whiteboard's drawing, only its id, so the
+      // current document is what the write restores it from. A read that fails
+      // must stop the write: taken as an empty canvas it would restore nothing,
+      // and the drawing would be gone for good behind a warning in a log.
+      let existingBlocks;
+      try {
+        existingBlocks = await readFromYSweetStrict(canvas.id, userId);
+      } catch (error) {
+        logger.error(
+          `[CANVAS-UPDATE] Could not read canvas ${canvas.id} before writing to it`,
+          error
+        );
+        res.status(503).json({ error: 'Could not read the canvas to update it. Please try again.' });
+        return;
+      }
+      const blocks = await convertMarkdownToBlockNote(markdown, existingBlocks);
 
       // Sync content to Y-Sweet for collaborative editing
       const ysweetSynced = await syncToYSweet(canvas.id, blocks, userId);

--- a/apps/backend/src/services/canvasService.ts
+++ b/apps/backend/src/services/canvasService.ts
@@ -2,6 +2,7 @@
  * Canvas Service - Creates canvases for knowledge learnings and other purposes
  */
 
+import { defaultBlockSpecs, defaultStyleSpecs } from '@blocknote/core';
 import { v4 as uuidv4 } from 'uuid';
 import { DatabaseClient } from '@/database/client';
 import type { KnowledgeLearning } from '@/workflows/utils/knowledge-generator';
@@ -15,14 +16,17 @@ import { toJsonSafeValue } from './jsonSafe';
 // Y-Sweet XML fragment name used by the frontend collaborative editor
 export const YSWEET_XML_FRAGMENT = 'document-store';
 
-
 /**
  * Convert markdown to BlockNote JSON format
  */
-export async function convertMarkdownToBlockNote(markdown: string): Promise<BlockNoteBlock[]> {
+export async function convertMarkdownToBlockNote(
+  markdown: string,
+  existingBlocks: unknown[] = [],
+): Promise<BlockNoteBlock[]> {
   try {
-    const parsed = await withServerEditor((editor) => editor.tryParseMarkdownToBlocks(markdown));
-    return toJsonSafeValue(parsed) as BlockNoteBlock[];
+    const parsed = await withServerEditor(editor => editor.tryParseMarkdownToBlocks(markdown));
+    const restored = restoreCustomBlocks(parsed as LooseBlock[], existingBlocks as LooseBlock[]);
+    return toJsonSafeValue(restored) as BlockNoteBlock[];
   } catch (error) {
     logger.error('[CanvasService] Error converting markdown to BlockNote:', error);
     return [];
@@ -303,37 +307,75 @@ export async function createKnowledgeCanvas(
  */
 export function getCanvasUrl(canvasId: string, workspaceId?: string): string {
   const frontendUrl = process.env.FRONTEND_URL || 'https://spaces.xyne.juspay.net';
-  const path = workspaceId
-    ? `/${workspaceId}/chat/canvas/${canvasId}`
-    : `/chat/canvas/${canvasId}`;
+  const path = workspaceId ? `/${workspaceId}/chat/canvas/${canvasId}` : `/chat/canvas/${canvasId}`;
   return `${frontendUrl}${path}`;
 }
 
-type LooseInline = { type?: string; text?: string; props?: Record<string, unknown>; styles?: unknown };
-type LooseBlock = {
+type LooseInline = {
   type?: string;
+  text?: string;
+  content?: unknown;
+  props?: Record<string, unknown>;
+  styles?: unknown;
+};
+type LooseBlock = {
+  id?: string;
+  type?: string;
+  props?: Record<string, unknown>;
   content?: unknown;
   children?: LooseBlock[];
 };
 
 // ServerBlockNoteEditor.create() only knows the default schema, so custom inline
 // nodes must be rewritten before Markdown export.
-const CUSTOM_INLINE_TYPES = new Set(['mention', 'citation']);
+const CUSTOM_INLINE_TYPES = new Set(['mention', 'citation', 'math']);
 
 // Render a custom inline node as plain text, mirroring the frontend display
 // logic (CanvasMentionSpec: prefer the group name for group mentions, otherwise
 // the username).
+/** Plain inline content is either the string itself or text nodes holding it. */
+function plainInlineToString(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map(part =>
+      part && typeof part === 'object' && typeof (part as LooseInline).text === 'string'
+        ? (part as LooseInline).text
+        : '',
+    )
+    .join('');
+}
+
 function customInlineToText(inline: LooseInline): string {
   // Citation chips are annotations that point at a transcript segment; in a
   // plain-text/markdown export (or Vespa index text) they carry no useful prose
   // — the cited words already live in the transcript — so drop them to empty.
   if (inline.type === 'citation') return '';
+  // Inline math keeps its LaTeX as plain content, so $…$ is the same formula.
+  if (inline.type === 'math') return `$${plainInlineToString(inline.content)}$`;
   const props = inline.props || {};
   const groupId = props['groupId'] as string | undefined;
   const groupName = props['groupName'] as string | undefined;
   const username = props['username'] as string | undefined;
   const name = groupId && groupName ? groupName : username || 'mention';
   return `@${name}`;
+}
+
+const DEFAULT_STYLE_NAMES: ReadonlySet<string> = new Set(Object.keys(defaultStyleSpecs));
+
+/**
+ * Drop styles the markdown editor has no spec for.
+ *
+ * Commenting on canvas text applies a `canvasCommentThread` style. The Yjs
+ * schema knows it, but the editor that writes markdown is built from the
+ * defaults alone, so leaving it on a text node throws and the whole canvas
+ * fails to read. Markdown could not carry the annotation anyway.
+ */
+function knownStylesOnly(styles: unknown): unknown {
+  if (!styles || typeof styles !== 'object') return styles;
+  return Object.fromEntries(
+    Object.entries(styles).filter(([name]) => DEFAULT_STYLE_NAMES.has(name)),
+  );
 }
 
 function normalizeInlineContent(content: unknown): unknown {
@@ -351,8 +393,276 @@ function normalizeInlineContent(content: unknown): unknown {
   }
 
   return Object.fromEntries(
-    Object.entries(content).map(([key, value]) => [key, normalizeInlineContent(value)]),
+    Object.entries(content).map(([key, value]) =>
+      key === 'styles' ? [key, knownStylesOnly(value)] : [key, normalizeInlineContent(value)],
+    ),
   );
+}
+
+const DEFAULT_BLOCK_TYPES: ReadonlySet<string> = new Set(Object.keys(defaultBlockSpecs));
+
+// Default types that still need rewriting: BlockNote serialises a video with
+// image syntax and audio as raw HTML, so both are rewritten despite being known.
+const REWRITTEN_DEFAULT_TYPES: ReadonlySet<string> = new Set(['video', 'audio', 'file']);
+
+/**
+ * A canvas block the server schema has no spec for, rendered as one it does.
+ *
+ * blocksToMarkdownLossy looks the spec up by block type, so an unmapped type
+ * throws on its propSchema and the whole canvas fails to convert — every block
+ * lost for the sake of the one that could not be rendered. Returning null drops
+ * just that block.
+ */
+function customBlockToDefault(block: LooseBlock): LooseBlock | null {
+  // Diagram and math hold their source as plain content, so a fenced code block
+  // is the same text under a language tag.
+  if (block.type === 'diagram') {
+    return { ...block, type: 'codeBlock', props: { language: 'mermaid' } };
+  }
+  if (block.type === 'mathBlock') {
+    return { ...block, type: 'codeBlock', props: { language: 'latex' } };
+  }
+  // Whiteboard and embed cannot be drawn from markdown, so they go out as a
+  // fence the write side recognises: the whiteboard's id lets restoreCustomBlocks
+  // put the original block back rather than lose the drawing, and the labels are
+  // what a reader can know about it.
+  if (block.type === 'whiteboard') {
+    const title = String(block.props?.['title'] ?? 'Untitled Whiteboard');
+    const labels = whiteboardLabels(block.props?.['data']);
+    const lines = [`id: ${block.id ?? ''}`, `title: ${title}`];
+    if (labels.length > 0) lines.push(`labels: ${labels.join(', ')}`);
+    return fenceBlock('whiteboard', lines.join('\n'));
+  }
+  if (block.type === 'embed') {
+    const url = String(block.props?.['url'] ?? '');
+    return url ? fenceBlock('embed', `url: ${url}`) : null;
+  }
+  // BlockNote renders a video with image syntax, audio as raw <audio> HTML and a
+  // file as a bare link, so a reader cannot tell a clip from a picture and an edit
+  // turns one into the other — or into a paragraph. A fence names the kind
+  // outright and carries the attachment id back.
+  if (block.type === 'video' || block.type === 'audio' || block.type === 'file') {
+    const attachment = String(block.props?.['url'] ?? '');
+    if (!attachment) return null;
+    const lines = [`attachment: ${attachment}`];
+    const name = String(block.props?.['name'] ?? '');
+    if (name) lines.push(`name: ${name}`);
+    const caption = String(block.props?.['caption'] ?? '');
+    if (caption) lines.push(`caption: ${caption}`);
+    return fenceBlock(block.type, lines.join('\n'));
+  }
+  return null;
+}
+
+const escapeHtml = (text: string): string =>
+  text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+/** A paragraph whose text is emitted verbatim, so raw HTML survives serialization. */
+const htmlBlock = (html: string): LooseBlock => ({
+  type: 'paragraph',
+  content: [{ type: 'text', text: html, styles: {} }],
+});
+
+const fenceBlock = (language: string, text: string): LooseBlock => ({
+  type: 'codeBlock',
+  props: { language },
+  content: [{ type: 'text', text, styles: {} }],
+});
+
+/** The `key: value` lines of a fence written by customBlockToDefault. */
+function fenceFields(block: LooseBlock): Record<string, string> {
+  const fields: Record<string, string> = {};
+  for (const line of plainInlineToString(block.content).split('\n')) {
+    const match = /^([a-zA-Z]+):\s*(.*)$/.exec(line);
+    if (match?.[1] && match[2] !== undefined) fields[match[1]] = match[2].trim();
+  }
+  return fields;
+}
+
+interface ExcalidrawTextElement {
+  type?: string;
+  text?: string;
+  originalText?: string;
+  isDeleted?: boolean;
+  x?: number;
+  y?: number;
+}
+
+/**
+ * The text on a whiteboard, in reading order.
+ *
+ * `data` is an Excalidraw scene; its text elements are both the free labels
+ * and the text bound inside shapes, so together they are what the board says.
+ */
+function whiteboardLabels(data: unknown): string[] {
+  let scene: unknown;
+  try {
+    scene = typeof data === 'string' ? JSON.parse(data) : data;
+  } catch {
+    return [];
+  }
+  const elements = (scene as { elements?: unknown } | null)?.elements;
+  if (!Array.isArray(elements)) return [];
+
+  const isText = (element: unknown): element is ExcalidrawTextElement =>
+    typeof element === 'object' &&
+    element !== null &&
+    (element as ExcalidrawTextElement).type === 'text' &&
+    !(element as ExcalidrawTextElement).isDeleted;
+
+  const labels = elements
+    .filter(isText)
+    .sort((a, b) => (a.y ?? 0) - (b.y ?? 0) || (a.x ?? 0) - (b.x ?? 0))
+    .map(element => (element.originalText ?? element.text ?? '').replace(/\s+/g, ' ').trim())
+    .filter(Boolean);
+  return [...new Set(labels)];
+}
+
+/**
+ * The inverse of customBlockToDefault, for markdown coming back in.
+ *
+ * The server parses with the default schema, so a fence can only become a
+ * codeBlock. The canvas renders a mermaid codeBlock through a view-only viewer
+ * whose editable source sits in a hidden <pre>, while a diagram block draws the
+ * same picture and opens its source on click — so the agent's diagrams are only
+ * editable if they come back as diagram blocks.
+ */
+// Blocks whose content is literal source text, where a $ is just a dollar sign.
+const PLAIN_CONTENT_TYPES = new Set(['codeBlock', 'diagram', 'mathBlock']);
+
+// customInlineToText writes inline math back as $…$, but nothing turned that
+// into a math node again — so an agent that read a canvas and wrote it back
+// flattened every inline formula to literal text. Rejecting a $…$ that opens or
+// closes on whitespace or spans a line keeps most prices out of it.
+const INLINE_MATH = /\$(?!\s)([^$\n]*[^$\n\s])\$/g;
+
+// What is between the dollars has to contain something only mathematics uses.
+// Requiring that, rather than rejecting things that look like numbers, is what
+// keeps a price *range* out: "$100-$200" leaves "100-" between the dollars,
+// which a numeric test lets through and this does not. A formula of digits and
+// a minus sign alone ("$1-2$") is given up in exchange, and stays as text.
+const MATHEMATICAL_CHARACTER = /[a-zA-Z\\^_{}=+*/<>]/;
+
+function restoreInlineMath(content: unknown): unknown {
+  if (!Array.isArray(content)) return content;
+
+  return content.flatMap((part): LooseInline[] => {
+    const node = part as LooseInline;
+    if (node?.type !== 'text' || typeof node.text !== 'string' || !node.text.includes('$')) {
+      return [node];
+    }
+
+    const parts: LooseInline[] = [];
+    let cursor = 0;
+    for (const match of node.text.matchAll(INLINE_MATH)) {
+      const latex = match[1];
+      if (latex === undefined || !MATHEMATICAL_CHARACTER.test(latex)) continue;
+      const start = match.index ?? 0;
+      if (start > cursor) {
+        parts.push({ ...node, text: node.text.slice(cursor, start) });
+      }
+      parts.push({ type: 'math', content: [{ type: 'text', text: latex, styles: {} }] });
+      cursor = start + match[0].length;
+    }
+
+    if (parts.length === 0) return [node];
+    if (cursor < node.text.length) parts.push({ ...node, text: node.text.slice(cursor) });
+    return parts;
+  });
+}
+
+function restoreCustomBlocks(blocks: LooseBlock[], existing: LooseBlock[] = []): LooseBlock[] {
+  // A whiteboard is only ever restored from the document being edited: the
+  // markdown carries its id and labels, never the drawing.
+  const whiteboards = existing.filter(block => block.type === 'whiteboard');
+  const restored = new Set<LooseBlock>();
+  const takeWhiteboard = (id: string): LooseBlock | undefined => {
+    const byId = whiteboards.find(board => board.id === id && !restored.has(board));
+    const board = byId ?? whiteboards.find(candidate => !restored.has(candidate));
+    if (board) restored.add(board);
+    return board;
+  };
+
+  // A diagram and an equation go out as a plain ```mermaid / ```latex fence,
+  // which is exactly what a person types when they want a code block. Coming
+  // back, the two are told apart by whether the canvas actually holds one with
+  // this source: an agent editing round the diagram keeps its block, and a
+  // fence nobody had before stays the code block it was written as. Both render
+  // the same diagram either way — that is what makes this safe.
+  const sourceOf = (block: LooseBlock): string =>
+    (Array.isArray(block.content) ? block.content : [])
+      .map(part => {
+        const node = part as LooseInline;
+        return typeof node?.text === 'string' ? node.text : '';
+      })
+      .join('')
+      .trim();
+
+  const takeSourceBlock = (type: string, source: string): LooseBlock | undefined => {
+    const match = existing.find(
+      block => block.type === type && !restored.has(block) && sourceOf(block) === source
+    );
+    if (match) restored.add(match);
+    return match;
+  };
+
+  const walk = (level: LooseBlock[]): LooseBlock[] =>
+    level.flatMap(block => {
+      const next: LooseBlock = { ...block };
+
+      if (Array.isArray(block.children) && block.children.length > 0) {
+        next.children = walk(block.children);
+      }
+
+      if (block.type !== undefined && !PLAIN_CONTENT_TYPES.has(block.type)) {
+        next.content = restoreInlineMath(block.content);
+      }
+
+      if (block.type !== 'codeBlock') return [next];
+
+      const language = String(block.props?.['language'] ?? '').toLowerCase();
+      if (language === 'mermaid' || language === 'latex') {
+        const type = language === 'mermaid' ? 'diagram' : 'mathBlock';
+        return takeSourceBlock(type, sourceOf(block))
+          ? [{ ...next, type, props: {} }]
+          : [next];
+      }
+      // Only a fence customBlockToDefault wrote carries these fields. One a
+      // person typed does not, and is left alone as the code block it is.
+      const fields = fenceFields(block);
+      if (language === 'whiteboard' && fields['id'] !== undefined) {
+        const board = takeWhiteboard(fields['id']);
+        return board ? [board] : [];
+      }
+      if (language === 'embed' && fields['url'] !== undefined) {
+        return fields['url'] ? [{ type: 'embed', props: { url: fields['url'] } }] : [];
+      }
+      if (
+        (language === 'video' || language === 'audio' || language === 'file') &&
+        fields['attachment'] !== undefined
+      ) {
+        if (!fields['attachment']) return [];
+        return [
+          {
+            type: language,
+            props: {
+              url: fields['attachment'],
+              ...(fields['name'] ? { name: fields['name'] } : {}),
+              ...(fields['caption'] ? { caption: fields['caption'] } : {}),
+            },
+          },
+        ];
+      }
+
+      return [next];
+    });
+
+  const result = walk(blocks);
+  // A drawing the markdown no longer mentions is kept rather than deleted: the
+  // writer never saw its content, so it cannot have meant to remove it. Only
+  // whiteboards — a diagram or equation the markdown drops really was dropped,
+  // since its source was there to be read.
+  return [...result, ...whiteboards.filter(board => !restored.has(board))];
 }
 
 // Remove citation blocks and replace custom inline nodes before serialization.
@@ -360,10 +670,37 @@ function normalizeBlocksForMarkdown(blocks: LooseBlock[]): LooseBlock[] {
   return blocks.flatMap(block => {
     if (block.type === 'citation') return [];
 
-    const next: LooseBlock = { ...block };
+    // Markdown has no toggle, and a bare list item comes back as a plain bullet
+    // while a toggleable heading loses both its arrow and its nesting. BlockNote
+    // parses <details> back into a toggle with its children intact — and into a
+    // toggleable heading when the summary holds an <hN> — so that is what both
+    // are written as.
+    const isToggleHeading = block.type === 'heading' && block.props?.['isToggleable'] === true;
+    if (block.type === 'toggleListItem' || isToggleHeading) {
+      const text = escapeHtml(plainInlineToString(block.content));
+      const level = Number(block.props?.['level'] ?? 1);
+      const summary = isToggleHeading ? `<h${level}>${text}</h${level}>` : text;
+      const children = Array.isArray(block.children)
+        ? normalizeBlocksForMarkdown(block.children)
+        : [];
+      return [
+        htmlBlock(`<details><summary>${summary}</summary>`),
+        ...children,
+        htmlBlock('</details>'),
+      ];
+    }
 
-    if (block.content !== undefined) {
-      next.content = normalizeInlineContent(block.content);
+    const needsRewrite =
+      Boolean(block.type) &&
+      (REWRITTEN_DEFAULT_TYPES.has(block.type as string) ||
+        !DEFAULT_BLOCK_TYPES.has(block.type as string));
+    const supported = needsRewrite ? customBlockToDefault(block) : block;
+    if (!supported) return [];
+
+    const next: LooseBlock = { ...supported };
+
+    if (supported.content !== undefined) {
+      next.content = normalizeInlineContent(supported.content);
     }
 
     if (Array.isArray(block.children) && block.children.length > 0) {
@@ -381,12 +718,14 @@ function normalizeBlocksForMarkdown(blocks: LooseBlock[]): LooseBlock[] {
  */
 export async function convertBlockNoteToMarkdown(blocks: unknown[]): Promise<string> {
   try {
-    // Strip custom inline nodes (e.g. mentions) the default server schema does
-    // not know about, otherwise blocksToMarkdownLossy throws
-    // "node type <x> not found in schema".
+    // Strip custom inline nodes (e.g. mentions) and rewrite custom blocks the
+    // default server schema does not know about, otherwise blocksToMarkdownLossy
+    // throws "node type <x> not found in schema" and the whole canvas is lost.
     const normalized = normalizeBlocksForMarkdown((blocks as LooseBlock[]) || []);
     // blocksToMarkdownLossy accepts the blocks array directly
-    const markdown = await withServerEditor((editor) => editor.blocksToMarkdownLossy(normalized as any));
+    const markdown = await withServerEditor(editor =>
+      editor.blocksToMarkdownLossy(normalized as any),
+    );
     return markdown;
   } catch (error) {
     logger.error('[CanvasService] Failed to convert BlockNote to Markdown:', error);
@@ -528,7 +867,7 @@ export async function approveKnowledgeCanvas(
         metadata: {
           canvasId: canvas.id,
           learningIds: learningIds || [],
-          originalLearnings: originalLearnings.map((l) => ({
+          originalLearnings: originalLearnings.map(l => ({
             id: String(l.id),
             title: String(l.title),
             learningType: String(l.learningType),

--- a/apps/backend/src/utils/canvasCustomBlockServerSpecs.ts
+++ b/apps/backend/src/utils/canvasCustomBlockServerSpecs.ts
@@ -1,0 +1,102 @@
+/**
+ * Server-side BlockNote specs for the canvas blocks that have no default
+ * equivalent: diagram, math (block and inline) and embed.
+ *
+ * WHY THIS EXISTS: `ServerBlockNoteEditor.yDocToBlocks` / `blocksToYDoc`
+ * (ysweetUtils) only know the types in the editor's schema. A type missing there
+ * is dropped reading out of Y-Sweet — so a canvas holding a diagram reached the
+ * agent with the diagram silently gone — and throws going in, which fails the
+ * whole write. This is the block-level counterpart of what mentionServerSpec and
+ * citationServerSpec already do for inline content.
+ *
+ * Only the config matters: type, propSchema and content are what the Yjs
+ * conversion reads. The renders are React-free fallbacks the Yjs path never
+ * calls (it serializes props and type, not HTML), kept minimal for the same
+ * reason as citationServerSpec.
+ *
+ * The configs MUST match the frontend specs: diagram and math come from
+ * @blocknote/diagram-block and @blocknote/math-block (both keep their source as
+ * plain content and declare no props), embed from CanvasEmbedSpec.
+ */
+import { createBlockSpec, createInlineContentSpec } from '@blocknote/core';
+
+/**
+ * The bit of the DOM these renders touch.
+ *
+ * lib is ES2020 (no DOM) on the server, so HTMLElement resolves to a name with
+ * no members; `document` arrives from JSDOM at runtime. Describing what is
+ * actually used keeps the renders typed without pulling the DOM lib in.
+ */
+interface ServerElement {
+  setAttribute(name: string, value: string): void;
+  appendChild(child: ServerElement): void;
+  textContent: string;
+}
+
+interface ServerDocument {
+  createElement(tagName: string): ServerElement;
+}
+
+function serverDocument(specName: string): ServerDocument {
+  const doc = (globalThis as { document?: ServerDocument }).document;
+  if (!doc) {
+    throw new Error(
+      `${specName}.render requires a \`document\` (e.g. via JSDOM). Set \`globalThis.document\` before rendering on the server.`
+    );
+  }
+  return doc;
+}
+
+/** BlockNote wants the DOM types it was compiled against; JSDOM supplies them. */
+const asDomElement = (element: ServerElement): HTMLElement => element as unknown as HTMLElement;
+
+/**
+ * A block whose content is plain source text — the Mermaid of a diagram, the
+ * LaTeX of an equation. contentDOM is what carries that text through.
+ */
+function renderSourceBlock(type: string): { dom: HTMLElement; contentDOM: HTMLElement } {
+  const doc = serverDocument(`${type}ServerSpec`);
+  const dom = doc.createElement('pre');
+  dom.setAttribute('data-block-type', type);
+  const contentDOM = doc.createElement('code');
+  dom.appendChild(contentDOM);
+  return { dom: asDomElement(dom), contentDOM: asDomElement(contentDOM) };
+}
+
+export const diagramServerSpec = createBlockSpec(
+  { type: 'diagram', propSchema: {}, content: 'plain' },
+  { render: () => renderSourceBlock('diagram') }
+)();
+
+export const mathBlockServerSpec = createBlockSpec(
+  { type: 'mathBlock', propSchema: {}, content: 'plain' },
+  { render: () => renderSourceBlock('mathBlock') }
+)();
+
+export const embedServerSpec = createBlockSpec(
+  { type: 'embed', propSchema: { url: { default: '' } }, content: 'none' },
+  {
+    render: (block) => {
+      const doc = serverDocument('embedServerSpec');
+      const dom = doc.createElement('div');
+      dom.setAttribute('data-block-type', 'embed');
+      dom.textContent = String(block.props.url ?? '');
+      return { dom: asDomElement(dom) };
+    },
+  }
+)();
+
+/** Inline math, whose LaTeX is plain content just like the block form. */
+export const mathInlineServerSpec = createInlineContentSpec(
+  { type: 'math', propSchema: {}, content: 'plain' },
+  {
+    render: () => {
+      const doc = serverDocument('mathInlineServerSpec');
+      const dom = doc.createElement('span');
+      dom.setAttribute('data-inline-content-type', 'math');
+      const contentDOM = doc.createElement('span');
+      dom.appendChild(contentDOM);
+      return { dom: asDomElement(dom), contentDOM: asDomElement(contentDOM) };
+    },
+  }
+);

--- a/apps/backend/src/utils/ysweetUtils.ts
+++ b/apps/backend/src/utils/ysweetUtils.ts
@@ -14,10 +14,16 @@ import {
   defaultInlineContentSpecs,
   defaultStyleSpecs,
 } from '@blocknote/core';
-import { mentionServerSpec } from 'blocknote-layout-server-utils';
+import { mentionServerSpec, whiteboardServerSpec } from 'blocknote-layout-server-utils';
 import { config } from '@/config/env.js';
 import { logger } from '@/utils/logger.js';
 import { citationServerSpec } from '@/utils/canvasCitationSpec.js';
+import {
+  diagramServerSpec,
+  embedServerSpec,
+  mathBlockServerSpec,
+  mathInlineServerSpec,
+} from '@/utils/canvasCustomBlockServerSpecs.js';
 import type { BlockNoteBlock } from '@/types/blockNoteTypes.js';
 
 const canvasCommentThreadStyleSpec = createStyleSpec(
@@ -45,13 +51,23 @@ const canvasCommentThreadStyleSpec = createStyleSpec(
 
 function createServerSchema() {
   return BlockNoteSchema.create({
-    blockSpecs: defaultBlockSpecs,
+    // The canvas schema's own blocks, for the same reason as the inline specs
+    // below: a type missing here is dropped coming out of Y-Sweet and throws
+    // going in, so one diagram would cost the whole document.
+    blockSpecs: {
+      ...defaultBlockSpecs,
+      whiteboard: whiteboardServerSpec,
+      diagram: diagramServerSpec,
+      mathBlock: mathBlockServerSpec,
+      embed: embedServerSpec,
+    },
     inlineContentSpecs: {
       ...defaultInlineContentSpecs,
       mention: mentionServerSpec,
       // Register "citation" so blocksToYDoc/blocksToYXmlFragment preserve the
       // call-summary citation chips into Y-Sweet instead of silently dropping them.
       citation: citationServerSpec,
+      math: mathInlineServerSpec,
     },
     styleSpecs: {
       ...defaultStyleSpecs,
@@ -326,40 +342,59 @@ export async function syncToYSweet(canvasId: string, blocks: BlockNoteBlock[], u
  * @param userId - The actual user/bot performing this read
  * @returns Array of BlockNote blocks, or empty array if unable to read
  */
+/**
+ * The canvas as it stands, with a failed read told apart from an empty canvas.
+ *
+ * readFromYSweet answers `[]` for both, which is harmless when the answer is
+ * only being read and destructive when it is being written back: a write that
+ * restores what markdown cannot carry — a whiteboard's drawing — would take an
+ * unreachable Y-Sweet as "there was nothing here" and commit the document
+ * without it.
+ */
+export async function readFromYSweetStrict(
+  canvasId: string,
+  userId: string
+): Promise<BlockNoteBlock[]> {
+  const ysweetUrl = config.ysweet.url;
+  if (!ysweetUrl) {
+    logger.warn('[YSweetUtils] Y-Sweet URL not configured, returning empty content');
+    return [];
+  }
+
+  // Get a client token with read-only authorization
+  const clientToken = await ysweetGetClientToken(canvasId, {
+    authorization: 'read-only',
+    userId,
+  });
+
+  // Override URLs to use direct Y-Sweet URL instead of proxy URL
+  overrideTokenUrls(clientToken, ysweetUrl, clientToken.baseUrl);
+
+  const existingUpdate = await ysweetGetAsUpdate(clientToken);
+
+  if (!existingUpdate || existingUpdate.length === 0) {
+    logger.debug(`[YSweetUtils] No existing Y-Sweet state for canvas ${canvasId}`);
+    return [];
+  }
+
+  // Create a new Y.Doc and apply the existing state
+  const ydoc = new Y.Doc();
+  Y.applyUpdate(ydoc, existingUpdate);
+
+  // Convert Y.Doc back to BlockNote blocks using ServerBlockNoteEditor
+  const editor = getServerEditor();
+  const blocks = editor.yDocToBlocks(ydoc, YSWEET_XML_FRAGMENT);
+
+  logger.info(
+    `[YSweetUtils] Successfully read ${blocks.length} blocks from Y-Sweet for canvas ${canvasId}`
+  );
+  return blocks as BlockNoteBlock[];
+}
+
+/** The same read, with a failure reported as an empty canvas. */
 export async function readFromYSweet(canvasId: string, userId: string): Promise<BlockNoteBlock[]> {
   try {
-    const ysweetUrl = config.ysweet.url;
-    if (!ysweetUrl) {
-      logger.warn('[YSweetUtils] Y-Sweet URL not configured, returning empty content');
-      return [];
-    }
-
-    // Get a client token with read-only authorization
-    const clientToken = await ysweetGetClientToken(canvasId, {
-      authorization: 'read-only',
-      userId,
-    });
-
-    // Override URLs to use direct Y-Sweet URL instead of proxy URL
-    overrideTokenUrls(clientToken, ysweetUrl, clientToken.baseUrl);
-
-    const existingUpdate = await ysweetGetAsUpdate(clientToken);
-
-    if (!existingUpdate || existingUpdate.length === 0) {
-      logger.debug(`[YSweetUtils] No existing Y-Sweet state for canvas ${canvasId}`);
-      return [];
-    }
-
-    // Create a new Y.Doc and apply the existing state
-    const ydoc = new Y.Doc();
-    Y.applyUpdate(ydoc, existingUpdate);
-
-    // Convert Y.Doc back to BlockNote blocks using ServerBlockNoteEditor
-    const editor = getServerEditor();
-    const blocks = editor.yDocToBlocks(ydoc, YSWEET_XML_FRAGMENT);
-
-    logger.info(`[YSweetUtils] Successfully read ${blocks.length} blocks from Y-Sweet for canvas ${canvasId}`);
-    return blocks as BlockNoteBlock[];
+    return await readFromYSweetStrict(canvasId, userId);
   } catch (error) {
     logger.error('[YSweetUtils] Failed to read from Y-Sweet:', error);
     return [];

--- a/apps/dashboard/src/components/Canvas/CanvasCodeBlockSpec.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasCodeBlockSpec.tsx
@@ -2,7 +2,7 @@ import { defaultBlockSpecs } from '@blocknote/core';
 import { createReactBlockSpec } from '@blocknote/react';
 import hljs from 'highlight.js';
 import { useMemo, type ReactElement, type Ref } from 'react';
-import { MermaidBlock } from '../Markdown/MermaidBlock';
+import { CanvasMermaidWithSource } from './CanvasMermaidWithSource';
 
 const codeConfig = defaultBlockSpecs.codeBlock.config;
 
@@ -64,7 +64,7 @@ export const canvasCodeBlockSpec = createReactBlockSpec(
   codeConfig,
   {
     meta: { code: true, defining: true },
-    render: ({ block, contentRef }) => {
+    render: ({ block, editor, contentRef }) => {
       const language = String(block.props.language ?? 'text').toLocaleLowerCase();
       const chart = Array.isArray(block.content)
         ? block.content
@@ -84,10 +84,13 @@ export const canvasCodeBlockSpec = createReactBlockSpec(
       }
       return (
         <div className='w-full' data-wiki-mermaid='true'>
-          <MermaidBlock chart={chart} messageId={`canvas-${block.id}`} controlsOnHover />
-          <pre className='hidden' aria-hidden='true'>
-            <code ref={contentRef} spellCheck={false} />
-          </pre>
+          <CanvasMermaidWithSource
+            source={chart}
+            cacheKey={`canvas-${block.id}`}
+            contentRef={contentRef as Ref<HTMLElement>}
+            onRemove={() => editor.removeBlocks([block.id])}
+            editable={editor.isEditable}
+          />
         </div>
       );
     },

--- a/apps/dashboard/src/components/Canvas/CanvasCodeCopyButton.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasCodeCopyButton.tsx
@@ -5,7 +5,7 @@ import type {
   StyleSchema,
 } from '@blocknote/core';
 import { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
-import { Check, Copy } from 'lucide-react';
+import { Check, Copy, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useClipboard } from '../../hooks/useClipboard';
 import { CANVAS_CODE_LANGUAGES } from './CanvasCodeBlockSpec';
@@ -130,6 +130,17 @@ export const CanvasCodeCopyButton = ({
     [editor],
   );
 
+  // The same action the diagram, equation and embed blocks carry. The toolbar
+  // is hover-positioned rather than part of the block, so the block it belongs
+  // to is the one under the pointer, not the one holding the cursor.
+  const handleDelete = useCallback(() => {
+    const blockId = hoveredBlockRef.current?.closest<HTMLElement>('[data-id]')?.dataset['id'];
+    if (!blockId) return;
+    hoveredBlockRef.current = null;
+    setPosition(prev => ({ ...prev, show: false }));
+    editor.removeBlocks([blockId]);
+  }, [editor]);
+
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -154,25 +165,29 @@ export const CanvasCodeCopyButton = ({
   return (
     <div
       ref={toolbarRef}
-      className='fixed z-50 flex -translate-x-full items-center gap-1 rounded-md border border-border bg-card p-1 shadow-sm'
+      className='canvas-code-toolbar fixed z-50 flex -translate-x-full items-center gap-1 rounded-md border border-border bg-card p-1 shadow-sm'
       style={{ top: position.top, left: position.left }}
     >
-      <select
-        value={language}
-        onChange={event => handleLanguageChange(event.target.value)}
-        onMouseDown={event => event.stopPropagation()}
-        aria-label='Code language'
-        title='Code language'
-        data-track-category='CANVAS'
-        data-track-name='Change_Code_Block_Language'
-        className='h-[26px] max-w-32 rounded px-2 text-xs text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus:bg-accent focus:text-foreground'
-      >
-        {CANVAS_CODE_LANGUAGES.map(option => (
-          <option key={option.value || 'auto'} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
+      {/* updateBlock writes through the API too, so a reader could otherwise
+          re-language someone else's code block. Copy stays: it takes nothing. */}
+      {editor.isEditable && (
+        <select
+          value={language}
+          onChange={event => handleLanguageChange(event.target.value)}
+          onMouseDown={event => event.stopPropagation()}
+          aria-label='Code language'
+          title='Code language'
+          data-track-category='CANVAS'
+          data-track-name='Change_Code_Block_Language'
+          className='h-[26px] max-w-32 rounded px-2 text-xs text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus:bg-accent focus:text-foreground'
+        >
+          {CANVAS_CODE_LANGUAGES.map(option => (
+            <option key={option.value || 'auto'} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      )}
       <button
         type='button'
         onMouseDown={event => event.preventDefault()}
@@ -185,6 +200,22 @@ export const CanvasCodeCopyButton = ({
       >
         {copied ? <Check size={13} /> : <Copy size={13} />}
       </button>
+      {/* removeBlocks writes to the document whatever the editor's editable
+          state, which only stops input handlers. */}
+      {editor.isEditable && (
+        <button
+          type='button'
+          onMouseDown={event => event.preventDefault()}
+          onClick={handleDelete}
+          title='Delete'
+          aria-label='Delete'
+          className='flex h-[26px] w-[26px] items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+          data-track-category='CANVAS'
+          data-track-name='Delete_Code_Block'
+        >
+          <Trash2 size={13} />
+        </button>
+      )}
     </div>
   );
 };

--- a/apps/dashboard/src/components/Canvas/CanvasDiagramSpec.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasDiagramSpec.tsx
@@ -1,0 +1,43 @@
+import { plainContentToString } from '@blocknote/core';
+import {
+  createDiagramBlockConfig,
+  parseDiagramCodeContent,
+  parseDiagramCodeElement,
+} from '@blocknote/diagram-block';
+import { createReactBlockSpec } from '@blocknote/react';
+import type { Ref } from 'react';
+import { CanvasMermaidWithSource } from './CanvasMermaidWithSource';
+
+/**
+ * Renders the diagram block through the same component as the mermaid code
+ * block. The package's own render shows a source popup instead and re-renders
+ * only when the source changes, so its diagrams keep the old palette after a
+ * theme switch — which is why this replaces it rather than restyling it.
+ */
+export const canvasDiagramBlockSpec = createReactBlockSpec(createDiagramBlockConfig, {
+  meta: {
+    code: true,
+    defining: true,
+    isolating: false,
+    highlight: () => 'mermaid',
+    hardBreakShortcut: 'enter',
+  },
+  parse: parseDiagramCodeElement,
+  parseContent: parseDiagramCodeContent,
+  // The code block also claims <pre><code>, so this rule must be tried first.
+  runsBefore: ['codeBlock'],
+  render: ({ block, editor, contentRef }) => (
+    <CanvasMermaidWithSource
+      source={plainContentToString(block.content).trim()}
+      cacheKey={`canvas-diagram-${block.id}`}
+      contentRef={contentRef as Ref<HTMLElement>}
+      onRemove={() => editor.removeBlocks([block.id])}
+      editable={editor.isEditable}
+    />
+  ),
+  toExternalHTML: ({ contentRef }) => (
+    <pre>
+      <code className='language-mermaid' data-language='mermaid' ref={contentRef} />
+    </pre>
+  ),
+})();

--- a/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
@@ -84,6 +84,7 @@ import { AnimatePresence } from 'framer-motion';
 
 import { CanvasInlineCommentThread } from '../CanvasInlineCommentThread/CanvasInlineCommentThread';
 import { createCanvasFormattingToolbar } from '../CanvasFormattingToolbar/CanvasFormattingToolbar';
+import { CanvasWidthHandles } from '../CanvasWidthHandles';
 import { useCanvasCommentEditorBridge } from '../useCanvasCommentEditorBridge';
 
 const canvasDictionary = {
@@ -403,6 +404,7 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
       openCommentsForCurrentBlock,
       focusCommentBlock,
       clearActiveCommentAnchor,
+      finishInlineCommentDraft,
       closeInlineCommentThread,
       applyCommentAnchorStyle,
       removeCommentAnchorStyle,
@@ -584,6 +586,7 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
       >
         <div className='relative flex min-h-0 flex-1 overflow-hidden'>
           <div className='thin-scrollbar relative min-h-0 flex-1 overflow-auto pt-8'>
+            <CanvasWidthHandles surfaceRef={containerRef} />
             <CanvasMentionContext.Provider value={mentionContextValue}>
               <BlockNoteView
                 editor={asBlockNoteEditorForView(editor)}
@@ -640,7 +643,7 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
               editable={editable}
               onClose={closeInlineCommentThread}
               onBeforeCreateThread={applyCommentAnchorStyle}
-              onCreateThreadCreated={clearActiveCommentAnchor}
+              onCreateThreadCreated={finishInlineCommentDraft}
               onCreateThreadFailed={removeCommentAnchorStyle}
             />
           )}

--- a/apps/dashboard/src/components/Canvas/CanvasEmbedSpec.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasEmbedSpec.tsx
@@ -190,12 +190,18 @@ export const canvasEmbedSpec = createReactBlockSpec(
       const editable = editor.isEditable;
 
       return (
-        <div className='group relative my-1 w-full'>
+        <div className='group relative my-1 w-full' data-canvas-embed='true'>
           {video ? (
             <PlayerEmbed embedUrl={video.embedUrl} provider={video.provider} />
           ) : (
             <GenericEmbedCard url={url} />
           )}
+          {/* A player is a cross-origin frame: it swallows the click, so the
+              block could never be selected — and an embed that cannot be
+              selected cannot be commented on or asked about. The shield takes
+              the first click for the block and disappears while it is selected,
+              so a second click reaches the player and it plays as before. */}
+          {video && <div className='canvas-embed-shield' contentEditable={false} />}
           <EmbedActions
             url={url}
             editable={editable}

--- a/apps/dashboard/src/components/Canvas/CanvasFormattingToolbar/CanvasFormattingToolbar.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasFormattingToolbar/CanvasFormattingToolbar.tsx
@@ -5,28 +5,47 @@ import {
   CreateLinkButton,
   type FormattingToolbarProps,
   TextAlignButton,
+  useBlockNoteEditor,
   useComponentsContext,
 } from '@blocknote/react';
+import { TextSelection, type Selection } from '@tiptap/pm/state';
 import { MessageSquarePlus } from 'lucide-react';
 import type { FC, ReactElement } from 'react';
 import { useCallback, useEffect, useRef } from 'react';
 import { xyneAIActor, type SelectionInfo } from '../../../machines/xyneAIMachine';
 
+/**
+ * Whether cells of a table are selected.
+ *
+ * Structural rather than `instanceof CellSelection`: prosemirror-tables is
+ * loaded once by BlockNote and again through @tiptap/pm, and a class compared
+ * across two copies of a module never matches.
+ */
+const isCellSelection = (selection: Selection): boolean => '$anchorCell' in selection;
+
 type CanvasFormattingToolbarOptions = {
   canvasId?: string;
   canvasTitle?: string;
   canComment?: boolean;
+  /**
+   * Text to hand Ask AI when there is no DOM selection to read. A selected
+   * diagram or equation is an object, not highlighted text, so its own source
+   * is what Ask AI is being asked about.
+   */
+  selectionText?: string;
 };
 
-function CanvasToolbarAttachedActions({
+export function CanvasToolbarAttachedActions({
   onAddComment,
   canvasId,
   canvasTitle,
   canComment = true,
+  selectionText,
 }: {
   onAddComment: () => void;
 } & CanvasFormattingToolbarOptions): ReactElement {
   const selectedTextRef = useRef('');
+  const editor = useBlockNoteEditor();
 
   useEffect(() => {
     const updateSelectedText = (): void => {
@@ -41,10 +60,55 @@ function CanvasToolbarAttachedActions({
     return (): void => document.removeEventListener('selectionchange', updateSelectedText);
   }, []);
 
+  /**
+   * What the reader has picked out, as the AI should read it.
+   *
+   * The document's own selection is the source of truth rather than the
+   * browser's: selecting cells in a table leaves the DOM selection inside a
+   * single cell, so a table went to Ask AI as one cell of it, and selecting a
+   * whole block leaves no DOM range at all. Anything wider than one paragraph
+   * goes as markdown, which is the only form that keeps a table's rows and
+   * columns and a code block's fence intact.
+   */
+  const readSelection = useCallback((): string => {
+    const state = editor?._tiptapEditor?.view?.state;
+    if (!state || state.selection.empty) return '';
+
+    const { selection } = state;
+    const withinOneTextblock =
+      selection instanceof TextSelection &&
+      selection.$from.parent === selection.$to.parent &&
+      selection.$from.parent.isTextblock;
+
+    if (!withinOneTextblock) {
+      try {
+        // Cells are selected by rectangle, not by range, and the slice cut from
+        // that range collapses to a single cell — which is why a table used to
+        // arrive as one of its cells. Picking cells out of a table means the
+        // table, so the whole block is what goes.
+        const blocks = isCellSelection(selection)
+          ? [editor.getTextCursorPosition().block]
+          : editor.getSelectionCutBlocks().blocks;
+        const markdown = editor
+          .blocksToMarkdownLossy(blocks as Parameters<typeof editor.blocksToMarkdownLossy>[0])
+          .trim();
+        if (markdown) return markdown;
+      } catch {
+        // Custom blocks without a markdown form fall through to their text.
+      }
+    }
+
+    return state.doc.textBetween(selection.from, selection.to, '\n', ' ').trim();
+  }, [editor]);
+
   const handleAskAI = useCallback((): void => {
     if (!canvasId) return;
 
-    const selectedText = window.getSelection()?.toString().trim() || selectedTextRef.current;
+    const selectedText =
+      selectionText ||
+      readSelection() ||
+      window.getSelection()?.toString().trim() ||
+      selectedTextRef.current;
     if (!selectedText) return;
 
     const preview = selectedText.length > 50 ? `${selectedText.substring(0, 50)}...` : selectedText;
@@ -65,7 +129,7 @@ function CanvasToolbarAttachedActions({
     });
 
     window.getSelection()?.removeAllRanges();
-  }, [canvasId, canvasTitle]);
+  }, [selectionText, readSelection, canvasId, canvasTitle]);
 
   return (
     <div className='canvas-formatting-menu__attached-actions'>

--- a/apps/dashboard/src/components/Canvas/CanvasMathBlockSpec.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasMathBlockSpec.tsx
@@ -1,0 +1,163 @@
+import { plainContentToString } from '@blocknote/core';
+import {
+  BlockMathMLElement,
+  createMathBlockConfig,
+  MathBlockInputRulesExtension,
+  parseBlockMathMLContent,
+  parseBlockMathMLElement,
+  useLatexToMathMLString,
+} from '@blocknote/math-block';
+import { createReactBlockSpec } from '@blocknote/react';
+import { Check, Pencil, Trash2 } from 'lucide-react';
+import { useCallback, useRef, useState, type ReactElement, type Ref } from 'react';
+import { useCollapseWhenLeft, useRemoveWhenAbandoned } from './useRemoveWhenAbandoned';
+
+/**
+ * The packaged math block edits through a floating source popup with its own
+ * OK button, which looks nothing like the diagram block beside it. This keeps
+ * the package's parsing and export and replaces only the render, so equations
+ * get the same icon-only Edit and the same source panel underneath the preview
+ * rather than over it. The equation itself stays unboxed — a border would put
+ * a card around what is often a single inline-sized formula.
+ */
+function CanvasMathBlock(props: {
+  source: string;
+  contentRef: Ref<HTMLElement>;
+  onRemove: () => void;
+  editable: boolean;
+}): ReactElement {
+  const root = useRef<HTMLDivElement>(null);
+  // A block inserted from the slash menu starts empty, so it opens straight
+  // into its source. Held in state rather than derived from emptiness, or the
+  // panel would snap shut on the first keystroke that makes the equation valid.
+  const [editing, setEditing] = useState(() => props.source.length === 0);
+  const toggleEditing = useCallback(() => setEditing(open => !open), []);
+  const stopEditing = useCallback(() => setEditing(false), []);
+  const { mathMLString, error } = useLatexToMathMLString(props.source);
+
+  // Half-typed LaTeX is invalid LaTeX, so the preview vanished and reappeared on
+  // almost every keystroke and the source panel jumped up and down under the
+  // cursor. Holding the last good render keeps the block a stable size while it
+  // is being edited; it is replaced the moment the new source parses.
+  const lastRendered = useRef('');
+  if (mathMLString && !error) lastRendered.current = mathMLString;
+  const shownMathML = mathMLString && !error ? mathMLString : lastRendered.current;
+
+  // An empty block has nothing to draw, and useLatexToMathMLString reports no
+  // error for empty input — so without the length check a freshly inserted
+  // equation counted as renderable and the block came up completely blank.
+  const empty = props.source.length === 0;
+  const renderable = !empty && Boolean(shownMathML);
+  const showSource = editing || !renderable;
+  // Only for someone who could have created it: removeBlocks writes through
+  // the API, which ProseMirror's editable gate does not cover.
+  useRemoveWhenAbandoned(root, empty && props.editable, props.onRemove);
+  useCollapseWhenLeft(root, editing, stopEditing);
+
+  return (
+    <div className='group/math relative w-full' data-canvas-math='true' ref={root}>
+      {/* Decoration, not text: a click on the equation must not place a caret. */}
+      {renderable && (
+        <div className='relative' contentEditable={false} suppressContentEditableWarning>
+          {/* Every action in this bar writes, so a reader gets none of it. The
+              equation itself is what they came to read. */}
+          {props.editable && (
+            <div className='absolute right-2 top-2 z-10 opacity-0 transition-opacity focus-within:opacity-100 group-hover/math:opacity-100'>
+              {/* One bar of icon actions, shaped like the diagram block's, so an
+                  equation and a diagram are operated the same way. */}
+              <div className='flex items-center gap-1 rounded-lg border border-border bg-background/90 p-1 shadow-sm backdrop-blur-sm'>
+                <button
+                  type='button'
+                  onClick={toggleEditing}
+                  className='flex items-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent'
+                  title='Edit source'
+                  aria-label='Edit source'
+                  data-track-category='CANVAS'
+                  data-track-name='Edit_Math_Block'
+                >
+                  <Pencil className='h-3 w-3' />
+                </button>
+                <button
+                  type='button'
+                  onClick={props.onRemove}
+                  className='flex items-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent'
+                  title='Delete'
+                  aria-label='Delete'
+                  data-track-category='CANVAS'
+                  data-track-name='Delete_Math_Block'
+                >
+                  <Trash2 className='h-3 w-3' />
+                </button>
+              </div>
+            </div>
+          )}
+          <div
+            className='flex justify-center py-2'
+            /* eslint-disable-next-line react/no-danger, @typescript-eslint/naming-convention */
+            dangerouslySetInnerHTML={{ __html: shownMathML }}
+          />
+        </div>
+      )}
+      {/* contentRef is what BlockNote edits, so it stays mounted when hidden. */}
+      <div
+        className={
+          showSource
+            ? 'canvas-math-source relative mt-2'
+            : 'canvas-math-source canvas-source-collapsed'
+        }
+      >
+        {renderable && (
+          <button
+            type='button'
+            onClick={() => setEditing(false)}
+            className='absolute right-2 top-2 z-10 flex items-center rounded border border-border bg-background/90 p-1 text-muted-foreground shadow-sm transition-colors hover:bg-accent'
+            title='Done editing'
+            aria-label='Done editing'
+            data-track-category='CANVAS'
+            data-track-name='Done_Editing_Math_Block'
+          >
+            <Check className='h-3 w-3' />
+          </button>
+        )}
+        <pre className='bn-code-block m-0 rounded-lg border border-border bg-background p-4'>
+          <code ref={props.contentRef} className='canvas-code-editor block' spellCheck={false} />
+        </pre>
+        {empty && (
+          <span className='pointer-events-none absolute left-4 top-4 font-mono text-[15px] leading-[1.55] text-muted-foreground'>
+            E = mc^2
+          </span>
+        )}
+        {/* The last good render stays on screen so the block does not jump, so
+            this is the only sign that the current LaTeX does not parse. */}
+        {error !== undefined && !empty && (
+          <p className='mt-2 whitespace-pre-wrap text-xs text-destructive'>{error}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const canvasMathBlockSpec = createReactBlockSpec(
+  createMathBlockConfig,
+  {
+    meta: {
+      code: true,
+      defining: true,
+      isolating: false,
+      highlight: () => 'latex',
+      hardBreakShortcut: 'shift+enter',
+    },
+    parse: parseBlockMathMLElement,
+    parseContent: parseBlockMathMLContent,
+    render: ({ block, editor, contentRef }) => (
+      <CanvasMathBlock
+        source={plainContentToString(block.content).trim()}
+        contentRef={contentRef as Ref<HTMLElement>}
+        onRemove={() => editor.removeBlocks([block.id])}
+        editable={editor.isEditable}
+      />
+    ),
+    toExternalHTML: BlockMathMLElement,
+  },
+  [MathBlockInputRulesExtension],
+)();

--- a/apps/dashboard/src/components/Canvas/CanvasMermaidWithSource.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasMermaidWithSource.tsx
@@ -1,0 +1,150 @@
+import { Check } from 'lucide-react';
+import mermaid from 'mermaid';
+import { useCallback, useEffect, useRef, useState, type ReactElement, type Ref } from 'react';
+import { MermaidBlock } from '../Markdown/MermaidBlock';
+import { isValidMermaidSyntax } from '../Markdown/MermaidBlock/MermaidBlock.utils';
+import { useCollapseWhenLeft, useRemoveWhenAbandoned } from './useRemoveWhenAbandoned';
+
+/**
+ * Whether Mermaid can actually draw this source, not just whether it opens with
+ * a diagram keyword. MermaidBlock shows a permanent spinner for a diagram that
+ * fails to parse in two lines or fewer — it only reports an error for longer
+ * ones, to stay quiet while a chat message is still streaming — and its toolbar
+ * lives inside that unrendered state, so a canvas block with a typo would have
+ * no way back to its own text.
+ */
+interface MermaidStatus {
+  renders: boolean;
+  error: string | null;
+}
+
+function useMermaidRenders(source: string): MermaidStatus {
+  const [status, setStatus] = useState<MermaidStatus>({ renders: true, error: null });
+
+  useEffect(() => {
+    if (!isValidMermaidSyntax(source)) {
+      setStatus({
+        renders: false,
+        error: source.trim().length === 0 ? null : 'Not a Mermaid diagram yet.',
+      });
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        await mermaid.parse(source);
+        if (!cancelled) setStatus({ renders: true, error: null });
+      } catch (cause) {
+        if (!cancelled) {
+          setStatus({
+            renders: false,
+            error: cause instanceof Error ? cause.message : String(cause),
+          });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [source]);
+
+  return status;
+}
+
+/**
+ * Preview and editable source for a Mermaid diagram, shared by the diagram
+ * block and the mermaid code block so the two are one UI rather than two that
+ * have to be kept looking alike.
+ *
+ * MermaidBlock supplies the card, the Diagram/Code toggle, copy, PNG download,
+ * an enlarge action and theme following. Edit reveals the source below the
+ * preview rather than replacing it, so both are visible at once.
+ */
+export function CanvasMermaidWithSource(props: {
+  source: string;
+  cacheKey: string;
+  contentRef: Ref<HTMLElement>;
+  onRemove: () => void;
+  editable: boolean;
+}): ReactElement {
+  const root = useRef<HTMLDivElement>(null);
+  // A block inserted from the slash menu starts empty, so it opens straight
+  // into its source. Held in state rather than derived from emptiness, or the
+  // panel would snap shut on the first keystroke that makes the diagram valid.
+  const [editing, setEditing] = useState(() => props.source.length === 0);
+  const toggleEditing = useCallback(() => setEditing(open => !open), []);
+  const stopEditing = useCallback(() => setEditing(false), []);
+
+  // The hook must run every render, so it is called before the empty check.
+  const { renders: rendersOk, error } = useMermaidRenders(props.source);
+  const empty = props.source.length === 0;
+
+  // A diagram is invalid for most of the time it takes to type one, and losing
+  // the preview on every keystroke made the block collapse and expand under the
+  // cursor. Once a block has drawn something, it keeps showing it while the
+  // source is being corrected — MermaidBlock itself holds the last good render.
+  const hasRendered = useRef(false);
+  if (rendersOk && !empty) hasRendered.current = true;
+  if (empty) hasRendered.current = false;
+  const renderable = !empty && (rendersOk || hasRendered.current);
+  const showSource = editing || !renderable;
+  // Only for someone who could have created it: removeBlocks writes through
+  // the API, which ProseMirror's editable gate does not cover.
+  useRemoveWhenAbandoned(root, empty && props.editable, props.onRemove);
+  useCollapseWhenLeft(root, editing, stopEditing);
+
+  return (
+    <div className='relative w-full' data-canvas-mermaid='true' ref={root}>
+      {/* The preview is decoration inside an editable block: without this a click
+          on the diagram drops a caret onto it. Only the source below is text. */}
+      {renderable && (
+        <div contentEditable={false} suppressContentEditableWarning>
+          <MermaidBlock
+            chart={props.source}
+            messageId={props.cacheKey}
+            controlsOnHover
+            // In a canvas a click selects the block, as it does on an image, so
+            // the enlarged preview moves onto its own toolbar button.
+            previewOnClick={false}
+            {...(props.editable && { onEdit: toggleEditing, onDelete: props.onRemove })}
+          />
+        </div>
+      )}
+      {/* contentRef is what BlockNote edits, so it stays mounted when hidden. */}
+      <div
+        className={
+          showSource
+            ? 'canvas-mermaid-source relative mt-2'
+            : 'canvas-mermaid-source canvas-source-collapsed'
+        }
+      >
+        {renderable && (
+          <button
+            type='button'
+            onClick={() => setEditing(false)}
+            className='absolute right-2 top-2 z-10 flex items-center rounded border border-border bg-background/90 p-1 text-muted-foreground shadow-sm transition-colors hover:bg-accent'
+            title='Done editing'
+            aria-label='Done editing'
+            data-track-category='Mermaid'
+            data-track-name='DONE_EDITING_DIAGRAM'
+          >
+            <Check className='h-3 w-3' />
+          </button>
+        )}
+        <pre className='bn-code-block m-0 rounded-lg border border-border bg-background p-4'>
+          <code ref={props.contentRef} className='canvas-code-editor block' spellCheck={false} />
+        </pre>
+        {empty && (
+          <span className='pointer-events-none absolute left-4 top-4 font-mono text-[15px] leading-[1.55] text-muted-foreground'>
+            flowchart LR
+          </span>
+        )}
+        {/* Keeping the last good preview up would otherwise hide the fact that
+            what is written now does not parse. */}
+        {error !== null && !empty && (
+          <p className='mt-2 whitespace-pre-wrap text-xs text-destructive'>{error}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/Canvas/CanvasObjectToolbar.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasObjectToolbar.tsx
@@ -1,0 +1,193 @@
+import { NodeSelection, type Selection } from '@tiptap/pm/state';
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { useBlockNoteEditor, useEditorSelectionChange } from '@blocknote/react';
+import { posToDOMRect } from '@tiptap/core';
+import { type FC, type ReactElement, useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { CanvasToolbarAttachedActions } from './CanvasFormattingToolbar/CanvasFormattingToolbar';
+
+/**
+ * Whether BlockNote's own formatting toolbar will show for this selection.
+ *
+ * A copy of its rule (FormattingToolbar.ts), because the two toolbars carry the
+ * same two actions and must never be on screen together. It hides for a whole
+ * block with no text — an embed — and for anything touching a block whose
+ * content is plain text rather than rich text: a code block, a diagram, an
+ * equation. Those are exactly the blocks that could not be commented on or
+ * asked about, which is what this toolbar is for.
+ */
+function blockNoteToolbarShows(selection: Selection, doc: ProseMirrorNode): boolean {
+  if (selection.empty) return false;
+  if (
+    selection instanceof NodeSelection &&
+    doc.textBetween(selection.from, selection.to).length === 0
+  ) {
+    return false;
+  }
+
+  let holdsPlainText = false;
+  selection.content().content.descendants(node => {
+    if (node.type.spec.content === 'text*') holdsPlainText = true;
+    return !holdsPlainText;
+  });
+  return !holdsPlainText;
+}
+
+/**
+ * Shut BlockNote's formatting toolbar. Its visibility is a store rather than a
+ * render of the selection, so it can be left showing after the selection it was
+ * opened for is gone. The same call is what the comment bridge uses.
+ */
+function closeFormattingToolbar(editor: { extensions: Map<string, unknown> } | null): void {
+  const toolbar = editor?.extensions.get('formattingToolbar');
+  const store = (toolbar as { store?: { setState?: (value: boolean) => void } } | undefined)?.store;
+  store?.setState?.(false);
+}
+
+/**
+ * What a selected block stands for: its own text, or what it points at.
+ *
+ * Empty when it stands for nothing — a divider is a line, with nothing in it to
+ * quote, comment on or ask about, so it is given no actions at all.
+ */
+function nodeLabel(node: ProseMirrorNode): string {
+  if (node.textContent.length > 0) return node.textContent;
+  const url: unknown = node.attrs['url'];
+  return typeof url === 'string' && url.length > 0 ? url : '';
+}
+
+/**
+ * Comment and Ask AI for the blocks BlockNote's formatting toolbar leaves out.
+ *
+ * It deliberately hides for blocks whose content is plain — it treats them as
+ * unformattable code — and for blocks with no text at all, so diagrams,
+ * equations, code blocks and embeds could never be commented on or asked
+ * about, the two actions that matter most on them. It also carries text
+ * controls that mean nothing for a picture, which is why this is only the two
+ * actions rather than the whole toolbar.
+ */
+export const CanvasObjectToolbar: FC<{
+  onAddComment: () => void;
+  canvasId?: string;
+  canvasTitle?: string;
+  canComment?: boolean;
+}> = (props): ReactElement | null => {
+  const editor = useBlockNoteEditor();
+  const [selected, setSelected] = useState<{ from: number; to: number; text: string } | null>(null);
+  // The rect is measured during render, so scrolling has to ask for one. A
+  // counter rather than a clock: two scroll events in the same millisecond
+  // would otherwise set identical state and skip the re-render.
+  const [, setMeasured] = useState(0);
+  const reposition = useCallback((): void => setMeasured(count => count + 1), []);
+  // A drag is still choosing what to act on, so the toolbar would open under
+  // the pointer and follow it across the text. BlockNote's own toolbar waits
+  // for the release the same way.
+  const choosing = useRef(false);
+
+  const refresh = useCallback((): void => {
+    const state = editor?._tiptapEditor?.view?.state;
+    if (!state) {
+      setSelected(null);
+      return;
+    }
+
+    const { selection } = state;
+    if (selection.empty || blockNoteToolbarShows(selection, state.doc)) {
+      setSelected(null);
+      return;
+    }
+
+    // The two toolbars carry the same actions, and BlockNote's own only
+    // re-reads the selection on a pointer release — one swallowed by an
+    // embedded player leaves it on screen beside this one. Closing it here
+    // makes them exclusive whatever order the events arrive in.
+    closeFormattingToolbar(editor);
+
+    // A selected block is asked about whole, and an embed holds no text at all
+    // so it goes as the link it shows. A range is left to the actions, which
+    // read it back out of the document.
+    if (selection instanceof NodeSelection) {
+      const text = nodeLabel(selection.node);
+      if (!text) {
+        setSelected(null);
+        return;
+      }
+      setSelected({ from: selection.from, to: selection.to, text });
+      return;
+    }
+
+    setSelected({ from: selection.from, to: selection.to, text: '' });
+  }, [editor]);
+
+  useEditorSelectionChange(() => {
+    // Only a *range* waits for the pointer: it is still growing under the
+    // cursor. Selecting a whole block is finished the moment it happens — and
+    // waiting for the release would lose it entirely, since a click that lands
+    // on an embedded player hands the release to the frame, not to us.
+    const isBlock = editor?._tiptapEditor?.view?.state.selection instanceof NodeSelection;
+    if (choosing.current && !isBlock) {
+      setSelected(null);
+      return;
+    }
+    refresh();
+  });
+
+  useEffect(() => {
+    const view = editor?._tiptapEditor?.view;
+    if (!view) return;
+
+    // Pointer down *in the document* starts a choice; the toolbar itself is
+    // portalled outside it, so pressing one of its buttons never hides it
+    // before the click lands.
+    const start = (): void => {
+      choosing.current = true;
+      setSelected(null);
+    };
+    const finish = (): void => {
+      choosing.current = false;
+      refresh();
+    };
+
+    const root: Document | ShadowRoot = view.root;
+    view.dom.addEventListener('pointerdown', start);
+    root.addEventListener('pointerup', finish, true);
+    // A button released over the browser's own chrome, or another window, never
+    // reaches the release above — and without these the toolbar would stay
+    // suppressed for every range selection from then on.
+    root.addEventListener('pointercancel', finish, true);
+    window.addEventListener('blur', finish);
+    // The toolbar is positioned in viewport coordinates, so without this it
+    // stayed where the block used to be and the reader scrolled away from it.
+    // Capture, because what moves is the canvas's own scroller, not the window.
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+    return (): void => {
+      view.dom.removeEventListener('pointerdown', start);
+      root.removeEventListener('pointerup', finish, true);
+      root.removeEventListener('pointercancel', finish, true);
+      window.removeEventListener('blur', finish);
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
+    };
+  }, [editor, refresh, reposition]);
+
+  const view = editor?._tiptapEditor?.view;
+  if (!selected || !view) return null;
+
+  const rect = posToDOMRect(view, selected.from, selected.to);
+  return createPortal(
+    <div
+      className='canvas-object-toolbar'
+      style={{ top: `${rect.top - 8}px`, left: `${rect.left + rect.width / 2}px` }}
+    >
+      <CanvasToolbarAttachedActions
+        onAddComment={props.onAddComment}
+        {...(selected.text && { selectionText: selected.text })}
+        {...(props.canvasId && { canvasId: props.canvasId })}
+        {...(props.canvasTitle && { canvasTitle: props.canvasTitle })}
+        {...(props.canComment !== undefined && { canComment: props.canComment })}
+      />
+    </div>,
+    editor?.portalElement ?? document.body,
+  );
+};

--- a/apps/dashboard/src/components/Canvas/CanvasWidthHandles.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasWidthHandles.tsx
@@ -1,0 +1,188 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactElement,
+  type RefObject,
+} from 'react';
+
+/** The width the reading column comes back to, matching global.css. */
+const DEFAULT_WIDTH = 720;
+const MIN_WIDTH = 480;
+const MAX_WIDTH = 1400;
+const KEYBOARD_STEP = 40;
+const WIDTH_VARIABLE = '--canvas-content-width';
+const HEIGHT_VARIABLE = '--canvas-visible-height';
+
+/**
+ * How wide this reader likes their canvases, kept per browser.
+ *
+ * Not in the document: the column is how one person prefers to read, and a
+ * width stored in the canvas would re-lay it out for everyone else who opens it.
+ */
+const STORAGE_KEY = 'canvas:content-width';
+
+const readNumber = (element: HTMLElement, variable: string, fallback: number): number => {
+  const raw = getComputedStyle(element).getPropertyValue(variable).trim();
+  const value = Number.parseFloat(raw);
+  return Number.isFinite(value) ? value : fallback;
+};
+
+const readStoredWidth = (): number | null => {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return null;
+    const value = Number.parseFloat(raw);
+    return Number.isFinite(value) ? value : null;
+  } catch {
+    // Private browsing, or storage turned off. The default width still works.
+    return null;
+  }
+};
+
+const storeWidth = (width: number | null): void => {
+  try {
+    if (width === null) window.localStorage.removeItem(STORAGE_KEY);
+    else window.localStorage.setItem(STORAGE_KEY, String(width));
+  } catch {
+    // As above — the width still applies for this session.
+  }
+};
+
+/**
+ * Drag either edge of the canvas to widen or narrow the reading column.
+ *
+ * The column is centred by `margin-inline: auto` off a single custom property,
+ * so moving one edge outward by a distance and the width by twice it keeps the
+ * centre exactly where it was: pull the right edge and the left edge comes with
+ * it. That is the whole of the symmetry — there are no two sides to keep in
+ * step, only one number.
+ *
+ * The handles live inside the scroller rather than beside it so that `50%` is
+ * the middle of the text and not of the whole pane, which the comments panel
+ * would otherwise shift them off. Sticky, so they stay against the visible area
+ * however far the document is scrolled.
+ */
+export function CanvasWidthHandles({
+  surfaceRef,
+}: {
+  /** The `.canvas-surface` element, which owns the width property. */
+  surfaceRef: RefObject<HTMLElement | null>;
+}): ReactElement {
+  const root = useRef<HTMLDivElement>(null);
+  const [dragging, setDragging] = useState(false);
+
+  useEffect(() => {
+    const surface = surfaceRef.current;
+    const stored = readStoredWidth();
+    if (surface && stored !== null) {
+      surface.style.setProperty(WIDTH_VARIABLE, `${stored}px`);
+    }
+  }, [surfaceRef]);
+
+  // The handles are one viewport tall, so the fade reads from end to end
+  // whatever the length of the document. Their own box is zero-height, so the
+  // height has to come from the scroller they are stuck to.
+  useEffect(() => {
+    const scroller = root.current?.parentElement;
+    if (!scroller) return;
+
+    const apply = (): void => {
+      root.current?.style.setProperty(HEIGHT_VARIABLE, `${scroller.clientHeight}px`);
+    };
+    apply();
+
+    const observer = new ResizeObserver(apply);
+    observer.observe(scroller);
+    return (): void => observer.disconnect();
+  }, []);
+
+  const setWidth = useCallback(
+    (width: number): void => {
+      const surface = surfaceRef.current;
+      const scroller = root.current?.parentElement;
+      if (!surface || !scroller) return;
+
+      // Never wider than the room there is, or the column would run under the
+      // gutter its drag handles live in.
+      const gutter = readNumber(surface, '--canvas-gutter', 54);
+      const room = Math.max(MIN_WIDTH, scroller.clientWidth - 2 * gutter);
+      const next = Math.round(Math.min(Math.max(width, MIN_WIDTH), Math.min(MAX_WIDTH, room)));
+      surface.style.setProperty(WIDTH_VARIABLE, `${next}px`);
+    },
+    [surfaceRef],
+  );
+
+  const currentWidth = useCallback((): number => {
+    const surface = surfaceRef.current;
+    return surface ? readNumber(surface, WIDTH_VARIABLE, DEFAULT_WIDTH) : DEFAULT_WIDTH;
+  }, [surfaceRef]);
+
+  const beginDrag = useCallback(
+    (side: -1 | 1) =>
+      (event: ReactPointerEvent<HTMLButtonElement>): void => {
+        if (event.button !== 0) return;
+        event.preventDefault();
+
+        const startX = event.clientX;
+        const startWidth = currentWidth();
+        setDragging(true);
+
+        const move = (moved: PointerEvent): void => {
+          // Twice the distance: the edge under the pointer moves by it, and the
+          // opposite edge mirrors it away from the unmoved centre.
+          setWidth(startWidth + 2 * side * (moved.clientX - startX));
+        };
+        const end = (): void => {
+          window.removeEventListener('pointermove', move);
+          setDragging(false);
+          storeWidth(currentWidth());
+        };
+
+        window.addEventListener('pointermove', move);
+        window.addEventListener('pointerup', end, { once: true });
+        window.addEventListener('pointercancel', end, { once: true });
+      },
+    [currentWidth, setWidth],
+  );
+
+  const reset = useCallback((): void => {
+    setWidth(DEFAULT_WIDTH);
+    storeWidth(null);
+  }, [setWidth]);
+
+  const nudge = useCallback(
+    (side: -1 | 1) =>
+      (event: React.KeyboardEvent<HTMLButtonElement>): void => {
+        const towards = event.key === 'ArrowLeft' ? -1 : event.key === 'ArrowRight' ? 1 : 0;
+        if (towards === 0) return;
+        event.preventDefault();
+        setWidth(currentWidth() + 2 * side * towards * KEYBOARD_STEP);
+        storeWidth(currentWidth());
+      },
+    [currentWidth, setWidth],
+  );
+
+  const handle = (side: -1 | 1): ReactElement => (
+    <button
+      type='button'
+      className={`canvas-width-handle canvas-width-handle--${side === -1 ? 'left' : 'right'}`}
+      aria-label='Resize the canvas width'
+      onPointerDown={beginDrag(side)}
+      onKeyDown={nudge(side)}
+      onDoubleClick={reset}
+      title='Drag to resize · double-click to reset'
+      data-track-category='CANVAS'
+      data-track-name='Resize_Canvas_Width'
+    />
+  );
+
+  return (
+    <div className='canvas-width-handles' ref={root} data-dragging={dragging ? 'true' : undefined}>
+      {handle(-1)}
+      {handle(1)}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
@@ -84,6 +84,8 @@ import { AnimatePresence } from 'framer-motion';
 
 import { CanvasInlineCommentThread } from '../CanvasInlineCommentThread/CanvasInlineCommentThread';
 import { createCanvasFormattingToolbar } from '../CanvasFormattingToolbar/CanvasFormattingToolbar';
+import { CanvasObjectToolbar } from '../CanvasObjectToolbar';
+import { CanvasWidthHandles } from '../CanvasWidthHandles';
 import { CanvasLinkToolbar, CanvasPastedLinkToolbar } from '../CanvasLinkToolbar';
 import { CanvasFilePanel } from '../CanvasFilePanel/CanvasFilePanel';
 import { useCanvasCommentEditorBridge } from '../useCanvasCommentEditorBridge';
@@ -561,6 +563,7 @@ export const CollaborativeCanvasEditor = forwardRef<
       openCommentsForCurrentBlock,
       focusCommentBlock,
       clearActiveCommentAnchor,
+      finishInlineCommentDraft,
       closeInlineCommentThread,
       applyCommentAnchorStyle,
       removeCommentAnchorStyle,
@@ -774,6 +777,7 @@ export const CollaborativeCanvasEditor = forwardRef<
               overflowWrap: 'break-word',
             }}
           >
+            <CanvasWidthHandles surfaceRef={containerRef} />
             <div
               className='blocknote-editor-wrapper w-full max-w-full'
               style={{
@@ -801,6 +805,12 @@ export const CollaborativeCanvasEditor = forwardRef<
                     onChange={handleCollaborativeChange}
                   >
                     <FormattingToolbarController formattingToolbar={canvasFormattingToolbar} />
+                    <CanvasObjectToolbar
+                      onAddComment={openCommentsForCurrentBlock}
+                      canComment={editable && !isReadOnly}
+                      {...(canvasId && { canvasId })}
+                      {...(title && { canvasTitle: title })}
+                    />
                     <LinkToolbarController linkToolbar={CanvasLinkToolbar} />
                     <CanvasPastedLinkToolbar />
                     <FilePanelController filePanel={CanvasFilePanel} />
@@ -846,7 +856,7 @@ export const CollaborativeCanvasEditor = forwardRef<
               editable={editable && !isReadOnly}
               onClose={closeInlineCommentThread}
               onBeforeCreateThread={applyCommentAnchorStyle}
-              onCreateThreadCreated={clearActiveCommentAnchor}
+              onCreateThreadCreated={finishInlineCommentDraft}
               onCreateThreadFailed={removeCommentAnchorStyle}
             />
           )}

--- a/apps/dashboard/src/components/Canvas/canvasSchema.ts
+++ b/apps/dashboard/src/components/Canvas/canvasSchema.ts
@@ -1,6 +1,5 @@
 import { BlockNoteSchema, defaultBlockSpecs, defaultInlineContentSpecs } from '@blocknote/core';
-import { createReactDiagramBlockSpec } from '@blocknote/diagram-block';
-import { createReactInlineMathSpec, createReactMathBlockSpec } from '@blocknote/math-block';
+import { createReactInlineMathSpec } from '@blocknote/math-block';
 import { Extension, type EditorOptions } from '@tiptap/core';
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
 import { Plugin, PluginKey, TextSelection, type Transaction } from '@tiptap/pm/state';
@@ -12,10 +11,13 @@ import { citationInlineContentSpec } from './CanvasCitationSpec';
 import { knownBlockTypesOf } from '../../utils/canvasUtils';
 import { canvasCommentThreadStyleSpec } from './CanvasCommentStyleSpec/CanvasCommentStyleSpec';
 import { canvasCodeBlockSpec } from './CanvasCodeBlockSpec';
+import { canvasDiagramBlockSpec } from './CanvasDiagramSpec';
+import { canvasMathBlockSpec } from './CanvasMathBlockSpec';
 import { CANVAS_EMBED_TYPE, canvasEmbedSpec } from './CanvasEmbedSpec';
 import { canvasFileBlockSpec } from './CanvasFileBlockSpec';
 import { canvasLinkShortcutsExtension } from './canvasLinkShortcuts';
 import { canvasPastedLinkExtension } from './canvasPastedLink';
+import { canvasSourceBlockShortcutsExtension } from './canvasSourceBlockShortcuts';
 import { canvasTableShortcutsExtension } from './canvasTableShortcuts';
 
 // Default blocks + whiteboard, then extended with mention and citation inline content.
@@ -26,8 +28,8 @@ import { canvasTableShortcutsExtension } from './canvasTableShortcuts';
 function createCanvasSchema() {
   return BlockNoteSchema.create({
     blockSpecs: Object.assign({}, defaultBlockSpecs, whiteboardBlockSpecs, {
-      diagram: createReactDiagramBlockSpec(),
-      mathBlock: createReactMathBlockSpec(),
+      diagram: canvasDiagramBlockSpec,
+      mathBlock: canvasMathBlockSpec,
       codeBlock: canvasCodeBlockSpec,
       [CANVAS_EMBED_TYPE]: canvasEmbedSpec,
       file: canvasFileBlockSpec,
@@ -280,6 +282,7 @@ export const canvasTiptapOptions = {
     canvasPastedLinkExtension,
     canvasLinkShortcutsExtension,
     canvasTableShortcutsExtension,
+    canvasSourceBlockShortcutsExtension,
   ],
   editorProps: {
     handleKeyDown: handleCanvasTableKeyDown,

--- a/apps/dashboard/src/components/Canvas/canvasSourceBlockShortcuts.ts
+++ b/apps/dashboard/src/components/Canvas/canvasSourceBlockShortcuts.ts
@@ -1,0 +1,617 @@
+import { Extension } from '@tiptap/core';
+import {
+  NodeSelection,
+  Plugin,
+  PluginKey,
+  Selection,
+  TextSelection,
+  type EditorState,
+  type Transaction,
+} from '@tiptap/pm/state';
+import type { Node as ProseMirrorNode, ResolvedPos } from '@tiptap/pm/model';
+import { Decoration, DecorationSet, type EditorView } from '@tiptap/pm/view';
+
+/** Blocks whose content is source text behind a rendered preview. */
+const SOURCE_BLOCK_TYPES = new Set(['mathBlock', 'diagram']);
+
+/**
+ * Blocks the reader treats as one thing: the source blocks above, embeds, code
+ * blocks — which includes the mermaid one, a code block showing a diagram — and
+ * dividers.
+ *
+ * Wider than SOURCE_BLOCK_TYPES because being *selected* as a whole and being
+ * *edited* as one are different questions. An embed holds no source to type
+ * into and ProseMirror already steps over and deletes it correctly as an atom;
+ * a code block is typed in constantly and must keep every key it has. Both need
+ * the click and the outline, neither needs the keymap.
+ *
+ * A divider is here for the outline alone. BlockNote draws nothing at all for a
+ * selected one, so there was no way to see what the next Backspace would take.
+ * It still gets no actions — see CanvasObjectToolbar — since a line holds
+ * nothing to quote or ask about.
+ */
+const OBJECT_BLOCK_TYPES = new Set([...SOURCE_BLOCK_TYPES, 'embed', 'codeBlock', 'divider']);
+
+/** The rendered previews a click may land on, per block kind. */
+const OBJECT_SELECTOR = '[data-canvas-math],[data-canvas-mermaid],[data-canvas-embed]';
+const SOURCE_SELECTOR = '[data-canvas-math],[data-canvas-mermaid]';
+
+type Dispatch = ((tr: Transaction) => void) | undefined;
+type Direction = 'up' | 'down' | 'left' | 'right';
+type Handler = (props: { editor: { state: EditorState; view: EditorView } }) => boolean;
+
+/** Which way a direction travels through the document. */
+const FORWARD: Record<Direction, boolean> = {
+  down: true,
+  right: true,
+  up: false,
+  left: false,
+};
+
+interface SourceBlock {
+  pos: number;
+  node: ProseMirrorNode;
+}
+
+/**
+ * Whether a block is one of the objects the arrows, Backspace and the letter
+ * shortcuts act on as a single thing.
+ *
+ * A code block joins them only while it is showing a preview instead of its
+ * source — which is what a mermaid code block is: a diagram whose source
+ * happens to be kept in a code block. A code block anyone types in never shows
+ * a preview, so every key it has stays its own; and a mermaid one with its
+ * source open is being edited, exactly as a diagram is while its source is up.
+ */
+function isSourceBlock(node: ProseMirrorNode, pos: number, view: EditorView): boolean {
+  if (SOURCE_BLOCK_TYPES.has(node.type.name)) return true;
+  return node.type.name === 'codeBlock' && isPreviewing(view, pos);
+}
+
+/** The diagram, equation or previewing code block containing a position. */
+function sourceBlockAround($pos: ResolvedPos, view: EditorView): SourceBlock | null {
+  for (let depth = $pos.depth; depth > 0; depth--) {
+    const node = $pos.node(depth);
+    const pos = $pos.before(depth);
+    if (isSourceBlock(node, pos, view)) {
+      return { pos, node };
+    }
+  }
+  return null;
+}
+
+/** The object block containing a position, if any. */
+function objectBlockAround($pos: ResolvedPos): SourceBlock | null {
+  for (let depth = $pos.depth; depth > 0; depth--) {
+    const node = $pos.node(depth);
+    if (OBJECT_BLOCK_TYPES.has(node.type.name)) {
+      return { pos: $pos.before(depth), node };
+    }
+  }
+  return null;
+}
+
+/**
+ * The object block a rendered element belongs to.
+ *
+ * An atom holds no positions inside itself, so a click on an embed resolves to
+ * the position beside it rather than within — which is why this looks at the
+ * node beside the resolved position as well as at the ancestors of it.
+ */
+function objectBlockAtDOM(view: EditorView, dom: Element): SourceBlock | null {
+  const pos = view.posAtDOM(dom, 0);
+  const inside = objectBlockAround(view.state.doc.resolve(pos));
+  if (inside) return inside;
+
+  for (const candidate of [pos, pos - 1]) {
+    if (candidate < 0) continue;
+    const node = view.state.doc.nodeAt(candidate);
+    if (node && OBJECT_BLOCK_TYPES.has(node.type.name)) return { pos: candidate, node };
+  }
+  return null;
+}
+
+/**
+ * The block whose source is being edited at a position.
+ *
+ * Wider than sourceBlockAround, which only counts a code block while it is
+ * showing its preview — and a source being edited is by definition not. Without
+ * this, Escape and Mod-a worked inside a diagram's source and did nothing
+ * inside the identical source of a mermaid code block.
+ */
+function openSourceBlockAround($pos: ResolvedPos, view: EditorView): SourceBlock | null {
+  for (let depth = $pos.depth; depth > 0; depth--) {
+    const node = $pos.node(depth);
+    const pos = $pos.before(depth);
+    if (SOURCE_BLOCK_TYPES.has(node.type.name)) return { pos, node };
+    const rendered = elementAt(view, pos);
+    if (
+      node.type.name === 'codeBlock' &&
+      rendered?.matches('[data-canvas-mermaid],[data-canvas-math]')
+    ) {
+      return { pos, node };
+    }
+  }
+  return null;
+}
+
+/** The code block containing a position — the mermaid one included. */
+function codeBlockAround($pos: ResolvedPos): SourceBlock | null {
+  for (let depth = $pos.depth; depth > 0; depth--) {
+    const node = $pos.node(depth);
+    if (node.type.name === 'codeBlock') return { pos: $pos.before(depth), node };
+  }
+  return null;
+}
+
+/** The selected node, when it is one of those objects. */
+function selectedSourceBlock(state: EditorState, view: EditorView): SourceBlock | null {
+  const { selection } = state;
+  if (!(selection instanceof NodeSelection)) return null;
+  if (!isSourceBlock(selection.node, selection.from, view)) return null;
+  return { pos: selection.from, node: selection.node };
+}
+
+/** The rendered element of the block at a position. */
+function elementAt(view: EditorView, pos: number): HTMLElement | null {
+  const dom = view.nodeDOM(pos);
+  const el = dom instanceof HTMLElement ? dom : ((dom as ChildNode | null)?.parentElement ?? null);
+  return el?.querySelector<HTMLElement>('[data-canvas-math],[data-canvas-mermaid]') ?? el;
+}
+
+/**
+ * Whether the block is showing its preview rather than its source. The source
+ * panel stays in the document while the preview is up — it is only clipped —
+ * so its class is what says which of the two the reader is looking at.
+ */
+function isPreviewing(view: EditorView, pos: number): boolean {
+  return Boolean(elementAt(view, pos)?.querySelector('.canvas-source-collapsed'));
+}
+
+/**
+ * The document position the caret would leave the current selection from,
+ * or null when the caret still has somewhere to go inside its own block.
+ *
+ * `endOfTextblock` is the editor's own answer to "is the caret against this
+ * edge", including the wrapped-line case that no amount of position arithmetic
+ * gets right — so a press only becomes navigation once the caret really is
+ * leaving.
+ */
+function exitPosition(state: EditorState, view: EditorView, direction: Direction): number | null {
+  const { selection } = state;
+  const forward = FORWARD[direction];
+
+  if (selection instanceof NodeSelection) {
+    return forward ? selection.to : selection.from;
+  }
+  if (!selection.empty || !view.endOfTextblock(direction)) return null;
+
+  const $from = selection.$from;
+  if ($from.depth === 0) return null;
+  return forward ? $from.after($from.depth) : $from.before($from.depth);
+}
+
+/** Inserts an empty line at a position and puts the caret in it. */
+function insertLineAt(state: EditorState, dispatch: Dispatch, at: number): boolean {
+  const container = state.doc.resolve(at).parent.type;
+  const paragraph =
+    container.contentMatch.defaultType?.createAndFill() ??
+    state.schema.nodes['paragraph']?.createAndFill();
+  if (!paragraph) return false;
+
+  if (dispatch) {
+    const tr = state.tr.insert(at, paragraph);
+    tr.setSelection(Selection.near(tr.doc.resolve(at), 1)).scrollIntoView();
+    dispatch(tr);
+  }
+  return true;
+}
+
+/**
+ * Arrow keys treat a diagram or equation as one object.
+ *
+ * Their source is only clipped while the preview shows, so stepping into it
+ * with a text cursor put the caret somewhere invisible. Moving onto one selects
+ * the whole block instead; moving off a selected block continues to wherever
+ * the editor would normally go. Anything that is not a move onto or off one of
+ * these blocks is left alone, so ordinary caret motion is untouched.
+ */
+function moveByArrow(direction: Direction) {
+  return (state: EditorState, dispatch: Dispatch, view: EditorView): boolean => {
+    const from = exitPosition(state, view, direction);
+    if (from === null) return false;
+
+    const clamped = Math.max(0, Math.min(from, state.doc.content.size));
+    const next = Selection.near(state.doc.resolve(clamped), FORWARD[direction] ? 1 : -1);
+
+    // The block being left, so arrowing out of one never lands back on it.
+    const leaving =
+      selectedSourceBlock(state, view)?.pos ?? sourceBlockAround(state.selection.$from, view)?.pos;
+
+    const target = sourceBlockAround(next.$from, view);
+    if (target && target.pos !== leaving) {
+      // Selecting is the whole action. A block left open closes itself once the
+      // caret is no longer inside it; clicking its button from here re-rendered
+      // React in the middle of the keypress and made the next arrow unreliable.
+      dispatch?.(
+        state.tr.setSelection(NodeSelection.create(state.doc, target.pos)).scrollIntoView(),
+      );
+      return true;
+    }
+
+    // A caret cannot leave a code block upwards on its own: the press does
+    // nothing at all, while downwards it leaves normally. `endOfTextblock` has
+    // already decided the caret is against the edge, so all that is left is to
+    // put it where the move lands — and only when that is outside the block, so
+    // a code block with nothing above it does not swallow its own caret.
+    const inCode = codeBlockAround(state.selection.$from);
+    if (inCode) {
+      const outside = next.from < inCode.pos || next.from > inCode.pos + inCode.node.nodeSize;
+      if (outside) {
+        dispatch?.(state.tr.setSelection(next).scrollIntoView());
+        return true;
+      }
+    }
+
+    const selected = selectedSourceBlock(state, view);
+    if (!selected) return false;
+
+    // Nowhere to go means the object is the first or last thing in the
+    // document, and there would be no way to write above or below it.
+    const $selected = state.doc.resolve(selected.pos);
+    const edge = FORWARD[direction]
+      ? $selected.after($selected.depth)
+      : $selected.before($selected.depth);
+    const stuck = next.from >= selected.pos && next.to <= selected.pos + selected.node.nodeSize;
+    if (stuck) {
+      return insertLineAt(state, dispatch, edge);
+    }
+
+    // Leaving a selected block: place the caret where the move lands, since a
+    // node selection has no caret for the editor to carry forward itself.
+    dispatch?.(state.tr.setSelection(next).scrollIntoView());
+    return true;
+  };
+}
+
+/**
+ * Shift+arrow extends across a whole diagram or equation in one press.
+ *
+ * Their source is clipped, so the default extension crawls through characters
+ * nobody can see — one press per character, with nothing appearing to happen.
+ * Taking the block whole matches how the plain arrows treat it as an object.
+ *
+ * Only the boundary is intercepted: inside a paragraph, or inside a source that
+ * is open for editing, shift+arrow selects text exactly as it always did.
+ */
+function extendByArrow(direction: Direction) {
+  return (state: EditorState, dispatch: Dispatch, view: EditorView): boolean => {
+    const forward = FORWARD[direction];
+    const { selection } = state;
+
+    // The end that moves, and the end that stays put.
+    const $head =
+      selection instanceof NodeSelection
+        ? state.doc.resolve(forward ? selection.to : selection.from)
+        : selection.$head;
+    const $anchor =
+      selection instanceof NodeSelection
+        ? state.doc.resolve(forward ? selection.from : selection.to)
+        : selection.$anchor;
+
+    // Inside a textblock the caret still has room, so leave it alone.
+    if (!(selection instanceof NodeSelection) && !view.endOfTextblock(direction)) {
+      return false;
+    }
+    if ($head.depth === 0) return false;
+
+    const edge = forward ? $head.after($head.depth) : $head.before($head.depth);
+    const clamped = Math.max(0, Math.min(edge, state.doc.content.size));
+    const next = Selection.near(state.doc.resolve(clamped), forward ? 1 : -1);
+
+    const target = sourceBlockAround(next.$from, view);
+    if (!target) return false;
+
+    // Past the block's *container*, not its content node. The content sits one
+    // position inside its wrapper, so stopping at the content's edge left the
+    // range one short of covering the block — and the outline, which asks
+    // whether the block is fully inside the selection, stayed off.
+    const $target = state.doc.resolve(target.pos);
+    const beyond = forward ? $target.after($target.depth) : $target.before($target.depth);
+    dispatch?.(
+      state.tr
+        .setSelection(TextSelection.between($anchor, state.doc.resolve(beyond)))
+        .scrollIntoView(),
+    );
+    return true;
+  };
+}
+
+/**
+ * Backspace inside a diagram or equation.
+ *
+ * BlockNote's default turns a non-paragraph block into a paragraph at its start
+ * and merges it upward, so an equation became its own raw LaTeX as plain text
+ * and further presses ate the block above. And while the preview is showing the
+ * source is only clipped, so Backspace silently chewed through characters the
+ * reader could not see. While the preview is up the block is one object and one
+ * press removes it; with the source open it edits normally.
+ */
+function backspace(state: EditorState, dispatch: Dispatch, view: EditorView): boolean {
+  const selected = selectedSourceBlock(state, view);
+  if (selected) {
+    dispatch?.(
+      state.tr.delete(selected.pos, selected.pos + selected.node.nodeSize).scrollIntoView(),
+    );
+    return true;
+  }
+
+  if (!state.selection.empty) return false;
+
+  const $from = state.selection.$from;
+  const block = sourceBlockAround($from, view);
+  if (!block) return false;
+
+  if (isPreviewing(view, block.pos) || block.node.textContent.length === 0) {
+    dispatch?.(state.tr.delete(block.pos, block.pos + block.node.nodeSize).scrollIntoView());
+    return true;
+  }
+
+  // Only the start boundary would convert the block; elsewhere delete normally.
+  return $from.parentOffset === 0;
+}
+
+/**
+ * Delete inside a diagram or equation.
+ *
+ * The mirror of backspace rather than the same handler: bound to it, Delete
+ * swallowed the key at the start of an open source — where backspace has a
+ * block conversion to prevent and Delete has nothing to prevent — and left the
+ * end alone, where BlockNote's default pulls the next block's text into the
+ * source. Only the boundary it can damage is claimed.
+ */
+function forwardDelete(state: EditorState, dispatch: Dispatch, view: EditorView): boolean {
+  const selected = selectedSourceBlock(state, view);
+  if (selected) {
+    dispatch?.(
+      state.tr.delete(selected.pos, selected.pos + selected.node.nodeSize).scrollIntoView(),
+    );
+    return true;
+  }
+
+  if (!state.selection.empty) return false;
+
+  const $from = state.selection.$from;
+  const block = sourceBlockAround($from, view);
+  if (!block) return false;
+
+  if (isPreviewing(view, block.pos) || block.node.textContent.length === 0) {
+    dispatch?.(state.tr.delete(block.pos, block.pos + block.node.nodeSize).scrollIntoView());
+    return true;
+  }
+
+  // Only the end boundary would pull the block below into this source;
+  // elsewhere the character to the right is deleted normally.
+  return $from.parentOffset === $from.parent.content.size;
+}
+
+/**
+ * Outlines every diagram or equation the selection covers.
+ *
+ * Keyed off what the selection *overlaps* rather than off one selection type:
+ * a node selection, a shift-extended range and select-all all have to light the
+ * same blocks. Keying it to NodeSelection alone was why a range covering a
+ * diagram showed nothing.
+ *
+ * It is a decoration rather than ProseMirror's own `ProseMirror-selectednode`
+ * class because that class is applied by the node view's selectNode(), which
+ * only runs when the selection changes — so an edit elsewhere in the document
+ * rebuilt the node view and silently dropped the outline while the block was
+ * still selected. Decorations are recomputed from state on every update.
+ */
+const selectionDecoration = new Plugin({
+  key: new PluginKey('canvasSourceBlockSelection'),
+  props: {
+    decorations(state: EditorState): DecorationSet | null {
+      const { from, to } = state.selection;
+      if (from === to) return null;
+
+      const decorations: Decoration[] = [];
+      state.doc.nodesBetween(from, to, (node, pos) => {
+        if (!OBJECT_BLOCK_TYPES.has(node.type.name)) return true;
+        const end = pos + node.nodeSize;
+        // Measured against the block's *content* span, not its node boundaries.
+        // A text selection cannot sit outside a textblock: its ends normalise to
+        // the nearest text position, which is inside the last block it reaches —
+        // so asking for the node to be covered could never be true for the block
+        // at the end of a range, and that block alone stayed unlit.
+        //
+        // A selection that stops short of both edges is someone editing the
+        // source, which must not outline the object around their cursor.
+        if (from <= pos + 1 && to >= end - 1) {
+          decorations.push(Decoration.node(pos, end, { class: 'canvas-object-selected' }));
+        }
+        return false;
+      });
+
+      return decorations.length > 0 ? DecorationSet.create(state.doc, decorations) : null;
+    },
+
+    /**
+     * Clicking a diagram or equation selects it, the way clicking an image
+     * does. That is what puts the block toolbar and its comment action on
+     * screen — those follow the selection, so a block that cannot be selected
+     * by clicking cannot be commented on either.
+     *
+     * On mousedown rather than ProseMirror's handleClickOn: the preview is a
+     * contenteditable=false subtree, and a click landing on (say) an SVG path
+     * inside a rendered diagram gives ProseMirror no document position to
+     * resolve, so handleClickOn never fires there.
+     */
+    handleDOMEvents: {
+      mousedown(view: EditorView, event: MouseEvent): boolean {
+        if (event.button !== 0) return false;
+
+        const target = event.target;
+        const el = target instanceof Element ? target : null;
+        // The block's own controls, and its open source, keep their clicks.
+        if (!el || el.closest('button')) return false;
+
+        const block = el.closest(OBJECT_SELECTOR);
+        if (!block) return false;
+        // A source block only takes the click while its preview is up; with the
+        // source open the caret belongs in it.
+        if (block.matches(SOURCE_SELECTOR) && !block.querySelector('.canvas-source-collapsed')) {
+          return false;
+        }
+
+        const around = objectBlockAtDOM(view, block);
+        if (!around) return false;
+
+        // Already selected means the reader is asking for the thing itself —
+        // the link an embed shows, the frame it plays in — so the second click
+        // is left to the block's own handlers.
+        const { selection } = view.state;
+        if (selection instanceof NodeSelection && selection.from === around.pos) return false;
+
+        event.preventDefault();
+        // Without this the card underneath opens the link on the same click:
+        // React listens at the root of the app, above the editor, so its
+        // handler would still run after this one.
+        event.stopPropagation();
+        view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, around.pos)));
+        // The preview is contenteditable=false, so without focus the editor
+        // re-syncs its selection from the browser's a moment later and the node
+        // selection silently becomes a caret inside the clipped source — where
+        // the arrow keys then move between invisible lines.
+        view.focus();
+        return true;
+      },
+    },
+  },
+});
+
+/**
+ * A diagram or equation showing its preview must never hold a bare text cursor.
+ *
+ * Its source is only clipped, so a caret can be left sitting in it invisibly —
+ * deleting the line below one lands there, for instance. Nothing appears
+ * selected, and the next Backspace looks like it deletes the block out of
+ * nowhere. Turning that caret into a selection of the block makes what is about
+ * to be acted on visible, and is what the reader means by "I'm on it".
+ *
+ * Only while the preview is up: with the source open the caret belongs there.
+ */
+const normaliseStrayCaret = new Plugin({
+  key: new PluginKey('canvasSourceBlockCaret'),
+  view() {
+    return {
+      update(view: EditorView) {
+        const { state } = view;
+        if (!state.selection.empty) return;
+
+        const block = sourceBlockAround(state.selection.$from, view);
+        if (!block || !isPreviewing(view, block.pos)) return;
+
+        view.dispatch(state.tr.setSelection(NodeSelection.create(state.doc, block.pos)));
+      },
+    };
+  },
+});
+
+export const canvasSourceBlockShortcutsExtension = Extension.create({
+  name: 'canvasSourceBlockShortcuts',
+  // Above the defaults: with a block selected, `p` and `c` are claimed by the
+  // editor's own typing behaviour unless these run first.
+  priority: 1000,
+  addProseMirrorPlugins() {
+    return [selectionDecoration, normaliseStrayCaret];
+  },
+  addKeyboardShortcuts() {
+    const run =
+      (command: (state: EditorState, dispatch: Dispatch, view: EditorView) => boolean): Handler =>
+      ({ editor }) =>
+        command(editor.state, editor.view.dispatch.bind(editor.view), editor.view);
+
+    return {
+      Backspace: run(backspace),
+      Delete: run(forwardDelete),
+      ArrowDown: run(moveByArrow('down')),
+      ArrowUp: run(moveByArrow('up')),
+      ArrowRight: run(moveByArrow('right')),
+      ArrowLeft: run(moveByArrow('left')),
+
+      'Shift-ArrowDown': run(extendByArrow('down')),
+      'Shift-ArrowUp': run(extendByArrow('up')),
+      'Shift-ArrowRight': run(extendByArrow('right')),
+      'Shift-ArrowLeft': run(extendByArrow('left')),
+
+      // Enter leaves the object and starts a new line after it, as in any
+      // document editor. Editing is the pencil on the block itself; binding
+      // Enter to it would cost the key its normal meaning.
+      Enter: ({ editor }) => {
+        const { state } = editor;
+        if (!selectedSourceBlock(state, editor.view)) return false;
+
+        // After the block's *container*, not after its content node: the
+        // content sits inside a wrapper, so inserting at the end of the content
+        // put the new line inside the block instead of between it and the next.
+        const $from = state.selection.$from;
+        return insertLineAt(
+          state,
+          editor.view.dispatch.bind(editor.view),
+          $from.after($from.depth),
+        );
+      },
+
+      // The two keys the package's own preview extension would have given these
+      // blocks. That extension is deliberately not enabled — with hasPreview set
+      // it also installs a capture-phase handler that swallows every printable
+      // character for a block whose popup is closed, and these blocks edit in
+      // place rather than through that popup, so their source would take no
+      // typing at all. Its Escape and Mod-a are gated on that same popup, so
+      // they are bound here instead.
+      Escape: ({ editor }) => {
+        const block = openSourceBlockAround(editor.state.selection.$from, editor.view);
+        if (!block || isPreviewing(editor.view, block.pos)) return false;
+        editor.view.dispatch(
+          editor.state.tr.setSelection(NodeSelection.create(editor.state.doc, block.pos)),
+        );
+        return true;
+      },
+
+      // Select this block's source, not the whole document.
+      'Mod-a': ({ editor }) => {
+        const { state } = editor;
+        const block = openSourceBlockAround(state.selection.$from, editor.view);
+        if (!block || isPreviewing(editor.view, block.pos)) return false;
+        const $from = state.selection.$from;
+        editor.view.dispatch(
+          state.tr.setSelection(TextSelection.create(state.doc, $from.start(), $from.end())),
+        );
+        return true;
+      },
+
+      // Diagrams open their enlarged preview. Through the toolbar's own button
+      // rather than the drawing: in a canvas a click on the diagram selects the
+      // block instead of enlarging it, so the drawing has no handler to fire.
+      p: ({ editor }) => {
+        const selected = selectedSourceBlock(editor.state, editor.view);
+        if (!selected) return false;
+        const block = elementAt(editor.view, selected.pos);
+        const open =
+          block?.querySelector<HTMLElement>('[data-track-name="OPEN_PREVIEW"]') ??
+          block?.querySelector<HTMLElement>('.mermaid-diagram');
+        open?.click();
+        return true;
+      },
+
+      c: ({ editor }) => {
+        const selected = selectedSourceBlock(editor.state, editor.view);
+        if (!selected) return false;
+        void navigator.clipboard?.writeText(selected.node.textContent);
+        return true;
+      },
+    };
+  },
+});

--- a/apps/dashboard/src/components/Canvas/useCanvasCommentEditorBridge.ts
+++ b/apps/dashboard/src/components/Canvas/useCanvasCommentEditorBridge.ts
@@ -4,6 +4,7 @@ import type {
   InlineContentSchema,
   StyleSchema,
 } from '@blocknote/core';
+import { NodeSelection } from '@tiptap/pm/state';
 import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
 import { toast } from 'sonner';
 
@@ -40,15 +41,36 @@ export type CanvasInlineCommentThreadState =
     }
   | null;
 
+/** The selected node, on the selections that have one (ProseMirror's NodeSelection). */
+interface SelectedNodeLike {
+  textContent: string;
+  attrs: Record<string, unknown>;
+  type: { name: string };
+}
+
 interface TiptapEditorLike {
   state: {
-    selection: { from: number; to: number; empty?: boolean };
+    selection: { from: number; to: number; empty?: boolean; node?: SelectedNodeLike };
     doc: { textBetween: (from: number, to: number, blockSeparator?: string) => string };
   };
   commands: {
     setTextSelection: (range: { from: number; to: number }) => boolean;
   };
 }
+
+/**
+ * What a comment on a block with no text is anchored to.
+ *
+ * An embed is a whole block that holds no characters, so there is no quoted
+ * text to hang the thread on — and the thread is refused without one. The link
+ * it shows is what the reader means by "this", so that is the quote.
+ */
+const anchorTextForNode = (node: SelectedNodeLike | undefined): string => {
+  if (!node) return '';
+  if (node.textContent.trim().length > 0) return node.textContent.trim();
+  const url: unknown = node.attrs['url'];
+  return typeof url === 'string' && url.length > 0 ? url : node.type.name;
+};
 
 const getTiptapEditor = (editor: CanvasEditorLike): TiptapEditorLike | null =>
   ((editor as unknown as { _tiptapEditor?: unknown })._tiptapEditor as
@@ -66,22 +88,47 @@ const closeFormattingToolbar = (editor: CanvasEditorLike): void => {
   }
 };
 
-const getSelectionRect = (container: HTMLElement | null, blockId: string): DOMRect | null => {
-  const selection = window.getSelection();
-  if (selection && selection.rangeCount > 0) {
-    const rect = selection.getRangeAt(0).getBoundingClientRect();
-    if (rect.width > 0 || rect.height > 0) return rect;
-  }
-
+const getSelectionRect = (
+  container: HTMLElement | null,
+  blockId: string,
+  preferBlockRect = false,
+): DOMRect | null => {
   const escapedBlockId =
     typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
       ? CSS.escape(blockId)
       : blockId.replace(/["\\]/g, '\\$&');
-  return (
-    container
-      ?.querySelector<HTMLElement>(`[data-id="${escapedBlockId}"]`)
-      ?.getBoundingClientRect() ?? null
-  );
+  const blockElement =
+    container?.querySelector<HTMLElement>(`[data-id="${escapedBlockId}"]`) ?? null;
+
+  // A whole-block selection has no text range to measure, and the browser's own
+  // selection stays wherever the caret last was — which put the thread there
+  // instead of on the block. Pressing the button moves it again, so the block's
+  // own rect is the only stable answer.
+  if (!preferBlockRect) {
+    const selection = window.getSelection();
+    if (selection && selection.rangeCount > 0) {
+      const range = selection.getRangeAt(0);
+      const rect = range.getBoundingClientRect();
+      // The range has to be in the document, not merely inside the one block the
+      // cursor is in: a selection spanning two paragraphs has the editor itself
+      // as its common ancestor, and requiring the block would throw such a
+      // selection back onto the whole block's rect — a long way from the text
+      // that was highlighted.
+      const container = blockElement?.closest('.bn-editor') ?? blockElement;
+      const insideEditor = container?.contains(range.commonAncestorContainer) ?? false;
+      if (insideEditor && (rect.width > 0 || rect.height > 0)) return rect;
+    }
+  }
+
+  const blockRect = blockElement?.getBoundingClientRect() ?? null;
+  if (!blockRect) return null;
+
+  // The card opens beside the anchor, so a diagram's full height put it a
+  // screen away from the Ask AI / Comment pill that was just pressed. The pill
+  // sits on the block's top edge; collapsing the anchor to that edge is what
+  // brings the two together.
+  if (preferBlockRect) return new DOMRect(blockRect.left, blockRect.top, blockRect.width, 0);
+  return blockRect;
 };
 
 const escapeSelectorValue = (value: string): string =>
@@ -269,7 +316,9 @@ export function useCanvasCommentEditorBridge({
       if (!blockId || !tiptapEditor || tiptapEditor.state.selection.empty) return null;
 
       const { from, to } = tiptapEditor.state.selection;
-      const anchorText = tiptapEditor.state.doc.textBetween(from, to, ' ').trim();
+      const anchorText =
+        tiptapEditor.state.doc.textBetween(from, to, ' ').trim() ||
+        anchorTextForNode(tiptapEditor.state.selection.node);
       if (!anchorText) return null;
 
       return {
@@ -296,6 +345,13 @@ export function useCanvasCommentEditorBridge({
       try {
         const tiptapEditor = getTiptapEditor(editor);
         if (!tiptapEditor) return false;
+        // A block with no characters — an embed — has nothing to highlight.
+        // The thread still belongs to it through its block id, so this reports
+        // success rather than refusing the comment outright.
+        const highlightable = tiptapEditor.state.doc
+          .textBetween(anchor.selectionFrom, anchor.selectionTo, ' ')
+          .trim();
+        if (!highlightable) return true;
         tiptapEditor.commands.setTextSelection({
           from: anchor.selectionFrom,
           to: anchor.selectionTo,
@@ -351,7 +407,14 @@ export function useCanvasCommentEditorBridge({
     setActiveCommentBlockId(blockId);
     setActiveCommentThreadId(null);
     if (anchor?.blockId === blockId) {
-      const rect = getSelectionRect(containerRef.current, blockId);
+      const currentEditor = getEditor();
+      const tiptapEditor = currentEditor ? getTiptapEditor(currentEditor) : null;
+      const selection = tiptapEditor?.state.selection;
+      // instanceof, not the constructor's name: minification renames the class,
+      // so a name test is always false in a production build — which silently
+      // put this back on the caret, the very thing it exists to avoid.
+      const wholeBlockSelected = selection instanceof NodeSelection;
+      const rect = getSelectionRect(containerRef.current, blockId, wholeBlockSelected);
       setIsCommentsOpen(false);
       setActiveCommentAnchor(anchor);
       if (rect) {
@@ -395,6 +458,19 @@ export function useCanvasCommentEditorBridge({
     setActiveCommentThreadId(null);
   }, []);
 
+  /**
+   * The draft card has done its job the moment the comment exists.
+   *
+   * It used to stay open showing the thread it had just created, so every
+   * comment left a card sitting over the document until something else was
+   * clicked. The comment is on the block, in the highlight and in the panel —
+   * there is nothing left for the card to say.
+   */
+  const finishInlineCommentDraft = useCallback((): void => {
+    clearActiveCommentAnchor();
+    setInlineCommentThread(null);
+  }, [clearActiveCommentAnchor]);
+
   const closeInlineCommentThread = useCallback((): void => {
     setInlineCommentThread(null);
     setActiveCommentThreadId(null);
@@ -411,6 +487,7 @@ export function useCanvasCommentEditorBridge({
     openCommentsForCurrentBlock,
     focusCommentBlock,
     clearActiveCommentAnchor,
+    finishInlineCommentDraft,
     closeInlineCommentThread,
     applyCommentAnchorStyle,
     removeCommentAnchorStyle,

--- a/apps/dashboard/src/components/Canvas/useRemoveWhenAbandoned.ts
+++ b/apps/dashboard/src/components/Canvas/useRemoveWhenAbandoned.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+/**
+ * Holds a callback so an effect can call the latest one without listing it as a
+ * dependency. A block spec rebuilds its callbacks on every render, and an
+ * effect keyed on their identity would tear down and re-add its document
+ * listener for every keystroke anywhere in the canvas.
+ */
+function useLatest<T>(value: T): RefObject<T> {
+  const ref = useRef(value);
+  ref.current = value;
+  return ref;
+}
+
+/**
+ * A block inserted from the slash menu and then abandoned should not be left
+ * behind as an empty shell. Clicking away from one whose source is still empty
+ * removes it, the way an untouched list item disappears.
+ *
+ * Guarded on emptiness so a block with content is never removed by a stray
+ * click, and it listens on mousedown so the removal happens before the editor
+ * moves the selection into whatever was clicked.
+ */
+export function useRemoveWhenAbandoned(
+  root: RefObject<HTMLElement | null>,
+  isEmpty: boolean,
+  remove: () => void,
+): void {
+  const latestRemove = useLatest(remove);
+
+  useEffect(() => {
+    if (!isEmpty) return;
+
+    const onPointerDown = (event: MouseEvent): void => {
+      const target = event.target;
+      if (target instanceof Node && root.current?.contains(target)) return;
+      latestRemove.current();
+    };
+
+    document.addEventListener('mousedown', onPointerDown, true);
+    return () => document.removeEventListener('mousedown', onPointerDown, true);
+  }, [root, isEmpty, latestRemove]);
+}
+
+/**
+ * Closes the source panel once the caret leaves the block, so a diagram or
+ * equation goes back to being an object as soon as you move on. Without it a
+ * block stayed open for the rest of the session unless its tick was clicked —
+ * and an open block takes the caret instead of being selected, so it never
+ * highlighted again.
+ */
+export function useCollapseWhenLeft(
+  root: RefObject<HTMLElement | null>,
+  editing: boolean,
+  collapse: () => void,
+): void {
+  const latestCollapse = useLatest(collapse);
+
+  useEffect(() => {
+    if (!editing) return;
+
+    const onSelectionChange = (): void => {
+      const anchor = document.getSelection()?.anchorNode;
+      // No selection at all means focus went somewhere that is not the editor;
+      // leave the block open rather than closing it behind the reader's back.
+      if (!anchor || root.current?.contains(anchor)) return;
+      // A re-render (a diagram re-parsing as it is typed) briefly detaches the
+      // node the selection points at. That is not the caret leaving.
+      if (!anchor.isConnected) return;
+      latestCollapse.current();
+    };
+
+    document.addEventListener('selectionchange', onSelectionChange);
+    return () => document.removeEventListener('selectionchange', onSelectionChange);
+  }, [root, editing, latestCollapse]);
+}

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/XyneAISidebar.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/XyneAISidebar.tsx
@@ -65,7 +65,11 @@ import {
   toAttachedContext,
   attachedContextToSelections,
 } from './components/ContextPickerPanel';
-import { MessageItem, ConversationToolInvocationsContext } from './components/MessageItem';
+import {
+  MessageItem,
+  ConversationToolInvocationsContext,
+  type EditedMessageContext,
+} from './components/MessageItem';
 import { ConversationHistory } from './components/ConversationHistory';
 import { XyneAIHeader } from './components/XyneAIHeader';
 import { XyneAIOnboardingHeader } from './components/XyneAIOnboardingHeader';
@@ -1643,7 +1647,11 @@ const XyneAISidebar = ({
   // follow-up before reload, flattens after). The JAF v1 path infers the
   // same intent from `parentMessageId`, so the extra params are no-ops there.
   const handleEditMessage = useCallback(
-    async (messageId: string, newContent: string): Promise<void> => {
+    async (
+      messageId: string,
+      newContent: string,
+      editedContext?: EditedMessageContext,
+    ): Promise<void> => {
       if (isActiveSessionStreaming) return;
 
       const messageToEdit = messages.find((m: Message) => m.id === messageId);
@@ -1653,11 +1661,21 @@ const XyneAISidebar = ({
 
       const editedParentAssistant = messageToEdit.parentId ?? undefined;
 
+      // An edit that dropped a context card must re-run without it. `undefined`
+      // means the editor never offered the choice (mobile), so the original
+      // still stands; an empty list means the reader removed everything.
+      const editedAttachments = editedContext
+        ? (editedContext.attachments ?? [])
+        : (messageToEdit.attachments ?? []);
+      const editedSelectionContexts = editedContext
+        ? editedContext.selectionContexts
+        : messageToEdit.selectionContexts;
+
       // Submit with new content, parentId = original message's parent (creates sibling branch)
       await submitQuery(
         newContent,
-        messageToEdit.attachments ?? [],
-        messageToEdit.selectionContexts,
+        editedAttachments,
+        editedSelectionContexts,
         newContent,
         undefined, // userTags — not needed for edit
         editedParentAssistant,
@@ -1830,14 +1848,36 @@ const XyneAISidebar = ({
     const userTagsForMessage =
       Object.keys(currentUserTags).length > 0 ? currentUserTags : undefined;
 
-    await submitQuery(
-      query,
-      messageAttachments,
-      selectionContexts,
-      displayContent,
-      userTagsForMessage,
-      parentMessageId,
-    );
+    try {
+      await submitQuery(
+        query,
+        messageAttachments,
+        selectionContexts,
+        displayContent,
+        userTagsForMessage,
+        parentMessageId,
+      );
+    } finally {
+      // The attachment belongs to the message it was sent with, not to the
+      // conversation: the sent message carries its own copy of attachedContext
+      // (persisted server-side — it is what the history pills and
+      // edit/regenerate read), so clearing the composer changes nothing already
+      // said. Left in place it silently steered every later answer, and nothing
+      // ever removed it.
+      //
+      // In a finally: a send that throws is exactly when the context must not
+      // be left behind, since the turn it belonged to never happened.
+      setSelectedChannels([]);
+      setSelectedTickets([]);
+      setSelectedCanvases([]);
+      setSelectedTranscripts([]);
+      setSelectedRecordings([]);
+      setActiveSelectionInfos([]);
+      processedSelectionKeysRef.current.clear();
+      // The machine holds the canvas selections that feed the list above;
+      // without this its next update would put them straight back.
+      xyneAIActor.send({ type: 'CLEAR_SELECTIONS' });
+    }
   }, [
     inputValue,
     attachments,
@@ -2266,8 +2306,8 @@ const XyneAISidebar = ({
                                   }
                                   onEditSubmit={
                                     !isLegacyConversation && isLatestUserMessage
-                                      ? (newContent: string) =>
-                                          void handleEditMessage(message.id, newContent)
+                                      ? (newContent: string, context?: EditedMessageContext) =>
+                                          void handleEditMessage(message.id, newContent, context)
                                       : undefined
                                   }
                                   onEditMobile={

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/MessageItem.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/MessageItem.tsx
@@ -20,6 +20,7 @@ import {
   Loader2,
   Bug,
   AlertTriangle,
+  X,
 } from 'lucide-react';
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
@@ -663,6 +664,20 @@ interface MessageActionsProps {
     | undefined;
 }
 
+/**
+ * What an edited message keeps of what was sent with it.
+ *
+ * An edit re-runs the turn, so the canvas selections and files attached to the
+ * original ride along again unless they are dropped here. Editing was the only
+ * place they could not be removed — the composer's pills are gone by the time
+ * the message exists — which left "ask about this diagram" stuck to every retry
+ * of that turn.
+ */
+export interface EditedMessageContext {
+  selectionContexts: SelectionContext[] | undefined;
+  attachments: MessageAttachment[] | undefined;
+}
+
 interface MessageItemProps {
   message: Message;
   onFeedback: (messageId: string, feedbackType: 'LIKE' | 'DISLIKE') => void;
@@ -680,7 +695,7 @@ interface MessageItemProps {
     | ((messageId: string, feedback: 0 | 1 | 2, comment?: string | null) => void)
     | undefined;
   onRegenerate?: (() => void) | undefined;
-  onEditSubmit?: ((newContent: string) => void) | undefined;
+  onEditSubmit?: ((newContent: string, context?: EditedMessageContext) => void) | undefined;
   onEditMobile?: (() => void) | undefined;
   isLatestBotMessage?: boolean | undefined;
   branchInfo?: { index: number; total: number } | undefined;
@@ -996,14 +1011,21 @@ export const AttachmentPreview = ({
 };
 
 // Selection context preview component
+/**
+ * One card of context on a user message. `onRemove` is only passed while the
+ * message is being edited — a sent message's own record of what it carried is
+ * not editable, so the card is read-only everywhere else.
+ */
 const SelectionContextPreview = ({
   selection,
   onClick,
+  onRemove,
 }: {
   selection: SelectionContext;
   onClick?: () => void;
+  onRemove?: () => void;
 }): ReactElement => {
-  return (
+  const card = (
     <button
       type='button'
       onClick={onClick}
@@ -1022,6 +1044,27 @@ const SelectionContextPreview = ({
         <span className="text-sm text-foreground font-['Inter'] truncate">{selection.preview}</span>
       </div>
     </button>
+  );
+
+  if (!onRemove) return card;
+
+  // A sibling rather than a child: the card is itself a button, and a button
+  // inside a button is neither valid markup nor reliably clickable.
+  return (
+    <div className='relative'>
+      {card}
+      <button
+        type='button'
+        onClick={onRemove}
+        className='absolute right-1 top-1 rounded p-1 text-muted-foreground transition-colors hover:bg-background hover:text-foreground'
+        title='Remove this context'
+        aria-label='Remove this context'
+        data-track-category='XyneAI'
+        data-track-name='EDIT_REMOVE_SELECTION_CONTEXT'
+      >
+        <X size={12} />
+      </button>
+    </div>
   );
 };
 
@@ -1096,7 +1139,30 @@ export const MessageItem = React.memo(
     const [copied, setCopied] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
     const [editText, setEditText] = useState('');
+    // What the edit will re-send. Seeded from the message when editing starts
+    // and narrowed by the × on each card, so cancelling leaves the sent message
+    // exactly as it was.
+    const [editSelectionContexts, setEditSelectionContexts] = useState<SelectionContext[]>([]);
+    const [editAttachments, setEditAttachments] = useState<MessageAttachment[]>([]);
     const editTextareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+    const startEditing = useCallback((): void => {
+      setEditText(message.content);
+      setEditSelectionContexts(message.selectionContexts ?? []);
+      setEditAttachments(message.attachments ?? []);
+      setIsEditing(true);
+      setTimeout(() => editTextareaRef.current?.focus(), 0);
+    }, [message.attachments, message.content, message.selectionContexts]);
+
+    const submitEdit = useCallback((): void => {
+      const trimmed = editText.trim();
+      if (!trimmed) return;
+      onEditSubmit?.(trimmed, {
+        selectionContexts: editSelectionContexts.length > 0 ? editSelectionContexts : undefined,
+        attachments: editAttachments.length > 0 ? editAttachments : undefined,
+      });
+      setIsEditing(false);
+    }, [editAttachments, editSelectionContexts, editText, onEditSubmit]);
     const navigate = useNavigate();
 
     // Resolve `@name` against this message's userTags + the live workspace
@@ -1200,9 +1266,7 @@ export const MessageItem = React.memo(
               if (onEditMobile) {
                 onEditMobile();
               } else {
-                setEditText(message.content);
-                setIsEditing(true);
-                setTimeout(() => editTextareaRef.current?.focus(), 0);
+                startEditing();
               }
             }}
             className='self-start mt-2 p-1 rounded opacity-0 group-hover/message:opacity-100 transition-opacity hover:bg-accent flex-shrink-0'
@@ -1240,6 +1304,47 @@ export const MessageItem = React.memo(
             {message.type === 'user' && isEditing ? (
               /* Inline edit mode */
               <div className='flex flex-col gap-2'>
+                {/* The context this turn was sent with, each card droppable.
+                    Shown here and nowhere else: this is the one moment the turn
+                    is about to run again and its context can still change. */}
+                {editSelectionContexts.length > 0 && (
+                  <div className='space-y-2'>
+                    {editSelectionContexts.map((selection, index) => (
+                      <SelectionContextPreview
+                        key={`${selection.canvasId}-${index}`}
+                        selection={selection}
+                        onClick={() => handleSelectionContextClick(selection.canvasId)}
+                        onRemove={() =>
+                          setEditSelectionContexts(previous =>
+                            previous.filter((_, at) => at !== index),
+                          )
+                        }
+                      />
+                    ))}
+                  </div>
+                )}
+                {editAttachments.length > 0 && (
+                  <div className='space-y-2'>
+                    {editAttachments.map((attachment, index) => (
+                      <div className='relative' key={`${attachment.filename}-${index}`}>
+                        <AttachmentPreview attachment={attachment} />
+                        <button
+                          type='button'
+                          onClick={() =>
+                            setEditAttachments(previous => previous.filter((_, at) => at !== index))
+                          }
+                          className='absolute right-1 top-1 rounded p-1 text-muted-foreground transition-colors hover:bg-background hover:text-foreground'
+                          title='Remove this attachment'
+                          aria-label='Remove this attachment'
+                          data-track-category='XyneAI'
+                          data-track-name='EDIT_REMOVE_ATTACHMENT'
+                        >
+                          <X size={12} />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
                 <textarea
                   ref={editTextareaRef}
                   value={editText}
@@ -1247,10 +1352,7 @@ export const MessageItem = React.memo(
                   onKeyDown={e => {
                     if (e.key === 'Enter' && !e.shiftKey) {
                       e.preventDefault();
-                      if (editText.trim()) {
-                        onEditSubmit?.(editText.trim());
-                        setIsEditing(false);
-                      }
+                      submitEdit();
                     }
                     if (e.key === 'Escape') {
                       setIsEditing(false);
@@ -1271,12 +1373,7 @@ export const MessageItem = React.memo(
                     Cancel
                   </button>
                   <button
-                    onClick={() => {
-                      if (editText.trim()) {
-                        onEditSubmit?.(editText.trim());
-                        setIsEditing(false);
-                      }
-                    }}
+                    onClick={submitEdit}
                     data-ph-capture-attribute-track-id='edit_message_submit'
                     disabled={!editText.trim()}
                     className="px-3 py-1.5 text-xs font-medium rounded-full bg-foreground text-background hover:opacity-90 transition-opacity disabled:opacity-50 font-['Inter']"

--- a/apps/dashboard/src/components/Markdown/MermaidBlock/MermaidBlock.tsx
+++ b/apps/dashboard/src/components/Markdown/MermaidBlock/MermaidBlock.tsx
@@ -1,6 +1,16 @@
 import { useEffect, useRef, useState, memo, type ReactElement } from 'react';
 import mermaid from 'mermaid';
-import { Code2, Image as ImageIcon, Download, Copy, Check, X } from 'lucide-react';
+import {
+  Code2,
+  Image as ImageIcon,
+  Download,
+  Copy,
+  Check,
+  X,
+  Pencil,
+  Maximize2,
+  Trash2,
+} from 'lucide-react';
 import { Dialog } from '../../ui/Dialog/Dialog';
 import { type MermaidBlockProps, type ViewMode } from './MermaidBlock.types';
 import {
@@ -61,6 +71,9 @@ const MermaidBlockComponent = ({
   chart,
   messageId,
   controlsOnHover = false,
+  onEdit,
+  onDelete,
+  previewOnClick = true,
 }: MermaidBlockProps): ReactElement => {
   const isDark = useIsDarkTheme();
   const elementRef = useRef<HTMLDivElement>(null);
@@ -151,39 +164,38 @@ const MermaidBlockComponent = ({
           <div className='flex items-center gap-1 bg-background/90 backdrop-blur-sm rounded-lg shadow-sm border border-border p-1'>
             <button
               onClick={() => setViewMode('diagram')}
-              className={`flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors ${
+              className={`flex items-center rounded p-1.5 transition-colors ${
                 viewMode === 'diagram'
-                  ? 'bg-blue-100 text-blue-700 mermaid-tab-active'
+                  ? 'mermaid-tab-active'
                   : 'text-muted-foreground hover:bg-accent'
               }`}
               title='View diagram'
+              aria-label='View diagram'
               data-track-category='Mermaid'
               data-track-name='VIEW_DIAGRAM'
             >
               <ImageIcon className='w-3 h-3' />
-              Diagram
             </button>
             <button
               onClick={() => setViewMode('code')}
-              className={`flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors ${
-                viewMode === 'code'
-                  ? 'bg-blue-100 text-blue-700 mermaid-tab-active'
-                  : 'text-muted-foreground hover:bg-accent'
+              className={`flex items-center rounded p-1.5 transition-colors ${
+                viewMode === 'code' ? 'mermaid-tab-active' : 'text-muted-foreground hover:bg-accent'
               }`}
               title='View code'
+              aria-label='View code'
               data-track-category='Mermaid'
               data-track-name='VIEW_CODE'
             >
               <Code2 className='w-3 h-3' />
-              Code
             </button>
 
             {/* Download Button (only in diagram mode) */}
             {viewMode === 'diagram' && (
               <button
                 onClick={handleDownloadImage}
-                className='flex items-center gap-1 px-2 py-1 rounded text-xs font-medium text-muted-foreground hover:bg-accent transition-colors'
+                className='flex items-center rounded p-1.5 text-muted-foreground hover:bg-accent transition-colors'
                 title='Download as PNG'
+                aria-label='Download as PNG'
                 data-track-category='Mermaid'
                 data-track-name='DOWNLOAD_PNG'
               >
@@ -195,22 +207,56 @@ const MermaidBlockComponent = ({
             {viewMode === 'code' && (
               <button
                 onClick={() => void handleCopyCode()}
-                className='flex items-center gap-1 px-2 py-1 rounded text-xs font-medium text-muted-foreground hover:bg-accent transition-colors'
+                className='flex items-center rounded p-1.5 text-muted-foreground hover:bg-accent transition-colors'
                 title='Copy code'
+                aria-label='Copy code'
                 data-track-category='Mermaid'
                 data-track-name='COPY_CODE'
               >
                 {copied ? (
-                  <>
-                    <Check className='w-3 h-3 text-green-600' />
-                    <span className='text-green-600'>Copied!</span>
-                  </>
+                  <Check className='w-3 h-3 text-green-600' />
                 ) : (
-                  <>
-                    <Copy className='w-3 h-3' />
-                    Copy
-                  </>
+                  <Copy className='w-3 h-3' />
                 )}
+              </button>
+            )}
+
+            {!previewOnClick && viewMode === 'diagram' && (
+              <button
+                onClick={() => setShowPreview(true)}
+                className='flex items-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent'
+                title='Open preview'
+                aria-label='Open preview'
+                data-track-category='Mermaid'
+                data-track-name='OPEN_PREVIEW'
+              >
+                <Maximize2 className='w-3 h-3' />
+              </button>
+            )}
+
+            {onEdit && (
+              <button
+                onClick={onEdit}
+                className='flex items-center rounded p-1.5 text-muted-foreground hover:bg-accent transition-colors'
+                title='Edit source'
+                aria-label='Edit source'
+                data-track-category='Mermaid'
+                data-track-name='EDIT_SOURCE'
+              >
+                <Pencil className='w-3 h-3' />
+              </button>
+            )}
+
+            {onDelete && (
+              <button
+                onClick={onDelete}
+                className='flex items-center rounded p-1.5 text-muted-foreground hover:bg-accent transition-colors'
+                title='Delete'
+                aria-label='Delete'
+                data-track-category='Mermaid'
+                data-track-name='DELETE_DIAGRAM'
+              >
+                <Trash2 className='w-3 h-3' />
               </button>
             )}
           </div>
@@ -224,16 +270,20 @@ const MermaidBlockComponent = ({
               className='mermaid-diagram flex justify-center rounded-lg border border-border bg-background p-4 transition-colors hover:bg-muted/30 cursor-pointer'
               /* eslint-disable-next-line react/no-danger, @typescript-eslint/naming-convention */
               dangerouslySetInnerHTML={{ __html: svg }}
-              onClick={() => setShowPreview(true)}
-              role='button'
-              tabIndex={0}
-              onKeyDown={(e): void => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  setShowPreview(true);
-                }
-              }}
-              title='Click to preview'
+              onClick={previewOnClick ? () => setShowPreview(true) : undefined}
+              role={previewOnClick ? 'button' : undefined}
+              tabIndex={previewOnClick ? 0 : undefined}
+              onKeyDown={
+                previewOnClick
+                  ? (e): void => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        setShowPreview(true);
+                      }
+                    }
+                  : undefined
+              }
+              title={previewOnClick ? 'Click to preview' : undefined}
               data-track-category='Mermaid'
               data-track-name='OPEN_PREVIEW'
             />
@@ -311,6 +361,13 @@ export const MermaidBlock = memo(MermaidBlockComponent, (prevProps, nextProps): 
   return (
     prevProps.chart === nextProps.chart &&
     prevProps.messageId === nextProps.messageId &&
-    prevProps.controlsOnHover === nextProps.controlsOnHover
+    prevProps.controlsOnHover === nextProps.controlsOnHover &&
+    // Deliberately not comparing onEdit/onDelete: a block spec rebuilds them on
+    // every render, so comparing identity would re-render every diagram on the
+    // page for every keystroke anywhere in the document. What they do never
+    // changes, only which closure carries it.
+    Boolean(prevProps.onEdit) === Boolean(nextProps.onEdit) &&
+    Boolean(prevProps.onDelete) === Boolean(nextProps.onDelete) &&
+    prevProps.previewOnClick === nextProps.previewOnClick
   );
 });

--- a/apps/dashboard/src/components/Markdown/MermaidBlock/MermaidBlock.types.ts
+++ b/apps/dashboard/src/components/Markdown/MermaidBlock/MermaidBlock.types.ts
@@ -2,6 +2,17 @@ export interface MermaidBlockProps {
   chart: string;
   messageId?: string;
   controlsOnHover?: boolean;
+  /** Shows an Edit control; the caller reveals its own editable source. */
+  onEdit?: () => void;
+  /** Shows a Delete control. Only a diagram that lives in a document — a canvas
+   *  block — can be removed; one rendered inside a chat message cannot. */
+  onDelete?: () => void;
+  /**
+   * Whether clicking the diagram opens the enlarged preview. False where the
+   * click means "select this block" instead, which moves the preview onto its
+   * own toolbar button.
+   */
+  previewOnClick?: boolean;
 }
 
 export type ViewMode = 'diagram' | 'code';

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -2714,6 +2714,11 @@ html .bn-code-block-source-popup-ok-button:hover {
   --canvas-content-width: 720px;
   /* Matches BlockNote's default .bn-editor padding-inline — the drag-handle / "+" gutter. */
   --canvas-gutter: 54px;
+  /* Trailing room under the last block: a canvas that ends exactly at the last
+     line reads as cramped, and this also gives somewhere to click past the end.
+     Clamped so a short viewport keeps a usable amount and a tall one does not
+     open a chasm. */
+  --canvas-bottom-space: clamp(96px, 25vh, 280px);
 }
 
 /* Centered reading column. .bn-editor keeps its inline padding as the
@@ -2722,11 +2727,83 @@ html .bn-code-block-source-popup-ok-button:hover {
   box-sizing: border-box;
   max-width: calc(var(--canvas-content-width) + 2 * var(--canvas-gutter));
   margin-inline: auto;
+  padding-bottom: var(--canvas-bottom-space);
   background-color: transparent;
   font-size: 15px;
   line-height: 1.55;
   font-weight: 450;
   color: hsl(var(--foreground));
+}
+
+/* Drag either edge to widen the reading column. Zero-height and sticky, so the
+   handles neither take part in the layout nor scroll away from the reader; each
+   one is a viewport tall so its fade runs end to end however long the document
+   is. Positioned off the same custom property the column is sized by, so they
+   stay on its edges as it changes with no measuring. */
+.canvas-surface .canvas-width-handles {
+  position: sticky;
+  top: 0;
+  height: 0;
+  z-index: 25;
+}
+
+.canvas-surface .canvas-width-handle {
+  position: absolute;
+  top: 0;
+  width: 16px;
+  height: var(--canvas-visible-height, 100vh);
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.canvas-surface .canvas-width-handle--left {
+  left: calc(50% - var(--canvas-content-width) / 2 - var(--canvas-gutter) - 8px);
+}
+
+.canvas-surface .canvas-width-handle--right {
+  left: calc(50% + var(--canvas-content-width) / 2 + var(--canvas-gutter) - 8px);
+}
+
+/* Brightest where the hand is, falling away to nothing at both ends, so the
+   line reads as an edge of the page rather than a border drawn around it. */
+.canvas-surface .canvas-width-handle::before {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  border-radius: 1px;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    hsl(var(--primary) / 0.7) 50%,
+    transparent 100%
+  );
+  /* Nothing at rest: the page is what the reader is looking at. The line only
+     appears once the pointer is on the edge that draws it. */
+  opacity: 0;
+  transition: opacity 140ms ease;
+}
+
+.canvas-surface .canvas-width-handle:hover::before,
+.canvas-surface .canvas-width-handle:focus-visible::before,
+.canvas-surface .canvas-width-handles[data-dragging="true"] .canvas-width-handle::before {
+  opacity: 1;
+}
+
+.canvas-surface .canvas-width-handle:focus-visible {
+  outline: none;
+}
+
+/* A phone has no room to give and no pointer to drag with. */
+@media (max-width: 768px) {
+  .canvas-surface .canvas-width-handles {
+    display: none;
+  }
 }
 
 .canvas-surface .bn-side-menu .mantine-UnstyledButton-root:not(.mantine-Menu-item) {
@@ -2961,9 +3038,125 @@ html .bn-code-block-source-popup-ok-button:hover {
 .canvas-surface .bn-editor .canvas-highlighted-code .canvas-code-editor::selection {
   background: hsl(var(--primary) / 0.24);
 }
+/* The highlighted mirror and the editable text are two stacked copies of the
+   same characters, so any difference in glyph advance makes the caret drift
+   from the text you can see — a few px per token, compounding along the line.
+   hljs colours its tokens but also restyles them (keywords land on Inter 600),
+   and BlockNote's inline-content wrapper resets to the UI font, so neither
+   layer was actually monospace throughout. Pin the metrics on both; only
+   colour may vary between them. */
+.canvas-surface .bn-editor .canvas-highlighted-code,
+.canvas-surface .bn-editor .canvas-highlighted-code *,
+.canvas-surface .bn-editor .canvas-mermaid-source .canvas-code-editor,
+.canvas-surface .bn-editor .canvas-mermaid-source .canvas-code-editor *,
+.canvas-surface .bn-editor .canvas-math-source .canvas-code-editor,
+.canvas-surface .bn-editor .canvas-math-source .canvas-code-editor * {
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 15px;
+  line-height: 1.55;
+  font-weight: 450;
+  font-style: normal;
+  letter-spacing: normal;
+  font-variant-ligatures: none;
+  tab-size: 4;
+}
+
 /* Language dropdown (revealed on hover) picks up the theme text colour. */
 .canvas-surface .bn-editor [data-content-type="codeBlock"] > div > select {
   color: hsl(var(--muted-foreground));
+}
+
+/* A native select paints itself from the OS colour scheme, not our tokens, so
+   in the dark theme both the closed control and its popup came out white.
+   color-scheme is the only thing that redraws the popup. */
+.canvas-code-toolbar select {
+  background-color: hsl(var(--card));
+  color: hsl(var(--foreground));
+}
+
+[data-theme="midnight"] .canvas-code-toolbar select,
+[data-theme="midnight"] .canvas-code-toolbar select option {
+  color-scheme: dark;
+  background-color: hsl(var(--card));
+  color: hsl(var(--foreground));
+}
+
+/* Comment / Ask AI for a selected diagram or equation, sitting above the block
+   the way BlockNote's own toolbar does for a text selection. */
+.canvas-object-toolbar {
+  position: fixed;
+  z-index: 40;
+  transform: translate(-50%, -100%);
+}
+
+/* BlockNote tints a selected node with a blue pseudo-element. These blocks
+   carry their own outline in the app's primary colour, so the tint is turned
+   off for them outright rather than only while our own class is present:
+   ProseMirror's selected-node class is not always cleared from a node view, and
+   a stale one left the equation tinted blue while the diagram was outlined —
+   two blocks looking selected at once, in two different styles. */
+.canvas-surface .bn-editor [data-canvas-math]::after,
+.canvas-surface .bn-editor [data-canvas-mermaid]::after {
+  content: none;
+}
+
+/* A selected diagram or equation is an object, so it gets an outline rather
+   than a text highlight. The class comes from the extension's decoration. */
+.canvas-surface .bn-editor .canvas-object-selected [data-canvas-mermaid],
+.canvas-surface .bn-editor .canvas-object-selected [data-canvas-math],
+.canvas-surface .bn-editor .canvas-object-selected [data-canvas-embed],
+/* A divider has nothing inside it to outline, so the block itself carries it. */
+.canvas-surface .bn-editor .canvas-object-selected[data-content-type='divider'] {
+  outline: 2px solid hsl(var(--primary) / 0.7);
+  outline-offset: 2px;
+  border-radius: 0.5rem;
+}
+
+/* First click selects the embed, second reaches the player. A cross-origin
+   frame never lets the click out, so without this an embedded video could not
+   be selected at all — and an embed that cannot be selected cannot be
+   commented on or asked about. */
+.canvas-surface .bn-editor .canvas-embed-shield {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+  cursor: pointer;
+}
+
+.canvas-surface .bn-editor .canvas-object-selected .canvas-embed-shield {
+  display: none;
+}
+
+/* The editable source has to stay laid out even while the preview is showing.
+   display:none removes it from the layout, and with it the only caret position
+   the block has — so there was nowhere to click between two previews, and no
+   way to walk onto the block with the keyboard to delete it. Zero-sized and
+   clipped, the way BlockNote's own source popup hides itself. */
+.canvas-surface .bn-editor .canvas-source-collapsed {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  height: 0;
+  width: 0;
+  overflow: clip;
+  color: transparent;
+  z-index: 0;
+}
+
+/* One mermaid preview renders inside two different blocks — the diagram block
+   and the mermaid code block — and each brought its own vertical padding, on
+   top of the my-4 MermaidBlock carries for chat. The same picture therefore sat
+   in a bigger gap as a code block (30/26) than as a diagram (19/19), so the
+   spacing down a canvas visibly stepped. Drop the component's own margin here
+   and let one rule set the rhythm for both.  */
+.canvas-surface .bn-editor [data-canvas-mermaid] > div:first-child {
+  margin-block: 0;
+}
+
+.canvas-surface .bn-editor [data-content-type="diagram"],
+.canvas-surface .bn-editor [data-content-type="codeBlock"]:has([data-canvas-mermaid]) {
+  padding-block: 14px 10px;
 }
 
 /* Mermaid renders its own unified Diagram/Code surface. Remove the generic
@@ -3043,6 +3236,7 @@ html .bn-code-block-source-popup-ok-button:hover {
  */
 .canvas-surface-preview {
   --canvas-gutter: 12px;
+  --canvas-bottom-space: 0px;
 }
 .canvas-surface-preview .bn-editor {
   padding-inline: var(--canvas-gutter);
@@ -3453,9 +3647,12 @@ img.inline-emoji,
 }
 
 /* --- Mermaid Diagram --- */
-[data-theme="midnight"] .mermaid-tab-active {
-  background-color: rgba(96, 165, 250, 0.15) !important;
-  color: #60a5fa !important;
+/* The selected view tab follows the app's primary colour rather than the blue
+   it used to hardcode, which belonged to no palette here. One rule for both
+   themes: the token already differs per theme. */
+.mermaid-tab-active {
+  background-color: hsl(var(--primary) / 0.15);
+  color: hsl(var(--primary));
 }
 
 /* --- 2D: Mention Styles --- */

--- a/apps/dashboard/src/machines/xyneAIMachine.ts
+++ b/apps/dashboard/src/machines/xyneAIMachine.ts
@@ -491,14 +491,13 @@ export const xyneAIMachine = setup({
           event.canvasInfo,
         );
 
-        // When opening from closed state with canvas context (Ask AI on canvas),
-        // always start a fresh chat unless explicitly overridden
+        // Opening from closed with canvas context (Ask AI on canvas) starts a
+        // fresh chat unless explicitly overridden. Once open, OPEN is handled by
+        // updateOpen instead, which keeps the conversation.
         const startFreshChat =
           event.startFreshChat !== undefined
             ? event.startFreshChat
-            : event.canvasInfo !== null && event.canvasInfo !== undefined
-              ? true
-              : false;
+            : event.canvasInfo !== null && event.canvasInfo !== undefined;
 
         // Preserve existing threadInfo when OPEN doesn't supply one (e.g.,
         // ticket Ask AI button after SET_TICKET_CONTEXT already set it).
@@ -575,14 +574,11 @@ export const xyneAIMachine = setup({
           event.canvasInfo,
         );
 
-        // When already open and canvas context is provided (Ask AI on canvas),
-        // always start a fresh chat unless explicitly overridden
-        const startFreshChat =
-          event.startFreshChat !== undefined
-            ? event.startFreshChat
-            : event.canvasInfo !== null && event.canvasInfo !== undefined
-              ? true
-              : false;
+        // Already open means there may be a conversation in progress, so Ask AI
+        // from a canvas block attaches its selection as more context instead of
+        // discarding the exchange that prompted the question. Opening from
+        // closed still starts fresh (see setOpen); an explicit flag still wins.
+        const startFreshChat = event.startFreshChat !== undefined ? event.startFreshChat : false;
 
         const threadInfo = event.threadInfo !== undefined ? event.threadInfo : context.threadInfo;
 

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -574,6 +574,9 @@ const AppRoot = (): ReactElement => {
     !isOnAIChatExperiencePage &&
     !isSdlcRoute &&
     !showSdlcDebuggerPanel;
+  // The SDLC lane ships Ask AI inside its own frame (see the isInPanelWebview
+  // branch), so this is what decides whether that in-frame panel is showing.
+  const showSdlcFrameXyneAI = isSdlcSurface && isXyneAIDrawerOpen && !isMobile && !isOnAIPage;
   const showBrowserPanel = browserPanelState === 'open' && !location.pathname.endsWith('/browser');
 
   const shouldShowMobileHeader =
@@ -708,66 +711,81 @@ const AppRoot = (): ReactElement => {
                         />
                       )}
                       {isInPanelWebview ? (
-                        isSdlcSurface && isXyneAIDrawerOpen && !isMobile && !isOnAIPage ? (
-                          // SDLC lane (chrome-free iframe) with Ask AI open: render the
-                          // XyneAI panel INSIDE the frame so Ask AI ships with this lane.
-                          <div className='flex h-screen flex-col'>
-                            <ResizableGroup
-                              orientation='horizontal'
-                              className='flex-1 no-scrollbar overflow-auto'
-                              autoSaveId='sdlc-frame-xyneai'
-                            >
-                              <Panel
-                                id='sdlc-frame-content'
-                                defaultSize={`${100 - XYNE_AI_PANEL_DEFAULT_SIZE}%`}
-                              >
-                                <main className='h-full flex-1 no-scrollbar overflow-auto'>
-                                  <EditWarningModal />
-                                  <Outlet />
-                                </main>
-                              </Panel>
-                              <Separator className='group flex w-[2px] cursor-col-resize items-center justify-center transition-colors'>
-                                <div className='h-full w-[2px] bg-transparent group-hover:bg-primary group-active:bg-primary' />
-                              </Separator>
-                              <Panel
-                                id='sdlc-frame-xyneai'
-                                defaultSize={`${XYNE_AI_PANEL_DEFAULT_SIZE}%`}
-                                maxSize={isXyneDebuggerOpen ? '55%' : '50%'}
-                                minSize={isXyneDebuggerOpen ? `${XYNE_AI_PANEL_MIN_SIZE}%` : '25%'}
-                              >
-                                <XyneAISidebarZIndexShell>
-                                  <XyneAISidebar
-                                    channelId={xyneAIChannelId}
-                                    threadInfo={xyneAIThreadInfo}
-                                    startFreshChat={xyneAIStartFreshChat}
-                                    canvasInfo={xyneAICanvasInfo}
-                                    initialContextSelections={xyneAIInitialContextSelections}
-                                    contextOpenNonce={xyneAIContextOpenNonce}
-                                    kbCollectionId={xyneAIKbCollectionId ?? ''}
-                                    kbChannelId={xyneAIKbChannelId ?? ''}
-                                    kbDocId={xyneAIKbDocId ?? ''}
-                                    kbDocName={xyneAIKbDocName ?? ''}
-                                    kbFolderId={xyneAIKbFolderId ?? ''}
-                                    kbFolderName={xyneAIKbFolderName ?? ''}
-                                    kbOpenNonce={xyneAIKbOpenNonce}
-                                    researchContext={xyneAIResearchContext}
-                                    initialQuery={xyneAIInitialQuery ?? undefined}
-                                    autoSendNonce={xyneAIAutoSendNonce}
-                                    onDebuggerOpenChange={setIsXyneDebuggerOpen}
-                                  />
-                                </XyneAISidebarZIndexShell>
-                              </Panel>
-                            </ResizableGroup>
-                          </div>
-                        ) : (
-                          // Inside the browser-panel webview (or SDLC lane with Ask AI
-                          // closed) — render only the route content. No GlobalTopBar /
-                          // AppSidebar / right panels / ChatDirectory.
-                          <main className='flex-1 h-screen'>
-                            <EditWarningModal />
-                            <Outlet />
-                          </main>
-                        )
+                        // Inside the browser-panel webview / SDLC lane: only the route
+                        // content, no GlobalTopBar / AppSidebar / right panels /
+                        // ChatDirectory. The Ask AI panel joins it as a sibling.
+                        //
+                        // The group is rendered whether or not Ask AI is open, and only
+                        // the assistant's own Panel is conditional. Swapping between two
+                        // different layouts moved <Outlet /> to another position in the
+                        // tree, so React unmounted the whole route and built it again —
+                        // opening Ask AI rebuilt the canvas editor and its Y-Sweet
+                        // connection, and the reader lost their place in the document.
+                        <div className='flex h-screen flex-col'>
+                          <ResizableGroup
+                            orientation='horizontal'
+                            className='flex-1 no-scrollbar overflow-auto'
+                            autoSaveId='sdlc-frame-xyneai'
+                            // The assistant's Panel is conditional, so the group
+                            // has to say which panels it is rendering — without
+                            // it the saved two-panel layout is restored over one
+                            // panel, and the split comes back wrong after Ask AI
+                            // has been closed and opened again.
+                            panelIds={
+                              showSdlcFrameXyneAI
+                                ? ['sdlc-frame-content', 'sdlc-frame-xyneai']
+                                : ['sdlc-frame-content']
+                            }
+                          >
+                            {/* defaultSize is read once, on mount: with the
+                                group now always rendered it must describe the
+                                whole width, and the split comes from the saved
+                                layout the ids above select. */}
+                            <Panel id='sdlc-frame-content' defaultSize='100%'>
+                              <main className='h-full flex-1 no-scrollbar overflow-auto'>
+                                <EditWarningModal />
+                                <Outlet />
+                              </main>
+                            </Panel>
+                            {showSdlcFrameXyneAI && (
+                              <>
+                                <Separator className='group flex w-[2px] cursor-col-resize items-center justify-center transition-colors'>
+                                  <div className='h-full w-[2px] bg-transparent group-hover:bg-primary group-active:bg-primary' />
+                                </Separator>
+                                <Panel
+                                  id='sdlc-frame-xyneai'
+                                  defaultSize={`${XYNE_AI_PANEL_DEFAULT_SIZE}%`}
+                                  maxSize={isXyneDebuggerOpen ? '55%' : '50%'}
+                                  minSize={
+                                    isXyneDebuggerOpen ? `${XYNE_AI_PANEL_MIN_SIZE}%` : '25%'
+                                  }
+                                >
+                                  <XyneAISidebarZIndexShell>
+                                    <XyneAISidebar
+                                      channelId={xyneAIChannelId}
+                                      threadInfo={xyneAIThreadInfo}
+                                      startFreshChat={xyneAIStartFreshChat}
+                                      canvasInfo={xyneAICanvasInfo}
+                                      initialContextSelections={xyneAIInitialContextSelections}
+                                      contextOpenNonce={xyneAIContextOpenNonce}
+                                      kbCollectionId={xyneAIKbCollectionId ?? ''}
+                                      kbChannelId={xyneAIKbChannelId ?? ''}
+                                      kbDocId={xyneAIKbDocId ?? ''}
+                                      kbDocName={xyneAIKbDocName ?? ''}
+                                      kbFolderId={xyneAIKbFolderId ?? ''}
+                                      kbFolderName={xyneAIKbFolderName ?? ''}
+                                      kbOpenNonce={xyneAIKbOpenNonce}
+                                      researchContext={xyneAIResearchContext}
+                                      initialQuery={xyneAIInitialQuery ?? undefined}
+                                      autoSendNonce={xyneAIAutoSendNonce}
+                                      onDebuggerOpenChange={setIsXyneDebuggerOpen}
+                                    />
+                                  </XyneAISidebarZIndexShell>
+                                </Panel>
+                              </>
+                            )}
+                          </ResizableGroup>
+                        </div>
                       ) : isOnboarding ? (
                         // Onboarding screen - full width without sidebar
                         <main


### PR DESCRIPTION
Port of #1534 to `release-20260904`.

Cherry-picked from its merge commit on `main` (`27c519d43`). One commit, independent of the other two ports.

## Conflict resolved

One conflict, in `MessageItem.tsx`. On `main` the edit-submit control had been refactored into a `<Button variant='ghost' trackId=…>` component and my change swapped its inline handler for `submitEdit`; that refactor has not landed on this line. Resolved by keeping this branch's own `<button>` markup with the `submitEdit` handler — the same semantic change, expressed in the markup this branch actually has.

Dashboard typechecks against `release-20260904`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zcCxPptiyCEbXXyZKRNCG
