### PR TITLE
fix: call participant list shows "Not joined" for users who actually joined

### DIFF
--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -1018,6 +1018,9 @@ export class CallRepository {
         joinedAt
       }
     });
+    // Rebuild the denormalized preview so the participant's hasJoined flag is
+    // reflected immediately, not only when the call ends.
+    await refreshCallParticipantPreview(tx, participant.callId);
     queueCallVespaFeed(participant.callId, { source: CallVespaFeedSource.CallRepositoryUpdateParticipantResponse });
     return participant;
   }

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -4793,6 +4793,11 @@ export function createMutators(
               isExternal: false,
             });
           }
+
+          // Keep the denormalized call_participants preview in sync on join so the
+          // hasJoined flag is correct for active calls and preview-only surfaces
+          // (e.g. call-history avatars), not only when the call ends.
+          await updateCallParticipantPreview(tx, call.id);
         },
       ),
       leave: defineMutator(

--- a/apps/dashboard/src/hooks/useCallParticipantRoster.ts
+++ b/apps/dashboard/src/hooks/useCallParticipantRoster.ts
@@ -105,9 +105,20 @@ export function useCallParticipantRoster(
     const merged = [...previewParticipants];
     const seen = new Set(merged.map(participant => participant.userId));
 
+    // Index the authoritative full roster by userId. Its live `joinedAt` must be
+    // able to OVERRIDE a possibly-stale preview `hasJoined` flag, not merely
+    // backfill participants the preview didn't already cover — otherwise a preview
+    // row whose cached flag is out of date would shadow the real join status.
+    const fullByUserId = new Map<string, MergedParticipant>();
     for (const participant of fullParticipants ?? []) {
-      if (participant.userId && !seen.has(participant.userId)) {
-        merged.push({ ...participant, isCurrentUser: participant.userId === currentUserId });
+      if (!participant.userId) continue;
+      const row: MergedParticipant = {
+        ...participant,
+        isCurrentUser: participant.userId === currentUserId,
+      };
+      fullByUserId.set(participant.userId, row);
+      if (!seen.has(participant.userId)) {
+        merged.push(row);
         seen.add(participant.userId);
       }
     }
@@ -115,6 +126,17 @@ export function useCallParticipantRoster(
     return merged.map(participant => {
       const isExternal = Boolean(participant.isExternal);
       const directoryUser = usersById.get(participant.userId);
+
+      // When the authoritative roster row is present, trust its `joinedAt`
+      // outright; only fall back to the preview flag for rows the roster does not
+      // cover (e.g. active calls where the full fetch is skipped).
+      const authoritative = fullByUserId.get(participant.userId);
+      const joinedAt = authoritative ? authoritative.joinedAt : participant.joinedAt;
+      const hasJoined = authoritative
+        ? joinedAt !== null && joinedAt !== undefined
+        : joinedAt !== null && joinedAt !== undefined
+          ? true
+          : Boolean(participant.previewHasJoined);
 
       return {
         userId: participant.userId,
@@ -124,12 +146,7 @@ export function useCallParticipantRoster(
         email: isExternal ? (participant.email ?? '') : (directoryUser?.email ?? ''),
         isExternal,
         isCurrentUser: Boolean(participant.isCurrentUser),
-        // `joinedAt` is the authoritative signal; preview-only rows fall back to
-        // the flag carried in the preview payload.
-        hasJoined:
-          participant.joinedAt !== null && participant.joinedAt !== undefined
-            ? true
-            : Boolean(participant.previewHasJoined),
+        hasJoined,
       };
     });
   }, [currentUserId, fullParticipants, previewParticipants, usersById]);


### PR DESCRIPTION
## 1. Problem Description
In Call details → participants list, some users who actually joined a call were shown as "Not joined". Status was correct for calls that ended cleanly and wrong for others (active calls, or calls that ended abnormally).

## 2. How the issue was identified
The join badge is driven by the denormalized `participantPreviewUserIds` snapshot stored on each call (with `hasJoined` baked in at write time). This blob was rebuilt on invite and on call-end, but NOT on join: the Zero `join` mutator and REST `updateParticipantResponse` both set `joinedAt` without refreshing the preview. `updateCallParticipantPreview` was called exactly once in the mutators file — only when the last participant leaves and the call ends. So joins were never reflected until (and unless) the call ended, leaving invite-time `hasJoined:false` flags. The dashboard hook `useCallParticipantRoster` also merged preview rows first and let their stale flag shadow the authoritative full-roster `joinedAt`.

## 3. Solution implemented
- `apps/backend/src/zero/mutators.ts` (`join` mutator): call `updateCallParticipantPreview(tx, call.id)` after recording `joinedAt`.
- `apps/backend/src/database/repositories/callRepository.ts` (`updateParticipantResponse`): call `refreshCallParticipantPreview(tx, participant.callId)` after the update.
- `apps/dashboard/src/hooks/useCallParticipantRoster.ts`: index the full roster by userId and let its live `joinedAt` override a possibly-stale preview flag (self-heals historical calls in the details popover), falling back to the preview flag only for rows the roster doesn't cover (e.g. active calls where the full fetch is skipped).

## 4. Documentation
N/A

## 5. DB Alter Details (if any)
N/A

## 6. Data fix Details (if any)
Optional one-time backfill: run `refreshCallParticipantPreview` over existing non-scheduled calls to correct already-stored snapshots (underlying `call_participants.joinedAt` data is intact). Only needed for preview-only surfaces (e.g. call-history avatars); the details popover self-heals via the frontend change.

## 7. Environment variable Changes (if any)
N/A

## 8. Testing
Backend and dashboard `tsc --noEmit` typecheck pass. Manual verification recommended: join a call, confirm the participant shows "Joined" while the call is still active and after it ends.

## 9. Services to which this change is to be deployed
backend (API + zero mutators), dashboard.

## 10. Main PR link (if against a release branch)
N/A — targets main.