### PR TITLE
feat: XYNE-63002 send attachments from the SEND_EMAIL_TO_USER automation step

### DIFF
--- a/apps/backend/src/automations/engine/config-validator.ts
+++ b/apps/backend/src/automations/engine/config-validator.ts
@@ -323,6 +323,19 @@ export class ConfigValidator {
         issues,
       );
 
+      // Both recipient fields are optional on their own, so only a cross-field
+      // check can refuse a step that names nobody — or two people.
+      if (step.type === 'SEND_EMAIL_TO_USER') {
+        const cfg = step.config as { userId?: unknown; toEmail?: unknown };
+        if (!cfg.userId === !cfg.toEmail) {
+          issues.push({
+            path: `${stepPath}.config`,
+            code: ValidationIssueCode.SHAPE,
+            message: 'Set exactly one of userId or toEmail',
+          });
+        }
+      }
+
       if (step.type === 'SEND_MESSAGE') {
         const attachments = (step.config as { attachments?: unknown }).attachments;
         if (Array.isArray(attachments)) {

--- a/apps/backend/src/automations/routes/automation.routes.ts
+++ b/apps/backend/src/automations/routes/automation.routes.ts
@@ -4,7 +4,7 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 import { triggerRegistry } from '../triggers/trigger-registry';
 import { stepRegistry } from '../steps/step-registry';
 import { ConditionOperator } from '../types/operators';
-import { automationService } from '../services/automation.service';
+import { automationService, personalMailboxReady } from '../services/automation.service';
 import {
   issueWebhookSecret,
   webhookSecretExists,
@@ -108,6 +108,21 @@ function prepareConfigForSave(
     context: JSON.stringify(configToSave),
     eventType: triggerTypeToEventType(configToSave.trigger.type),
   };
+}
+
+/** True means the 400 has already been sent and the caller should return. */
+async function rejectUnconnectedPersonalMailbox(
+  config: AutomationConfig,
+  authorId: string,
+  res: Response,
+): Promise<boolean> {
+  if (await personalMailboxReady(config, authorId)) return false;
+  res.status(400).json({
+    success: false,
+    error:
+      'A step sends from your own mailbox, but your Google account is not connected. Connect it on that step, or switch the step back to the channel mailbox.',
+  });
+  return true;
 }
 
 function parseListLimit(raw: unknown): number {
@@ -420,6 +435,7 @@ router.post('/', async (req: Request, res: Response) => {
 
     const prepared = prepareConfigForSave(parsed.data.config, res);
     if (!prepared) return;
+    if (await rejectUnconnectedPersonalMailbox(prepared.config, auth.userId, res)) return;
 
     const workflow = await db.$transaction(async tx => {
       await claimAutomationTemplates(tx, prepared.config, auth.workspaceId);
@@ -593,6 +609,11 @@ router.put('/:id', async (req: Request<{ id: string }>, res: Response) => {
       ? prepareConfigForSave(parsed.data.config, res)
       : null;
     if (parsed.data.config !== undefined && !prepared) return;
+    // The save below always writes auth.userId as createdById, so the author to
+    // check is the caller in both the draft and the non-draft branch.
+    if (prepared && (await rejectUnconnectedPersonalMailbox(prepared.config, auth.userId, res))) {
+      return;
+    }
 
     const metadata = buildAutomationMetadata({
       description: parsed.data.description !== undefined

--- a/apps/backend/src/automations/services/automation-template.service.ts
+++ b/apps/backend/src/automations/services/automation-template.service.ts
@@ -28,7 +28,7 @@ const TEMPLATE_TYPES = {
 export const AutomationTemplateAttachmentSchema = z.object({
   attachmentId: z.string().min(1),
   originalFilename: z.string().min(1),
-  mimetype: z.enum(['text/plain', 'text/markdown', 'text/html']),
+  mimetype: z.string().min(1),
   size: z.number().int().nonnegative().max(AUTOMATION_TEMPLATE_MAX_FILE_BYTES),
   templatePaths: z.array(z.string().min(1)),
 });
@@ -47,7 +47,13 @@ export class AutomationTemplateInputError extends Error {
 
 interface StoredTemplate {
   descriptor: AutomationTemplateAttachment;
-  content: string;
+  /**
+   * Null for a file sent byte-for-byte. Only the TEMPLATE_TYPES extensions are
+   * templated — a .csv or .json holding {{context...}} is delivered with the
+   * braces intact, which is why the builder names the three that are rendered.
+   */
+  content: string | null;
+  buffer: Buffer;
 }
 
 export interface PreparedAutomationTemplateFile {
@@ -124,10 +130,6 @@ export async function storeAutomationTemplates(params: {
     const prepared = await Promise.all(
       files.map(async (file) => {
         const extension = extensionOf(file.originalname);
-        if (!extension)
-          throw new AutomationTemplateInputError(
-            `${file.originalname}: only .txt, .md, and .html are allowed`
-          );
         if (!file.path) throw new Error(`${file.originalname}: uploaded storage path is missing`);
         const buffer = await storageService.getFileBuffer(normalizeStoragePath(file.path));
         if (buffer.byteLength > AUTOMATION_TEMPLATE_MAX_FILE_BYTES) {
@@ -136,13 +138,15 @@ export async function storeAutomationTemplates(params: {
             413
           );
         }
-        const content = decodeUtf8(buffer, file.originalname);
+        // Anything outside TEMPLATE_TYPES is attached byte-for-byte, so it is
+        // never decoded and never scanned for variables.
+        const content = extension ? decodeUtf8(buffer, file.originalname) : null;
         return {
           originalFilename: file.originalname,
-          mimetype: TEMPLATE_TYPES[extension],
+          mimetype: extension ? TEMPLATE_TYPES[extension] : file.mimetype,
           size: buffer.byteLength,
           storagePath: normalizeStoragePath(file.path),
-          templatePaths: extractTemplatePaths(content),
+          templatePaths: content === null ? [] : extractTemplatePaths(content),
         };
       })
     );
@@ -203,7 +207,7 @@ export async function readAutomationTemplate(params: {
     throw new Error(`Automation template ${descriptor.attachmentId} was not found`);
   }
   const extension = extensionOf(record.originalFilename);
-  if (!extension || TEMPLATE_TYPES[extension] !== record.mimetype) {
+  if (extension && TEMPLATE_TYPES[extension] !== record.mimetype) {
     throw new Error(`Automation template ${descriptor.attachmentId} has an invalid file type`);
   }
   const storagePath = normalizeStoragePath(record.url);
@@ -211,8 +215,8 @@ export async function readAutomationTemplate(params: {
   if (buffer.byteLength > AUTOMATION_TEMPLATE_MAX_FILE_BYTES) {
     throw new Error(`${record.originalFilename}: maximum file size is 10MB`);
   }
-  const content = decodeUtf8(buffer, record.originalFilename);
-  const actualPaths = extractTemplatePaths(content);
+  const content = extension ? decodeUtf8(buffer, record.originalFilename) : null;
+  const actualPaths = content === null ? [] : extractTemplatePaths(content);
   if (!samePaths(actualPaths, descriptor.templatePaths)) {
     throw new Error(
       `${record.originalFilename}: template variables changed; reopen and save the file`
@@ -222,11 +226,12 @@ export async function readAutomationTemplate(params: {
     descriptor: {
       attachmentId: record.id,
       originalFilename: record.originalFilename,
-      mimetype: TEMPLATE_TYPES[extension],
+      mimetype: record.mimetype,
       size: buffer.byteLength,
       templatePaths: actualPaths,
     },
     content,
+    buffer,
   };
 }
 
@@ -259,8 +264,11 @@ export async function prepareRenderedAutomationFiles(params: {
     )
   );
   const rendered = stored.map((file) => {
-    const content = renderAutomationTemplate(file.content, context);
-    const buffer = Buffer.from(content, 'utf8');
+    // A file attached as-is has no variables to resolve; its bytes are the payload.
+    const buffer =
+      file.content === null
+        ? file.buffer
+        : Buffer.from(renderAutomationTemplate(file.content, context), 'utf8');
     if (buffer.byteLength > AUTOMATION_TEMPLATE_MAX_FILE_BYTES) {
       throw new Error(`${file.descriptor.originalFilename}: rendered file exceeds 10MB`);
     }

--- a/apps/backend/src/automations/services/automation.service.ts
+++ b/apps/backend/src/automations/services/automation.service.ts
@@ -7,6 +7,7 @@ import { ConfigValidator } from '../engine/config-validator';
 import { triggerRegistry } from '../triggers/trigger-registry';
 import { stepRegistry } from '../steps/step-registry';
 import { encryptWebhookStepHeaders } from '../engine/webhook-step-encryption';
+import { PERSONAL_EMAIL_SOURCE_TYPE, usesPersonalMailbox } from '../steps/send-email-to-user.step';
 import {
   AUTOMATION_WORKFLOW_TYPE,
   buildAutomationMetadata,
@@ -18,6 +19,22 @@ import {
 } from '../types/workflow-adapter';
 
 const validator = new ConfigValidator(triggerRegistry, stepRegistry);
+
+/**
+ * Whether a PERSONAL send has a mailbox behind it. Async, so it cannot live in
+ * the synchronous ConfigValidator.
+ */
+export async function personalMailboxReady(
+  config: AutomationConfig,
+  authorId: string,
+): Promise<boolean> {
+  if (!usesPersonalMailbox(config.steps)) return true;
+  const source = await repositories.externalSources.findActiveByOwnerAndSourceType(
+    authorId,
+    PERSONAL_EMAIL_SOURCE_TYPE,
+  );
+  return !!source;
+}
 
 export interface SaveResult {
   automation: AutomationView;
@@ -72,6 +89,13 @@ class AutomationService {
             })
           : existing;
       return { automation: workflowToAutomation(demoted), validation };
+    }
+
+    const owner = parseAutomationMetadata(existing.metadata).createdById;
+    if (owner && !(await personalMailboxReady(config, owner))) {
+      throw new Error(
+        "The owner's Google account is no longer connected — reconnect it, or switch that step to the channel mailbox.",
+      );
     }
 
     const triggerImpl = triggerRegistry.get(config.trigger.type);

--- a/apps/backend/src/automations/steps/send-email-to-user.step.ts
+++ b/apps/backend/src/automations/steps/send-email-to-user.step.ts
@@ -1,20 +1,56 @@
 import { z } from 'zod';
+import { AttachmentEntityType } from '@xyne/shared';
+import { normalizeStoragePath } from '@xyne/storage';
 import { BaseActionStep } from './base-step';
 import { StepCategory } from '../types/categories';
 import { variableRef } from '../engine/variable-ref';
+import {
+  AutomationTemplateAttachmentSchema,
+  AUTOMATION_TEMPLATE_MAX_TOTAL_BYTES,
+  prepareRenderedAutomationFiles,
+} from '../services/automation-template.service';
 import { repositories } from '@/database/repositories';
 import { ExternalSourceRepository } from '@/database/repositories/externalSourceRepository';
 import { adapterRegistry } from '@/integrations/core/adapterRegistry';
+import { storageService } from '@/services/storage';
 import { extractEmailAddress } from '@/utils/email';
 import { logger } from '@/utils/logger';
+import type { OutgoingAttachment } from '@/integrations/core/baseMailReplySender';
 import type { AutomationContext } from '../types/context';
 
+/** The user's own Google grant, reused from call-recording recaps. */
+export const PERSONAL_EMAIL_SOURCE_TYPE = 'google-recording-email';
+
+/** True if any step, at any nesting depth, sends from the author's mailbox. */
+export function usesPersonalMailbox(node: unknown): boolean {
+  if (Array.isArray(node)) return node.some(usesPersonalMailbox);
+  if (!node || typeof node !== 'object') return false;
+  const step = node as { type?: string; config?: { sendAs?: string } };
+  if (step.type === 'SEND_EMAIL_TO_USER' && step.config?.sendAs === 'PERSONAL') return true;
+  return Object.values(node).some(usesPersonalMailbox);
+}
+
 const SendEmailToUserConfigSchema = z.object({
-  userId: variableRef(z.string().min(1)),
+  userId: variableRef(
+    z.string().min(1).describe('Xyne user to email. Set exactly one of userId or toEmail.'),
+  ).optional(),
+  toEmail: variableRef(
+    z.string().email().describe('Address to email when there is no Xyne user id. Set exactly one of userId or toEmail.'),
+  ).optional(),
   subject: variableRef(z.string().min(1)),
   body: variableRef(z.string().min(1)),
   cc: z.array(variableRef(z.string().email())).optional(),
   bcc: z.array(variableRef(z.string().email())).optional(),
+  sendAs: z
+    .enum(['CHANNEL', 'PERSONAL'])
+    .default('CHANNEL')
+    .describe("CHANNEL uses the desk mailbox; PERSONAL uses the author's own Google account."),
+  attachments: z.array(AutomationTemplateAttachmentSchema).max(10).optional(),
+  // Points at a trigger array such as {{trigger.email.attachments}}. Only the id
+  // is trusted: every other field is re-read from the database before sending.
+  triggerAttachments: variableRef(
+    z.array(z.object({ id: z.string().min(1) }).passthrough()).max(10),
+  ).optional(),
 });
 
 const SendEmailToUserOutputSchema = z.object({
@@ -36,7 +72,7 @@ export class SendEmailToUserStep extends BaseActionStep<
   readonly outputSchema = SendEmailToUserOutputSchema;
   readonly name = 'Send email to user';
   readonly description =
-    'Sends an email directly to a user\'s email address using the workspace\'s connected email integration.';
+    'Sends an email directly to a user\'s email address, from the workspace\'s connected email integration or from a person\'s own connected mailbox.';
   readonly category = StepCategory.MESSAGING;
   readonly icon = 'Mail';
 
@@ -46,20 +82,31 @@ export class SendEmailToUserStep extends BaseActionStep<
     config: z.infer<typeof SendEmailToUserConfigSchema>,
     context: AutomationContext,
   ): Promise<SendEmailToUserOutput> {
-    const userId = config.userId as string;
+    const userId = config.userId as string | undefined;
     const subject = config.subject as string;
     const body = config.body as string;
     const workspaceId = context.automation.workspaceId;
 
-    const user = await repositories.users.findById(userId);
-    if (!user?.email) {
-      throw new Error(`[SEND_EMAIL_TO_USER] User ${userId} not found or has no email`);
-    }
-    if (user.workspaceId !== workspaceId) {
-      throw new Error(`[SEND_EMAIL_TO_USER] User ${userId} does not belong to workspace ${workspaceId}`);
+    if (!userId === !config.toEmail) {
+      throw new Error('[SEND_EMAIL_TO_USER] Set exactly one of userId or toEmail (an unresolved {{ref}} counts as unset)');
     }
 
-    let externalSource = await this.externalSourceRepo.findEmailSourceByWorkspaceId(workspaceId);
+    let toEmail = config.toEmail as string;
+    if (userId) {
+      const user = await repositories.users.findById(userId);
+      if (!user?.email) {
+        throw new Error(`[SEND_EMAIL_TO_USER] User ${userId} not found or has no email`);
+      }
+      if (user.workspaceId !== workspaceId) {
+        throw new Error(`[SEND_EMAIL_TO_USER] User ${userId} does not belong to workspace ${workspaceId}`);
+      }
+      toEmail = user.email;
+    }
+
+    let externalSource =
+      config.sendAs === 'PERSONAL'
+        ? await this.resolvePersonalSource(context)
+        : await this.externalSourceRepo.findEmailSourceByWorkspaceId(workspaceId);
 
     if (!externalSource) {
       const trigger = context.trigger as { channel?: { id?: string } };
@@ -89,6 +136,9 @@ export class SendEmailToUserStep extends BaseActionStep<
     }
 
     const fromEmail = extractEmailAddress(externalSource.displayName) || externalSource.displayName;
+    // Outside the try below: a file that cannot be read must fail the step, not
+    // be reported as a delivery failure.
+    const fileAttachments = await this.collectAttachments(config, context);
 
     try {
       await adapter.sendMailNew({
@@ -96,24 +146,109 @@ export class SendEmailToUserStep extends BaseActionStep<
         sourceId: externalSource.id,
         subject,
         body,
-        to: [user.email],
+        to: [toEmail],
         cc: (config.cc as string[] | undefined) ?? [],
         bcc: (config.bcc as string[] | undefined) ?? [],
         ...(fromEmail && { fromEmailAddress: fromEmail }),
+        ...(fileAttachments.length > 0 && { fileAttachments }),
       });
     } catch (error) {
       logger.error(
         `[automations] SEND_EMAIL_TO_USER delivery failed via ${externalSource.sourceType} source=${externalSource.id} workspace=${workspaceId}`,
         error,
       );
-      return { delivered: false, toEmail: user.email };
+      return { delivered: false, toEmail };
     }
 
     logger.info(
       `[automations] SEND_EMAIL_TO_USER sent via ${externalSource.sourceType} source=${externalSource.id} workspace=${workspaceId}`,
     );
 
-    return { delivered: true, toEmail: user.email };
+    return { delivered: true, toEmail };
+  }
+
+  /** Files uploaded on the step, plus any the trigger's email carried. */
+  private async collectAttachments(
+    config: z.infer<typeof SendEmailToUserConfigSchema>,
+    context: AutomationContext,
+  ): Promise<OutgoingAttachment[]> {
+    const uploaded = await prepareRenderedAutomationFiles({
+      attachments: config.attachments ?? [],
+      context,
+    });
+    const files: OutgoingAttachment[] = [
+      ...uploaded.map(file => ({
+        name: file.originalName,
+        contentType: file.mimeType,
+        content: file.buffer,
+      })),
+      ...(await this.readTriggerAttachments(config, context)),
+    ];
+    // prepareRenderedAutomationFiles caps its own files; only the combined
+    // total can still exceed what a provider will accept.
+    const total = files.reduce((sum, file) => sum + file.content.length, 0);
+    if (total > AUTOMATION_TEMPLATE_MAX_TOTAL_BYTES) {
+      throw new Error('[SEND_EMAIL_TO_USER] Attachments exceed the 25MB total limit');
+    }
+    return files;
+  }
+
+  /** Files named by a trigger reference, re-read from the database by id. */
+  private async readTriggerAttachments(
+    config: z.infer<typeof SendEmailToUserConfigSchema>,
+    context: AutomationContext,
+  ): Promise<OutgoingAttachment[]> {
+    const refs = config.triggerAttachments;
+    if (!Array.isArray(refs) || refs.length === 0) return [];
+
+    const workspaceId = context.automation.workspaceId;
+    const rows = await repositories.messageAttachments.findByIds(refs.map(ref => ref.id));
+    // findByIds filters on id alone, so an id from another workspace — or one
+    // pointing at something that is not an email file — must be refused here.
+    const usable = rows.filter(
+      row =>
+        row.workspaceId === workspaceId &&
+        row.entityType === AttachmentEntityType.EMAIL &&
+        !row.isDeleted,
+    );
+    if (usable.length !== refs.length) {
+      throw new Error(
+        `[SEND_EMAIL_TO_USER] ${refs.length - usable.length} of ${refs.length} trigger attachments are unavailable`,
+      );
+    }
+    // Inbound mail carries no per-file cap of its own, so the recorded sizes are
+    // checked before anything is pulled into memory.
+    const total = usable.reduce((sum, row) => sum + row.size, 0);
+    if (total > AUTOMATION_TEMPLATE_MAX_TOTAL_BYTES) {
+      throw new Error('[SEND_EMAIL_TO_USER] Trigger attachments exceed the 25MB total limit');
+    }
+
+    return Promise.all(
+      usable.map(async row => ({
+        name: row.originalFilename,
+        contentType: row.mimetype,
+        content: await storageService.getFileBuffer(normalizeStoragePath(row.url)),
+      })),
+    );
+  }
+
+  /** The author's own mailbox. Throws rather than falling back to the desk inbox. */
+  private async resolvePersonalSource(context: AutomationContext) {
+    const workspaceId = context.automation.workspaceId;
+    const senderUserId = context.automation.createdById;
+    const source = await this.externalSourceRepo.findActiveByOwnerAndSourceType(
+      senderUserId,
+      PERSONAL_EMAIL_SOURCE_TYPE,
+    );
+    if (!source) {
+      throw new Error(`[SEND_EMAIL_TO_USER] User ${senderUserId} has no connected Google account`);
+    }
+    // findActiveByOwnerAndSourceType filters on ownerUserId only, so without this
+    // an automation could borrow a mailbox from another tenant.
+    if (source.workspaceId !== workspaceId) {
+      throw new Error(`[SEND_EMAIL_TO_USER] Personal mailbox of ${senderUserId} is not in workspace ${workspaceId}`);
+    }
+    return source;
   }
 }
 

--- a/apps/backend/src/automations/triggers/email-context.ts
+++ b/apps/backend/src/automations/triggers/email-context.ts
@@ -75,6 +75,15 @@ interface EmailRow {
   externalMessageId: string;
   createdAt: Date;
   hasAttachments?: boolean;
+  attachments?: EmailAttachmentRef[];
+}
+
+/** What a step needs to fetch and attach a file the triggering email carried. */
+interface EmailAttachmentRef {
+  id: string;
+  filename: string;
+  mimetype: string;
+  size: number;
 }
 
 async function loadTicketContextForEmail(
@@ -132,6 +141,7 @@ function emailRowToOutput(email: EmailRow): EmailRow {
     externalMessageId: email.externalMessageId,
     createdAt: email.createdAt,
     hasAttachments: email.hasAttachments,
+    attachments: email.attachments,
   };
 }
 
@@ -150,14 +160,24 @@ export async function hydrateEmailReceivedPayload(
   }
 
   const ticketContext = await loadTicketContextForEmail(email.conversationId);
-  const hasAttachments = await repositories.messageAttachments
-    .hasEmailAttachment(email.id)
+  // One query serves both the boolean filter and the descriptors a step needs
+  // to forward the files; a failure still lets the automation fire, as before.
+  const attachments = await repositories.messageAttachments
+    .findByEmailIds([email.id])
+    .then(rows =>
+      rows.map(row => ({
+        id: row.id,
+        filename: row.originalFilename,
+        mimetype: row.mimetype,
+        size: row.size,
+      })),
+    )
     .catch(error => {
       logger.warn(
         `[automations] failed to hydrate attachment state for email=${email.id}`,
         error,
       );
-      return false;
+      return [];
     });
   const emailUrl = buildEmailUrl({
     ticketUrl: ticketContext?.ticket.url,
@@ -168,7 +188,14 @@ export async function hydrateEmailReceivedPayload(
 
   return {
     ...payload,
-    email: { ...emailRowToOutput({ ...email, hasAttachments } as EmailRow), url: emailUrl },
+    email: {
+      ...emailRowToOutput({
+        ...email,
+        hasAttachments: attachments.length > 0,
+        attachments,
+      } as EmailRow),
+      url: emailUrl,
+    },
     ...(ticketContext ?? {}),
     requester: {
       email: extractEmailAddress(email.from),

--- a/apps/backend/src/automations/triggers/email-received.trigger.ts
+++ b/apps/backend/src/automations/triggers/email-received.trigger.ts
@@ -120,6 +120,10 @@ export const EmailReceivedOutputSchema = TicketContextSchema.partial().extend({
     externalMessageId: z.string(),
     createdAt: z.coerce.date(),
     hasAttachments: z.boolean(),
+    // Enough for a later step to fetch each file and forward it.
+    attachments: z
+      .object({ id: z.string(), filename: z.string(), mimetype: z.string(), size: z.number() })
+      .array(),
   }),
   requester: z.object({
     email: z.string(),

--- a/apps/backend/src/database/repositories/messageAttachmentRepository.ts
+++ b/apps/backend/src/database/repositories/messageAttachmentRepository.ts
@@ -283,18 +283,6 @@ export class MessageAttachmentRepository {
     });
   }
 
-  async hasEmailAttachment(emailId: string): Promise<boolean> {
-    const attachment = await this.db.messageAttachment.findFirst({
-      where: {
-        entityId: emailId,
-        entityType: AttachmentEntityType.EMAIL,
-        isDeleted: false,
-      },
-      select: { id: true },
-    });
-    return attachment !== null;
-  }
-
   async updateVersion(id: string, metadata: Record<string, any>): Promise<MessageAttachment> { // eslint-disable-line @typescript-eslint/no-explicit-any
     // Increment version in metadata
     const currentVersion = (metadata.version as number) || 0;

--- a/apps/backend/src/integrations/routes/google-auth.ts
+++ b/apps/backend/src/integrations/routes/google-auth.ts
@@ -28,6 +28,7 @@ import { encrypt } from '@/services/encryptionService';
 import { emailFetchQueue, enqueueCursorCatchup } from '@/queues/emailFetchQueue';
 import { getFrontendUrl, getBackendUrl } from '@/utils/publicUrls';
 import { pubSubWatchService } from '@/pubsub';
+import { automationService } from '@/automations/services/automation.service';
 
 const TAG = '[GoogleAuth]';
 
@@ -634,6 +635,47 @@ router.post(
       res.status(error instanceof GoogleAuthRouteError ? error.status : 400).json({
         error: error instanceof GoogleAuthRouteError ? error.message : 'Unable to start Google Docs connection',
       });
+    }
+  },
+);
+
+/**
+ * A run uses the automation's own author, not whoever is looking at the builder,
+ * so `automationId` names the automation whose author to report on; without it
+ * the caller is the author (a new, unsaved automation).
+ */
+router.get(
+  '/connect/personal-email/status',
+  authV2Middleware.authenticate,
+  async (req: Request, res: Response): Promise<void> => {
+    const workspaceId = req.user!.workspaceId;
+    const automationId = typeof req.query.automationId === 'string' ? req.query.automationId : '';
+
+    try {
+      const automation = automationId ? await automationService.get(automationId) : null;
+      const ownerId =
+        automation && automation.workspaceId === workspaceId && automation.createdById
+          ? automation.createdById
+          : req.user!.id;
+
+      const [source, owner] = await Promise.all([
+        new ExternalSourceRepository().findActiveByOwnerAndSourceType(
+          ownerId,
+          RECORDING_EMAIL_SOURCE_TYPE,
+        ),
+        db.user.findFirst({ where: { id: ownerId, workspaceId }, select: { email: true } }),
+      ]);
+      const connected = source?.workspaceId === workspaceId ? source : null;
+
+      res.json({
+        connected: !!connected,
+        isOwner: ownerId === req.user!.id,
+        // The connected address when there is one, else who would have to connect.
+        email: connected?.displayName ?? owner?.email ?? null,
+      });
+    } catch (error: unknown) {
+      logger.error(`${TAG} Error reading personal email connection status`, error);
+      res.status(500).json({ error: 'Unable to read email connection status' });
     }
   },
 );

--- a/apps/dashboard/src/api/automationsApi.ts
+++ b/apps/dashboard/src/api/automationsApi.ts
@@ -403,7 +403,8 @@ export function fetchClawAgents(): Promise<ClawAgent[]> {
 export interface AutomationTemplateAttachment {
   attachmentId: string;
   originalFilename: string;
-  mimetype: 'text/plain' | 'text/markdown' | 'text/html';
+  /** One of the text template types, or any type accepted for a plain file attachment. */
+  mimetype: string;
   size: number;
   templatePaths: string[];
 }

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/AutomationBuilder.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/AutomationBuilder.tsx
@@ -1,5 +1,6 @@
 import { logger, Event as LogEvent } from '../../../utils/logger';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AutomationIdContext } from './AutomationIdContext';
 import { useNavigate } from 'react-router-dom';
 import { useMutation, useQueries, useQuery } from '@tanstack/react-query';
 import {
@@ -1221,94 +1222,96 @@ export function AutomationBuilder({
           >
             <AddStepRow catalog={stepCatalog} onPick={type => handleAddStep(type, 0)} />
 
-            {config.steps.map((step, index) => {
-              const isLast = index === config.steps.length - 1;
-              const variableSources = buildVariableSources(
-                triggerSchema,
-                config.trigger.config,
-                config.steps,
-                stepSchemaCache,
-                index,
-                formFieldNameMap,
-              );
-              const stepIssues = issuesUnder(validation?.issues, `steps[${index}]`);
-
-              const card =
-                step.type === CONDITIONAL_STEP_TYPE ? (
-                  <ConditionalCard
-                    step={step as ConditionalStepConfig}
-                    catalog={stepCatalog}
-                    schemaCache={stepSchemaCache}
-                    schemaLoadingFor={stepSchemaLoadingFor}
-                    operators={operators}
-                    variableSources={variableSources}
-                    index={index + 1}
-                    total={config.steps.length}
-                    onChange={next => updateStepAt(index, next)}
-                    onMoveUp={() => handleMoveStep(index, -1)}
-                    onMoveDown={() => handleMoveStep(index, 1)}
-                    onDelete={() => handleDeleteStep(index)}
-                    issues={stepIssues}
-                    pathPrefix={`steps[${index}]`}
-                    readOnly={!editMode}
-                    ensureSchema={ensureSchema}
-                    renderConditionalCard={renderConditionalCard}
-                    renderSwitchCard={renderSwitchCard}
-                  />
-                ) : step.type === SWITCH_STEP_TYPE ? (
-                  <SwitchCard
-                    step={step as SwitchStepConfig}
-                    catalog={stepCatalog}
-                    schemaCache={stepSchemaCache}
-                    schemaLoadingFor={stepSchemaLoadingFor}
-                    operators={operators}
-                    variableSources={variableSources}
-                    index={index + 1}
-                    total={config.steps.length}
-                    onChange={next => updateStepAt(index, next)}
-                    onMoveUp={() => handleMoveStep(index, -1)}
-                    onMoveDown={() => handleMoveStep(index, 1)}
-                    onDelete={() => handleDeleteStep(index)}
-                    issues={stepIssues}
-                    pathPrefix={`steps[${index}]`}
-                    readOnly={!editMode}
-                    ensureSchema={ensureSchema}
-                    renderConditionalCard={renderConditionalCard}
-                    renderSwitchCard={renderSwitchCard}
-                  />
-                ) : (
-                  <StepCard
-                    step={step as ActionStepConfig}
-                    catalogItem={
-                      stepCatalog.find(c => c.type === (step as ActionStepConfig).type) ?? null
-                    }
-                    schema={stepSchemaCache[(step as ActionStepConfig).type] ?? null}
-                    schemaLoading={stepSchemaLoadingFor((step as ActionStepConfig).type)}
-                    index={index + 1}
-                    total={config.steps.length}
-                    variableSources={variableSources}
-                    onConfigChange={cfg => handleStepConfigChange(index, cfg)}
-                    onMoveUp={() => handleMoveStep(index, -1)}
-                    onMoveDown={() => handleMoveStep(index, 1)}
-                    onDelete={() => handleDeleteStep(index)}
-                    issues={stepIssues}
-                    pathPrefix={`steps[${index}].config.`}
-                    readOnly={!editMode}
-                  />
+            <AutomationIdContext.Provider value={savedId ?? undefined}>
+              {config.steps.map((step, index) => {
+                const isLast = index === config.steps.length - 1;
+                const variableSources = buildVariableSources(
+                  triggerSchema,
+                  config.trigger.config,
+                  config.steps,
+                  stepSchemaCache,
+                  index,
+                  formFieldNameMap,
                 );
+                const stepIssues = issuesUnder(validation?.issues, `steps[${index}]`);
 
-              return (
-                <div key={step.id} className='flex flex-col'>
-                  {card}
-                  {!isLast && (
-                    <AddStepRow
+                const card =
+                  step.type === CONDITIONAL_STEP_TYPE ? (
+                    <ConditionalCard
+                      step={step as ConditionalStepConfig}
                       catalog={stepCatalog}
-                      onPick={type => handleAddStep(type, index + 1)}
+                      schemaCache={stepSchemaCache}
+                      schemaLoadingFor={stepSchemaLoadingFor}
+                      operators={operators}
+                      variableSources={variableSources}
+                      index={index + 1}
+                      total={config.steps.length}
+                      onChange={next => updateStepAt(index, next)}
+                      onMoveUp={() => handleMoveStep(index, -1)}
+                      onMoveDown={() => handleMoveStep(index, 1)}
+                      onDelete={() => handleDeleteStep(index)}
+                      issues={stepIssues}
+                      pathPrefix={`steps[${index}]`}
+                      readOnly={!editMode}
+                      ensureSchema={ensureSchema}
+                      renderConditionalCard={renderConditionalCard}
+                      renderSwitchCard={renderSwitchCard}
                     />
-                  )}
-                </div>
-              );
-            })}
+                  ) : step.type === SWITCH_STEP_TYPE ? (
+                    <SwitchCard
+                      step={step as SwitchStepConfig}
+                      catalog={stepCatalog}
+                      schemaCache={stepSchemaCache}
+                      schemaLoadingFor={stepSchemaLoadingFor}
+                      operators={operators}
+                      variableSources={variableSources}
+                      index={index + 1}
+                      total={config.steps.length}
+                      onChange={next => updateStepAt(index, next)}
+                      onMoveUp={() => handleMoveStep(index, -1)}
+                      onMoveDown={() => handleMoveStep(index, 1)}
+                      onDelete={() => handleDeleteStep(index)}
+                      issues={stepIssues}
+                      pathPrefix={`steps[${index}]`}
+                      readOnly={!editMode}
+                      ensureSchema={ensureSchema}
+                      renderConditionalCard={renderConditionalCard}
+                      renderSwitchCard={renderSwitchCard}
+                    />
+                  ) : (
+                    <StepCard
+                      step={step as ActionStepConfig}
+                      catalogItem={
+                        stepCatalog.find(c => c.type === (step as ActionStepConfig).type) ?? null
+                      }
+                      schema={stepSchemaCache[(step as ActionStepConfig).type] ?? null}
+                      schemaLoading={stepSchemaLoadingFor((step as ActionStepConfig).type)}
+                      index={index + 1}
+                      total={config.steps.length}
+                      variableSources={variableSources}
+                      onConfigChange={cfg => handleStepConfigChange(index, cfg)}
+                      onMoveUp={() => handleMoveStep(index, -1)}
+                      onMoveDown={() => handleMoveStep(index, 1)}
+                      onDelete={() => handleDeleteStep(index)}
+                      issues={stepIssues}
+                      pathPrefix={`steps[${index}].config.`}
+                      readOnly={!editMode}
+                    />
+                  );
+
+                return (
+                  <div key={step.id} className='flex flex-col'>
+                    {card}
+                    {!isLast && (
+                      <AddStepRow
+                        catalog={stepCatalog}
+                        onPick={type => handleAddStep(type, index + 1)}
+                      />
+                    )}
+                  </div>
+                );
+              })}
+            </AutomationIdContext.Provider>
 
             {config.steps.length > 0 && (
               <AddStepRow catalog={stepCatalog} onPick={type => handleAddStep(type)} />

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/AutomationIdContext.ts
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/AutomationIdContext.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+
+// Own module: AutomationBuilder imports StepCard, so a step form reading this from it would cycle.
+export const AutomationIdContext = createContext<string | undefined>(undefined);

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/StepCard/FileAttachmentsField.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/StepCard/FileAttachmentsField.tsx
@@ -1,0 +1,177 @@
+import { useRef, useState } from 'react';
+import { Loader2, Paperclip, Trash2, Upload } from 'lucide-react';
+import { toast } from 'sonner';
+import { cn } from '../../../../utils/classNames';
+import {
+  releaseAutomationTemplate,
+  uploadAutomationTemplates,
+  type AutomationTemplateAttachment,
+} from '../../../../api/automationsApi';
+
+const MAX_FILES = 10;
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+const MAX_TOTAL_BYTES = 25 * 1024 * 1024;
+
+interface FileAttachmentsFieldProps {
+  stepId: string;
+  value: AutomationTemplateAttachment[];
+  onChange: (next: AutomationTemplateAttachment[]) => void;
+  readOnly?: boolean;
+}
+
+/**
+ * Files sent exactly as uploaded, of any type. TemplateAttachmentsField is the
+ * text-template sibling; its editor, preview and variable picker only make sense
+ * for a file whose bytes are UTF-8 text, so binaries get this plainer field.
+ */
+export function FileAttachmentsField({
+  stepId,
+  value,
+  onChange,
+  readOnly = false,
+}: FileAttachmentsFieldProps): React.ReactElement {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [dragging, setDragging] = useState(false);
+
+  const addFiles = async (incoming: File[]): Promise<void> => {
+    const error = validateFiles(incoming, value);
+    if (error) {
+      toast.error(error);
+      return;
+    }
+    setUploading(true);
+    try {
+      const uploaded = await uploadAutomationTemplates(stepId, incoming);
+      onChange([...value, ...uploaded]);
+      toast.success(uploaded.length === 1 ? 'File attached' : `${uploaded.length} files attached`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'File upload failed');
+    } finally {
+      setUploading(false);
+      if (inputRef.current) inputRef.current.value = '';
+    }
+  };
+
+  const remove = (attachment: AutomationTemplateAttachment): void => {
+    onChange(value.filter(file => file.attachmentId !== attachment.attachmentId));
+    releaseAutomationTemplate(attachment.attachmentId).catch(error => {
+      toast.error(error instanceof Error ? error.message : 'Could not release the file');
+    });
+  };
+
+  return (
+    <div className='flex flex-col gap-2'>
+      {value.length > 0 ? (
+        <div
+          className='overflow-hidden rounded-md border border-border'
+          data-testid='automation-file-attachments'
+        >
+          {value.map((attachment, index) => (
+            <div
+              key={attachment.attachmentId}
+              className={cn(
+                'flex items-center gap-3 px-3 py-2.5',
+                index > 0 && 'border-t border-border',
+              )}
+            >
+              <div className='flex size-8 shrink-0 items-center justify-center rounded-md bg-sky-500/10 text-sky-700 dark:text-sky-300'>
+                <Paperclip className='size-4' />
+              </div>
+              <div className='min-w-0 flex-1'>
+                <div className='truncate text-sm font-medium text-foreground'>
+                  {attachment.originalFilename}
+                </div>
+                <div className='flex items-center gap-2 text-[11px] text-muted-foreground'>
+                  <span>{formatBytes(attachment.size)}</span>
+                  {/* Only .txt/.md/.html are templated, so this badge is the
+                      per-file proof of which rule a given upload landed under. */}
+                  {attachment.templatePaths.length > 0 ? (
+                    <span className='rounded bg-amber-500/10 px-1.5 py-0.5 text-amber-700 dark:text-amber-300'>
+                      {attachment.templatePaths.length} variable
+                      {attachment.templatePaths.length === 1 ? '' : 's'}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+              {!readOnly ? (
+                <button
+                  type='button'
+                  data-track-category='automation-builder'
+                  data-track-name='email-attachment-remove'
+                  aria-label='Remove file'
+                  title='Remove file'
+                  onClick={() => remove(attachment)}
+                  className='flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground'
+                >
+                  <Trash2 className='size-3.5' />
+                </button>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {!readOnly && value.length < MAX_FILES ? (
+        <button
+          type='button'
+          data-track-category='automation-builder'
+          data-track-name='email-attachment-upload'
+          disabled={uploading}
+          onClick={() => inputRef.current?.click()}
+          onDragEnter={event => {
+            event.preventDefault();
+            setDragging(true);
+          }}
+          onDragOver={event => event.preventDefault()}
+          onDragLeave={() => setDragging(false)}
+          onDrop={event => {
+            event.preventDefault();
+            setDragging(false);
+            void addFiles(Array.from(event.dataTransfer.files));
+          }}
+          className={cn(
+            'flex min-h-20 items-center justify-center gap-3 rounded-md border border-dashed px-4 py-3 text-left',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/40',
+            dragging
+              ? 'border-sky-500 bg-sky-500/10 text-foreground'
+              : 'border-border text-muted-foreground hover:border-foreground/30 hover:bg-accent/30',
+          )}
+        >
+          {uploading ? <Loader2 className='size-4 animate-spin' /> : <Upload className='size-4' />}
+          <span className='flex flex-col'>
+            <span className='text-sm font-medium text-foreground'>
+              {uploading ? 'Uploading files…' : 'Upload files'}
+            </span>
+            <span className='text-[11px]'>Choose or drop any file, up to 10MB each</span>
+          </span>
+        </button>
+      ) : null}
+      <input
+        ref={inputRef}
+        className='hidden'
+        type='file'
+        multiple
+        onChange={event => void addFiles(Array.from(event.target.files ?? []))}
+      />
+    </div>
+  );
+}
+
+function validateFiles(incoming: File[], existing: AutomationTemplateAttachment[]): string | null {
+  if (incoming.length === 0) return 'Choose at least one file';
+  if (existing.length + incoming.length > MAX_FILES) return `Maximum ${MAX_FILES} files allowed`;
+  for (const file of incoming) {
+    if (file.size > MAX_FILE_BYTES) return `${file.name}: maximum file size is 10MB`;
+  }
+  const total =
+    existing.reduce((sum, file) => sum + file.size, 0) +
+    incoming.reduce((sum, file) => sum + file.size, 0);
+  return total > MAX_TOTAL_BYTES ? 'Total attachment size cannot exceed 25MB' : null;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/StepCard/SendEmailToUserStepForm.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/StepCard/SendEmailToUserStepForm.tsx
@@ -1,0 +1,242 @@
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { AutomationIdContext } from '../AutomationIdContext';
+import { Button } from '../../../ui/Button/Button';
+import { SchemaForm } from '../SchemaForm/SchemaForm';
+import { resolveSchema } from '../SchemaForm/SchemaForm.utils';
+import { ReferenceChip, UseVariableButton } from '../SchemaForm/VariableFieldParts';
+import { FileAttachmentsField } from './FileAttachmentsField';
+import {
+  personalEmailService,
+  type PersonalEmailStatus,
+} from '@/services/Automation/personalEmailService';
+import { recordingEmailService } from '@/services/Recording/recordingEmailService';
+import type { AutomationTemplateAttachment } from '../../../../api/automationsApi';
+import type { VariablePickerSource } from '../VariablePicker/VariablePicker.types';
+import type { JsonSchema, ValidationIssue } from '../../Automation.types';
+
+/** Rendered below by hand, so SchemaForm must not also draw them generically. */
+const CUSTOM_FIELDS = ['attachments', 'triggerAttachments'] as const;
+
+interface SendEmailToUserStepFormProps {
+  schema: JsonSchema;
+  stepId: string;
+  value: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+  issues: ValidationIssue[] | null;
+  pathPrefix: string;
+  variableSources: VariablePickerSource[];
+  readOnly?: boolean;
+}
+
+export function SendEmailToUserStepForm({
+  schema,
+  stepId,
+  value,
+  onChange,
+  issues,
+  pathPrefix,
+  variableSources,
+  readOnly = false,
+}: SendEmailToUserStepFormProps): React.ReactElement {
+  const genericSchema = useMemo(() => {
+    const resolved = resolveSchema(schema);
+    if (!resolved.properties) return resolved;
+    const properties = { ...resolved.properties };
+    CUSTOM_FIELDS.forEach(key => delete properties[key]);
+    return { ...resolved, properties };
+  }, [schema]);
+
+  // pathPrefix already ends in a dot, so the key is appended bare. Prefix rather
+  // than equality because config-validator emits an element issue as
+  // `<prefix>attachments.0.mimetype`, which no exact match would find.
+  const issueFor = (key: string): string | undefined => {
+    const base = `${pathPrefix}${key}`;
+    return (issues ?? []).find(issue => issue.path === base || issue.path.startsWith(`${base}.`))
+      ?.message;
+  };
+
+  const setField = (key: string, next: unknown): void => onChange({ ...value, [key]: next });
+
+  const triggerRef =
+    typeof value['triggerAttachments'] === 'string' ? value['triggerAttachments'] : '';
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <SchemaForm
+        schema={genericSchema}
+        value={value}
+        onChange={onChange}
+        issues={issues}
+        pathPrefix={pathPrefix}
+        variableSources={variableSources}
+      />
+      {value['sendAs'] === 'PERSONAL' ? <PersonalMailboxNotice /> : null}
+
+      <FieldRow
+        label='Files'
+        error={issueFor('attachments')}
+        description='Sent exactly as uploaded. Only .txt, .md and .html files have their variables resolved first.'
+      >
+        <FileAttachmentsField
+          stepId={stepId}
+          value={
+            Array.isArray(value['attachments'])
+              ? (value['attachments'] as AutomationTemplateAttachment[])
+              : []
+          }
+          onChange={next => setField('attachments', next)}
+          readOnly={readOnly}
+        />
+      </FieldRow>
+
+      <FieldRow
+        label='Files from the trigger'
+        error={issueFor('triggerAttachments')}
+        description='Forward the files the triggering email carried, e.g. the email attachments variable.'
+      >
+        {triggerRef ? (
+          <ReferenceChip
+            value={triggerRef}
+            sources={variableSources}
+            onClear={() => setField('triggerAttachments', undefined)}
+          />
+        ) : (
+          <UseVariableButton
+            sources={variableSources}
+            onPick={reference => setField('triggerAttachments', reference)}
+            // Only an array can resolve to a file list; without this the picker
+            // offers strings that would fail at run time instead of at pick time.
+            targetLeafType='array'
+          />
+        )}
+      </FieldRow>
+    </div>
+  );
+}
+
+function FieldRow({
+  label,
+  description,
+  error,
+  children,
+}: {
+  label: string;
+  description?: string;
+  error?: string | undefined;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <div className='flex flex-col gap-1.5'>
+      <div className='flex items-baseline gap-2'>
+        <label className='text-sm font-medium text-foreground'>{label}</label>
+        {description && <span className='text-[11px] text-muted-foreground'>{description}</span>}
+      </div>
+      {children}
+      {error && <span className='text-[11px] text-red-600'>{error}</span>}
+    </div>
+  );
+}
+
+/**
+ * Nothing in the config reveals whether the author has connected their mailbox,
+ * so without this prompt a PERSONAL step saves fine and fails on its first run.
+ */
+function PersonalMailboxNotice(): React.ReactElement {
+  const [status, setStatus] = useState<PersonalEmailStatus | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
+  // Undefined until first save, where the creator is the author.
+  const automationId = useContext(AutomationIdContext);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = (): void => {
+      personalEmailService
+        .getStatus(automationId)
+        .then(next => {
+          if (!cancelled) setStatus(next);
+        })
+        .catch(() => undefined);
+    };
+    load();
+    // Electron sends consent to the system browser while this stays mounted, so
+    // without this the notice would sit on "not connected" with no way to recheck.
+    window.addEventListener('focus', load);
+    return () => {
+      cancelled = true;
+      window.removeEventListener('focus', load);
+    };
+  }, [automationId]);
+
+  const handleConnect = useCallback(async (): Promise<void> => {
+    setIsConnecting(true);
+    try {
+      const currentPath = `${window.location.pathname}${window.location.search}`;
+      const returnPath =
+        currentPath.startsWith('/') && !currentPath.startsWith('//') ? currentPath : '/automations';
+      // Electron must hand the consent screen to the system browser, and the
+      // backend needs to know so the callback returns through /launch instead of
+      // stranding the user on the web app. Mirrors the recording composer.
+      const isElectron = typeof window.electronAPI?.openExternal === 'function';
+      const authUrl = await recordingEmailService.connectGoogle(
+        returnPath,
+        isElectron ? 'electron' : 'web',
+      );
+      // Never navigate this tab away: the builder holds the whole automation in
+      // component state with no draft persistence, so leaving would discard every
+      // unsaved edit — including the sendAs choice that raised this prompt.
+      if (isElectron) {
+        window.electronAPI?.openExternal(authUrl);
+      } else {
+        window.open(authUrl, '_blank', 'noopener');
+      }
+      setIsConnecting(false);
+    } catch (error) {
+      const message =
+        (error as { response?: { data?: { error?: string } } })?.response?.data?.error ||
+        (error instanceof Error ? error.message : 'Unable to start Google email connection');
+      toast.error(message);
+      setIsConnecting(false);
+    }
+  }, []);
+
+  // A failed status call leaves this unknown; showing "not connected" then would
+  // nag a connected author forever and send them through a pointless consent.
+  if (!status) return <></>;
+
+  return (
+    <div
+      className={`rounded-md border px-3 py-2 text-[12px] ${
+        status.connected
+          ? 'border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-900/60 dark:bg-emerald-950/30 dark:text-emerald-200'
+          : 'border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200'
+      }`}
+    >
+      <div className='flex flex-wrap items-center gap-x-3 gap-y-2'>
+        <span>
+          {status.connected
+            ? `Sending as ${status.email ?? "the automation owner's Google account"}${
+                status.isOwner ? '.' : ' — the automation owner.'
+              }`
+            : status.isOwner
+              ? 'Connect your Google account so this step can send from your own address.'
+              : `The owner (${status.email ?? 'unknown'}) has to reconnect their Google account before this can send.`}
+        </span>
+        {/* Only the owner can grant consent, and only their grant is ever used.
+            Offered even when connected: a revoked grant is fixed by reconnecting. */}
+        {status.isOwner ? (
+          <Button
+            type='button'
+            size='sm'
+            variant='secondary'
+            onClick={() => void handleConnect()}
+            disabled={isConnecting}
+            loading={isConnecting}
+          >
+            {status.connected ? 'Reconnect' : 'Connect Google account'}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/StepCard/StepCard.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/StepCard/StepCard.tsx
@@ -26,6 +26,7 @@ import { CreateEmailDraftStepForm } from './CreateEmailDraftStepForm';
 import { ReplyOnMessageStepForm } from './ReplyOnMessageStepForm';
 import { NotifyStepForm } from './NotifyStepForm';
 import { ApplyConversationLabelStepForm } from './ApplyConversationLabelStepForm';
+import { SendEmailToUserStepForm } from './SendEmailToUserStepForm';
 import type { StepCardProps } from './StepCard.types';
 
 export function StepCard({
@@ -246,6 +247,17 @@ export function StepCard({
                 step.type === 'NOTIFY_GROUP' ? (
                 <NotifyStepForm
                   recipient={step.type === 'NOTIFY_GROUP' ? 'group' : 'user'}
+                  value={step.config}
+                  onChange={onConfigChange}
+                  issues={issues ?? null}
+                  pathPrefix={pathPrefix}
+                  variableSources={variableSources}
+                />
+              ) : step.type === 'SEND_EMAIL_TO_USER' ? (
+                <SendEmailToUserStepForm
+                  schema={schema.configSchema}
+                  stepId={step.id}
+                  readOnly={readOnly}
                   value={step.config}
                   onChange={onConfigChange}
                   issues={issues ?? null}

--- a/apps/dashboard/src/services/Automation/personalEmailService.ts
+++ b/apps/dashboard/src/services/Automation/personalEmailService.ts
@@ -1,0 +1,25 @@
+import { apiInstance } from '../clients/apiClient';
+
+// Connection status for the mailbox behind a PERSONAL SEND_EMAIL_TO_USER step.
+// Connecting is the recap composer's flow: recordingEmailService.connectGoogle.
+
+export interface PersonalEmailStatus {
+  connected: boolean;
+  /** Whether the viewer is the automation's author — only they can grant consent. */
+  isOwner: boolean;
+  /** The connected address, or the address that would have to be connected. */
+  email: string | null;
+}
+
+class PersonalEmailService {
+  /** `automationId` reports on that automation's author; omitted means the caller. */
+  async getStatus(automationId?: string): Promise<PersonalEmailStatus> {
+    const response = await apiInstance.get<PersonalEmailStatus>(
+      '/integrations/google/connect/personal-email/status',
+      automationId ? { params: { automationId } } : undefined,
+    );
+    return response.data;
+  }
+}
+
+export const personalEmailService = new PersonalEmailService();


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

XYNE-63002. The `SEND_EMAIL_TO_USER` automation step could only send a subject and a body, so an automation had no way to deliver a document, or to pass along what an inbound email arrived with. The upload machinery that existed (`automation-template.service.ts`) was templates-only, restricted to `.txt/.md/.html`, and the email trigger exposed just `hasAttachments: boolean` with no descriptors to reference.

Two routes are added:

- **Upload any file type on the step.** `automation-template.service` now stores a non-template file byte-for-byte, marked by an empty `templatePaths`. Text templates keep resolving `{{context...}}` exactly as before.
- **Forward the triggering email's own files** via `{{trigger.email.attachments}}`. The email trigger's output gained an `attachments` array, hydrated from the same single query that already computed `hasAttachments`.

Both feed `fileAttachments` on `sendMailNew`, which the Google and Microsoft adapters already forwarded — no adapter change.

**Only the `id` from a trigger reference is trusted.** Filename, mimetype and bytes are re-read from `message_attachments` and filtered on `workspaceId` + `entityType: EMAIL` + `!isDeleted`, because `findByIds` is unscoped. Their recorded sizes are summed and checked *before* any buffer is loaded, since inbound mail carries no per-file cap of its own.

**What deliberately did not change:** the upload middleware already used the shared workspace-wide `uploadFileFilter` (PDFs and images were always allowed), and `claimAutomationTemplates` walks the config generically — so claim, release and GC cover the new step with no route changes. `TemplateAttachmentsField.tsx`, which `SEND_MESSAGE` uses, is untouched; the new `FileAttachmentsField` is a separate, plainer component, because the editor, preview and text-returning download in the original would corrupt a binary.

`hasEmailAttachment` was deleted from `MessageAttachmentRepository` — this change orphaned it.

### Known limitation

`MicrosoftDeskService.sendNewEmail` inlines attachments as base64 into a single `/me/sendMail` POST, which Graph caps at ~3MB; the chunked upload-session path exists only on the reply sender. Gmail handles the full 25MB. Pre-existing and unchanged here — worth a follow-up if Microsoft-backed desks need large attachments.

### Pre-existing bugs found, not fixed here

- `SendMessageStepForm.tsx:43-44` builds `` `${pathPrefix}.` `` where `pathPrefix` already ends in a dot, so `SEND_MESSAGE`'s per-field validation errors never match and are silently dead.
- `issuesForField` (`SchemaForm.utils.ts:261`) matches exactly, so every generic SchemaForm field misses element-level issues such as `...attachments.0.mimetype`.

## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] Existing contract modified (shape, status codes, auth)

`AutomationTemplateAttachment.mimetype` widens from the literal union `'text/plain' | 'text/markdown' | 'text/html'` to `string`, on both `POST /automations/attachments` and the step config. Additive and backward compatible: every value the old contract could return is still valid. The `EMAIL_RECEIVED` trigger output gains an `attachments` array; existing fields are unchanged.

---

## How did you test it?

Static analysis plus the full pre-commit suite. The change was reviewed file by file against a separate adversarial reviewer, which caught four defects that are fixed here: plain-text files such as `.csv` silently losing templating; trigger attachments being loaded into memory before the size check; the variable picker offering string variables that only fail at run time; and both hand-surfaced validation errors being dead due to a double dot and an exact-match path comparison.

### Automated

- [x] Not covered by tests <!-- no existing test suite for automation steps; verified by typecheck, build and lint -->

### Manual

Not manually exercised end to end — the Microsoft ~3MB path in particular is worth a real send before this is relied on for large files.

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Backend `typecheck` + `build` pass
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [x] Commits follow `<type>: <TICKET-ID> <subject>`
- [x] No debug logging or commented-out code left behind
