### PR TITLE
fix: XYNE-56410 render DM add-member system message with plain names

### DIFF
--- a/apps/backend/src/controllers/channelController.ts
+++ b/apps/backend/src/controllers/channelController.ts
@@ -169,7 +169,17 @@ export class ChannelController {
       } else if (operationType === 'conversation_moved_target') {
         systemContent = `${actor} moved messages from a previous conversation into this one`;
       } else {
-        systemContent = `${formattedUsers} ${pills.length === 1 ? 'was' : 'were'} ${addedOrRemovedText} by ${actor}`;
+        // Add/remove participant system messages use PLAIN names, matching the
+        // channel-side generator (formatSystemGenerateMessage) so both the DM and
+        // channel add-member messages render identically. Names stay escaped.
+        const plainNames = newParticipants.map(p => esc(p.userName));
+        let plainUsers = '';
+        if (plainNames.length === 1) {
+          plainUsers = plainNames[0];
+        } else if (plainNames.length > 1) {
+          plainUsers = `${plainNames.slice(0, -1).join(', ')} and ${plainNames[plainNames.length - 1]}`;
+        }
+        systemContent = `${plainUsers} ${plainNames.length === 1 ? 'was' : 'were'} ${addedOrRemovedText} by ${esc(authData.name)}`;
       }
 
       // Create metadata


### PR DESCRIPTION
## What
The DM participant add/remove system message ("X was added by Y") was rendering every name as a blue @mention pill (introduced in #690). Those pills keep a fixed blue color while the system-message line is muted (`text-muted-foreground`), so the line looked "neither faded nor bold."

This reverts the add/remove branch of `channelController.sendAddAndRemoveParticipantsSystemMessage` to emit PLAIN (escaped) names + "by <actor name>", matching the channel-side generator `formatSystemGenerateMessage` (`systemMessagesUtils.ts`). Now the DM and channel add-member messages render identically. No CSS override was added.

## Scope
- Only the `participants_added` / `participants_removed` branch changed.
- The separate `conversation_moved_*` messages (also added in #690) are untouched.
- HTML-escaping of names is retained.

## Files
- apps/backend/src/controllers/channelController.ts