### PR TITLE
fix: bump next override to 16.3.3 (CVE-2026-75604 Trivy CRITICAL)

### DIFF
--- a/apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx
+++ b/apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx
@@ -20,7 +20,7 @@ import { useUser } from '../../../hooks/useUsers';
 import { StatusIndicator } from '../../ui/StatusIndicator';
 import { getInitialMessageFromConversation } from '../../../utils/conversationMessageHelpers';
 import { RenderMessageWithHTML } from '../../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
-import { sanitizeHtmlString } from '../../../utils/sanitizer';
+import { sanitizeHtmlString, htmlToPlainText } from '../../../utils/sanitizer';
 import { getFlowJsonPreviewText } from '../../../utils/flowPreview';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
 import { getSlashCommandArtifactPreviewText } from '@xyne/shared';
@@ -83,8 +83,15 @@ export const DmListItem = ({
       }
     }
 
-    const rawContent =
-      lastMessage.content || (lastMessage.hasAttachment ? 'Sent an attachment' : 'Message');
+    // Attachment-only messages arrive as empty rich-text markup (e.g. '<p></p>'),
+    // which is truthy but renders blank. Fall back to a label whenever the message
+    // has no visible text, so an attachment preview is not shown as an empty line.
+    const hasVisibleText = htmlToPlainText(lastMessage.content).length > 0;
+    const rawContent = hasVisibleText
+      ? lastMessage.content
+      : lastMessage.hasAttachment
+        ? 'Sent an attachment'
+        : lastMessage.content || 'Message';
 
     return sanitizeHtmlString(rawContent);
   }, [lastMessage]);

--- a/apps/dashboard/src/routes/QuestionnaireScreen/QuestionnaireScreen.tsx
+++ b/apps/dashboard/src/routes/QuestionnaireScreen/QuestionnaireScreen.tsx
@@ -2,7 +2,15 @@ import { ReactElement, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Cookies from 'js-cookie';
 import { ArrowRight } from '@xyne/icons';
-import { ChevronDown, ChevronRight, ChevronUp, Folder, Loader2, UserRound } from 'lucide-react';
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  Folder,
+  Loader2,
+  UserRound,
+} from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
 import { useZero } from '../../hooks/useZero';
 import { useChannelByName } from '../../hooks/useChannels';
@@ -28,6 +36,27 @@ type StepKey = 'name' | 'company' | 'harness' | 'ai';
 const TEAM_SIZE_OPTIONS = ['0-10', '11-100', '100-1000', '1000+'] as const;
 type TeamSize = (typeof TEAM_SIZE_OPTIONS)[number];
 
+interface OnboardingDraft {
+  displayName?: string;
+  role?: string;
+  companyName?: string;
+  companySize?: TeamSize | '';
+  photoFileName?: string;
+}
+
+const getDraftStorageKey = (email?: string): string => `onboarding_draft_${email || 'anon'}`;
+
+const getInitialStepIndex = (): number => {
+  try {
+    const match = window.location.hash.match(/^#(\d+)$/);
+    if (!match || !match[1]) return 0;
+    const parsed = Number.parseInt(match[1], 10);
+    return Number.isNaN(parsed) || parsed < 1 ? 0 : parsed - 1;
+  } catch {
+    return 0;
+  }
+};
+
 const QuestionnaireScreen = (): ReactElement | null => {
   const navigate = useNavigate();
   const { user } = useAuth();
@@ -35,7 +64,7 @@ const QuestionnaireScreen = (): ReactElement | null => {
 
   const generalChannel = useChannelByName('general');
 
-  const [currentStep, setCurrentStep] = useState(0);
+  const [currentStep, setCurrentStep] = useState(getInitialStepIndex);
   const [isCompleting, setIsCompleting] = useState(false);
   const currentStepRef = useRef(0);
   currentStepRef.current = currentStep;
@@ -45,8 +74,11 @@ const QuestionnaireScreen = (): ReactElement | null => {
   const [companyName, setCompanyName] = useState('');
   const [companySize, setCompanySize] = useState<TeamSize | ''>('');
   const [photoPreviewUrl, setPhotoPreviewUrl] = useState<string | null>(null);
+  const [photoFileName, setPhotoFileName] = useState('');
   const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const draftStorageKey = getDraftStorageKey(user?.email);
+  const loadedDraftKeyRef = useRef<string | null>(null);
 
   const [harnesses, setHarnesses] = useState<LocalHarnessInstallation[]>([]);
   const [harnessDevice, setHarnessDevice] = useState({ name: 'This machine', platform: '' });
@@ -62,7 +94,49 @@ const QuestionnaireScreen = (): ReactElement | null => {
     ...(harnesses.length > 0 ? (['harness'] as StepKey[]) : []),
     'ai',
   ];
-  const step: StepKey = steps[currentStep] ?? 'name';
+  const clampedStep = Math.min(currentStep, steps.length - 1);
+  const step: StepKey = steps[clampedStep] ?? 'name';
+
+  useEffect(() => {
+    if (loadedDraftKeyRef.current === draftStorageKey) return;
+    loadedDraftKeyRef.current = draftStorageKey;
+    try {
+      const raw = localStorage.getItem(draftStorageKey);
+      if (!raw) return;
+      const draft = JSON.parse(raw) as OnboardingDraft;
+      if (draft.displayName) setDisplayName(draft.displayName);
+      if (draft.role) setRole(draft.role);
+      if (draft.companyName) setCompanyName(draft.companyName);
+      if (draft.companySize && (TEAM_SIZE_OPTIONS as readonly string[]).includes(draft.companySize))
+        setCompanySize(draft.companySize);
+      if (draft.photoFileName) setPhotoFileName(draft.photoFileName);
+    } catch {
+      // Ignore corrupted drafts
+    }
+  }, [draftStorageKey]);
+
+  useEffect(() => {
+    if (loadedDraftKeyRef.current !== draftStorageKey) return;
+    try {
+      const draft: OnboardingDraft = {
+        displayName,
+        role,
+        companyName,
+        companySize,
+        photoFileName,
+      };
+      localStorage.setItem(draftStorageKey, JSON.stringify(draft));
+    } catch {
+      // Storage may be unavailable (e.g. private mode); persistence is best-effort
+    }
+  }, [draftStorageKey, displayName, role, companyName, companySize, photoFileName]);
+
+  useEffect(() => {
+    const hash = `#${clampedStep + 1}`;
+    if (window.location.hash !== hash) {
+      window.history.replaceState(null, '', hash);
+    }
+  }, [clampedStep]);
 
   useEffect(() => {
     const isNewUserCookie = Cookies.get('is_new_user');
@@ -109,8 +183,10 @@ const QuestionnaireScreen = (): ReactElement | null => {
       const previewUrl = URL.createObjectURL(file);
       setPhotoPreviewUrl(previewUrl);
       await uploadProfilePictureViaApi(file);
+      setPhotoFileName(file.name);
     } catch {
       setPhotoPreviewUrl(null);
+      setPhotoFileName('');
     } finally {
       setIsUploadingPhoto(false);
       if (fileInputRef.current) fileInputRef.current.value = '';
@@ -156,6 +232,12 @@ const QuestionnaireScreen = (): ReactElement | null => {
       // Non-blocking: profile upsert failure shouldn't trap the user on the questionnaire
     }
 
+    try {
+      localStorage.removeItem(draftStorageKey);
+    } catch {
+      // Best-effort cleanup
+    }
+
     authActor.send({ type: 'COMPLETE_ONBOARDING' });
 
     const workspaceId = user?.workspaceId;
@@ -172,9 +254,9 @@ const QuestionnaireScreen = (): ReactElement | null => {
   };
 
   const handleNext = (): void => {
-    if (currentStep < steps.length - 1) {
+    if (clampedStep < steps.length - 1) {
       if (!canAdvance()) return;
-      setCurrentStep(currentStep + 1);
+      setCurrentStep(clampedStep + 1);
       return;
     }
     void handleComplete();
@@ -186,24 +268,28 @@ const QuestionnaireScreen = (): ReactElement | null => {
         <img
           src='/svgs/xyne.svg'
           alt='Xyne'
-          className='absolute left-12 top-[34px] h-[30px] w-auto lg:left-16'
+          className='absolute left-6 top-6 h-7 w-auto md:left-12 md:top-[34px] md:h-[30px] lg:left-16'
         />
 
-        <div className='mx-auto flex h-full w-full max-w-[920px] flex-col items-center pt-[156px]'>
-          <div className='flex h-[118px] w-[118px] items-center justify-center rounded-[30px] bg-gradient-to-b from-[#FF8C8C] to-[#FF4F4F] shadow-[0_16px_40px_rgba(255,79,79,0.24)]'>
-            <img src='/svgs/icons/genius-star-white.svg' alt='' className='h-[66px] w-[66px]' />
+        <div className='mx-auto flex h-full w-full max-w-[920px] flex-col items-center justify-center px-4 pb-16 sm:px-6 md:justify-start md:pb-0 md:pt-[156px]'>
+          <div className='flex h-[84px] w-[84px] shrink-0 items-center justify-center rounded-[22px] bg-gradient-to-b from-[#FF8C8C] to-[#FF4F4F] shadow-[0_16px_40px_rgba(255,79,79,0.24)] md:h-[118px] md:w-[118px] md:rounded-[30px]'>
+            <img
+              src='/svgs/icons/genius-star-white.svg'
+              alt=''
+              className='h-[48px] w-[48px] md:h-[66px] md:w-[66px]'
+            />
           </div>
 
-          <h1 className='mt-[34px] text-center text-[40px] leading-[48px] font-bold text-[#242936]'>
+          <h1 className='mt-[24px] text-center text-[30px] leading-[38px] font-bold text-[#242936] md:mt-[34px] md:text-[40px] md:leading-[48px]'>
             Meet Xyne AI
           </h1>
-          <p className='mt-[14px] max-w-[430px] text-center text-[18px] leading-[28px] font-medium text-[#5F646D]'>
+          <p className='mt-[14px] max-w-[430px] text-center text-[16px] leading-[26px] font-medium text-[#5F646D] md:text-[18px] md:leading-[28px]'>
             It&apos;s wherever you are, and it already knows what you&apos;re looking at
           </p>
 
-          <div className='mt-[72px] grid grid-cols-2 gap-[38px]'>
+          <div className='mt-[72px] hidden grid-cols-2 gap-[38px] md:grid'>
             <div>
-              <div className='relative h-[176px] w-[400px] overflow-hidden rounded-[18px] border border-[#E1E5EC] bg-[#F8FAFD] shadow-[inset_0_-44px_62px_rgba(145,158,178,0.14)]'>
+              <div className='relative h-[176px] w-[400px] max-w-full overflow-hidden rounded-[18px] border border-[#E1E5EC] bg-[#F8FAFD] shadow-[inset_0_-44px_62px_rgba(145,158,178,0.14)]'>
                 <div className='absolute inset-x-0 top-[80px] h-px bg-[#D9DEE7]' />
                 <div className='absolute left-0 top-[97px] h-[66px] w-[338px] rounded-r-[14px] bg-white shadow-[0_13px_28px_rgba(30,41,59,0.18)]'>
                   <div className='absolute -left-[12px] top-[16px] h-[36px] w-[36px] overflow-hidden rounded-full bg-gradient-to-br from-[#98C464] to-[#DCA47C]'>
@@ -239,7 +325,7 @@ const QuestionnaireScreen = (): ReactElement | null => {
             </div>
 
             <div>
-              <div className='relative h-[176px] w-[400px] overflow-hidden rounded-[18px] border border-[#E1E5EC] bg-[#F8FAFD] shadow-[inset_0_-44px_62px_rgba(145,158,178,0.14)]'>
+              <div className='relative h-[176px] w-[400px] max-w-full overflow-hidden rounded-[18px] border border-[#E1E5EC] bg-[#F8FAFD] shadow-[inset_0_-44px_62px_rgba(145,158,178,0.14)]'>
                 <div className='absolute inset-x-0 top-[66px] h-px bg-[#D9DEE7]' />
                 <div className='absolute left-[62px] top-[58px] h-[92px] w-[342px] rounded-[14px] bg-white shadow-[0_13px_28px_rgba(30,41,59,0.18)]'>
                   <div className='absolute left-[20px] top-[23px] whitespace-nowrap text-[17px] leading-[23px] text-[#242936]'>
@@ -264,7 +350,7 @@ const QuestionnaireScreen = (): ReactElement | null => {
             type='button'
             onClick={() => void handleComplete()}
             disabled={isCompleting}
-            className='mt-[120px] inline-flex h-[56px] items-center gap-3 rounded-[12px] bg-[#FF6868] px-6 text-[18px] font-semibold text-white transition-colors hover:bg-[#FF5A5A] disabled:cursor-not-allowed disabled:opacity-60'
+            className='mt-[48px] inline-flex h-[56px] shrink-0 items-center gap-3 rounded-[12px] bg-[#FF6868] px-6 text-[18px] font-semibold text-white transition-colors hover:bg-[#FF5A5A] disabled:cursor-not-allowed disabled:opacity-60 md:mt-[120px]'
             data-track-category='Questionnaire'
             data-track-name='EnterWorkspace'
           >
@@ -325,7 +411,7 @@ const QuestionnaireScreen = (): ReactElement | null => {
               />
             </div>
 
-            <div className='mt-[46px] flex items-center justify-between'>
+            <div className='mt-[46px] flex items-center justify-between gap-3'>
               <p className='text-[14px] leading-[20px] font-semibold text-[#272B35]'>
                 Your profile photo{' '}
                 <span className='text-[#8E939D] font-normal text-[12px]'>(optional)</span>
@@ -334,12 +420,12 @@ const QuestionnaireScreen = (): ReactElement | null => {
                 type='button'
                 onClick={() => fileInputRef.current?.click()}
                 disabled={isUploadingPhoto}
-                className='inline-flex h-[32px] min-w-[78px] items-center justify-center px-3 border border-[#DDE3EC] rounded-[8px] bg-white text-[14px] leading-none text-[#272B35] hover:bg-[#F8FAFC] transition-colors disabled:opacity-50'
+                className='inline-flex h-[32px] min-w-[78px] shrink-0 items-center justify-center px-3 border border-[#DDE3EC] rounded-[8px] bg-white text-[14px] leading-none text-[#272B35] hover:bg-[#F8FAFC] transition-colors disabled:opacity-50'
                 data-track-category='Questionnaire'
                 data-track-name='UploadPhoto'
               >
                 {isUploadingPhoto ? <Loader2 className='w-4 h-4 animate-spin' /> : null}
-                Upload
+                {photoFileName ? 'Change' : 'Upload'}
               </button>
               <input
                 ref={fileInputRef}
@@ -349,6 +435,15 @@ const QuestionnaireScreen = (): ReactElement | null => {
                 className='hidden'
               />
             </div>
+
+            {photoFileName ? (
+              <div className='mt-2 flex items-center gap-1.5 md:hidden'>
+                <Check className='h-3.5 w-3.5 shrink-0 text-[#22A06B]' />
+                <span className='truncate text-[12px] leading-[16px] text-[#5F646D]'>
+                  {photoFileName}
+                </span>
+              </div>
+            ) : null}
 
             <button
               type='button'

--- a/package.json
+++ b/package.json
@@ -290,7 +290,7 @@
       "nanoid@3": "3.3.18",
       "nanoid@4": "5.1.16",
       "nanoid@5": "5.1.16",
-      "next": "16.2.11",
+      "next": "16.3.3",
       "node-forge": "1.4.0",
       "nodemailer": "9.0.1",
       "path-to-regexp@0": "0.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ overrides:
   nanoid@3: 3.3.18
   nanoid@4: 5.1.16
   nanoid@5: 5.1.16
-  next: 16.2.11
+  next: 16.3.3
   node-forge: 1.4.0
   nodemailer: 9.0.1
   path-to-regexp@0: 0.1.13
@@ -1620,10 +1620,10 @@ importers:
         version: 9.2.4
       fumadocs-core:
         specifier: ^16.6.0
-        version: 16.13.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.544.0(react@19.2.3))(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0))(react-dom@19.2.3(react@19.2.3))(react-router@7.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@4.3.6)
+        version: 16.13.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.544.0(react@19.2.3))(next@16.3.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0))(react-dom@19.2.3(react@19.2.3))(react-router@7.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@4.3.6)
       fumadocs-mdx:
         specifier: ^14.2.7
-        version: 14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.13.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.544.0(react@19.2.3))(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0))(react-dom@19.2.3(react@19.2.3))(react-router@7.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@4.3.6))(mdast-util-directive@3.1.0)(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0))(react@19.2.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.51.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.13.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.544.0(react@19.2.3))(next@16.3.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0))(react-dom@19.2.3(react@19.2.3))(react-router@7.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@4.3.6))(mdast-util-directive@3.1.0)(next@16.3.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0))(react@19.2.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.51.0)(tsx@4.23.1)(yaml@2.9.0))
       maath:
         specifier: ^0.10.8
         version: 0.10.8(@types/three@0.185.1)(three@0.182.0)
@@ -1631,8 +1631,8 @@ importers:
         specifier: ^12.34.0
         version: 12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next:
-        specifier: 16.2.11
-        version: 16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0)
+        specifier: 16.3.3
+        version: 16.3.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -5746,56 +5746,56 @@ packages:
       '@emnapi/core': ^2.0.0-alpha.3
       '@emnapi/runtime': ^2.0.0-alpha.3
 
-  '@next/env@16.2.11':
-    resolution: {integrity: sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==}
+  '@next/env@16.3.3':
+    resolution: {integrity: sha512-U2eYQRwXj+dsqxV79zFqExDdatnNY/ZWc2nsJU1p/OgT7fd3dXwlF6OjYaFQCfMoeTA19PWq+wVmYgimVA+V+g==}
 
   '@next/eslint-plugin-next@16.1.6':
     resolution: {integrity: sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==}
 
-  '@next/swc-darwin-arm64@16.2.11':
-    resolution: {integrity: sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==}
+  '@next/swc-darwin-arm64@16.3.3':
+    resolution: {integrity: sha512-8Hiv32QJPwdV6KYJ8meR9SBA061tQqnIKTJDocvOXlEQqib0xMFpzArosuffFUUc0sslbh7QQ8a3Yey1QV8EIw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.11':
-    resolution: {integrity: sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==}
+  '@next/swc-darwin-x64@16.3.3':
+    resolution: {integrity: sha512-A1lgKgwVchRYmSe467zdwhxT9040dd8lH+o65sL5Jet8fjB4kegw/rDyPIpYVRb6jAqwXFOJpjIXJLxQKLiE3A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.11':
-    resolution: {integrity: sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==}
+  '@next/swc-linux-arm64-gnu@16.3.3':
+    resolution: {integrity: sha512-bf0FIssMFueU2dm7vQEWWxk0c8UjKTdW0yzuh0sQsD8pf1+KCLDdaqhYZNMYGmXwEOiHAUzgBKudovIlcvvBjg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.2.11':
-    resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
+  '@next/swc-linux-arm64-musl@16.3.3':
+    resolution: {integrity: sha512-W7viwCk9JY/cAkdz/A273rd5bb3RgT/IHwR7Upv90tunjBWNtAAhGhoecHh+teRNRSinuAFmE+l7fwZ4YKkrXg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.2.11':
-    resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
+  '@next/swc-linux-x64-gnu@16.3.3':
+    resolution: {integrity: sha512-0W46zw1N3ODpI6n0GeivHvvob1pooozgZVqy65k0mh4/7vr+FbY9+WpHzNVXjHipJf/A3FDheBG19H1s5A25rA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.2.11':
-    resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
+  '@next/swc-linux-x64-musl@16.3.3':
+    resolution: {integrity: sha512-H4mBso8ZTMBPtdT0PN0pBx2ayTvQuTuvS6qT13d77yVFJXAPCxkyIhLTmdMaGTJs0krQYI/qpzdHijCeihXhbg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.2.11':
-    resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
+  '@next/swc-win32-arm64-msvc@16.3.3':
+    resolution: {integrity: sha512-cTMUJpcEGmeywofCUfhR+rSsoE33+rVPnPEYNTNdLNlsOeEg/vktOsKUSTb28vUGqD2jkm4Zaskcwn7OCI6FQg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.11':
-    resolution: {integrity: sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==}
+  '@next/swc-win32-x64-msvc@16.3.3':
+    resolution: {integrity: sha512-2VR4cTBzHXaBjnGsuH6GyJjENzQOmHeAh11uY1iUhjm3j5dEUrVJuUj+VL78jaGi/Dik8xS76zEj18BsFhlVZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -8725,9 +8725,6 @@ packages:
 
   '@swc/helpers@0.3.17':
     resolution: {integrity: sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==}
-
-  '@swc/helpers@0.5.15':
-    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
@@ -13661,7 +13658,7 @@ packages:
       algoliasearch: 5.x.x
       flexsearch: '*'
       lucide-react: '*'
-      next: 16.2.11
+      next: 16.3.3
       react: ^19.2.0
       react-dom: ^19.2.0
       react-router: 7.18.2
@@ -13714,7 +13711,7 @@ packages:
       '@types/react': '*'
       fumadocs-core: ^15.0.0 || ^16.0.0
       mdast-util-directive: '*'
-      next: 16.2.11
+      next: 16.3.3
       react: ^19.2.0
       vite: 6.x.x || 7.x.x || 8.x.x
     peerDependenciesMeta:
@@ -16408,8 +16405,8 @@ packages:
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
 
-  next@16.2.11:
-    resolution: {integrity: sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==}
+  next@16.3.3:
+    resolution: {integrity: sha512-tuRTx1nQ/yVw83cwJBo9F+njGUgMn3UHQycreWHB8XsStvvAh1AthbI8/4IpKnFaF58F+iSiHejYOlMQ/eq83g==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -25246,34 +25243,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@next/env@16.2.11': {}
+  '@next/env@16.3.3': {}
 
   '@next/eslint-plugin-next@16.1.6':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.2.11':
+  '@next/swc-darwin-arm64@16.3.3':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.11':
+  '@next/swc-darwin-x64@16.3.3':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.11':
+  '@next/swc-linux-arm64-gnu@16.3.3':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.11':
+  '@next/swc-linux-arm64-musl@16.3.3':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.11':
+  '@next/swc-linux-x64-gnu@16.3.3':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.11':
+  '@next/swc-linux-x64-musl@16.3.3':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.11':
+  '@next/swc-win32-arm64-msvc@16.3.3':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.11':
+  '@next/swc-win32-x64-msvc@16.3.3':
     optional: true
 
   '@nexus2520/bitbucket-mcp-server@2.0.4(@cfworker/json-schema@4.1.1)(debug@4.4.3)(zod@4.3.6)':
@@ -28144,7 +28141,7 @@ snapshots:
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
-  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)':
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.3)(redux@5.0.1))(react@19.2.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@standard-schema/utils': 0.3.0
@@ -28678,10 +28675,6 @@ snapshots:
   '@stitches/core@1.2.8': {}
 
   '@swc/helpers@0.3.17':
-    dependencies:
-      tslib: 2.8.1
-
-  '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
 
@@ -34874,7 +34867,7 @@ snapshots:
       mkdirp: 0.5.6
       rimraf: 2.7.1
 
-  fumadocs-core@16.13.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.544.0(react@19.2.3))(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0))(react-dom@19.2.3(react@19.2.3))(react-router@7.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@4.3.6):
+  fumadocs-core@16.13.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.544.0(react@19.2.3))(next@16.3.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0))(react-dom@19.2.3(react@19.2.3))(react-router@7.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@4.3.6):
     dependencies:
       '@orama/orama': 3.1.18
       estree-util-value-to-estree: 3.5.0
@@ -34901,7 +34894,7 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/react': 19.2.17
       lucide-react: 0.544.0(react@19.2.3)
-      next: 16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0)
+      next: 16.3.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       react-router: 7.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -34909,14 +34902,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.13.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.544.0(react@19.2.3))(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0))(react-dom@19.2.3(react@19.2.3))(react-router@7.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@4.3.6))(mdast-util-directive@3.1.0)(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0))(react@19.2.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.51.0)(tsx@4.23.1)(yaml@2.9.0)):
+  fumadocs-mdx@14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.13.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.544.0(react@19.2.3))(next@16.3.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0))(react-dom@19.2.3(react@19.2.3))(react-router@7.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@4.3.6))(mdast-util-directive@3.1.0)(next@16.3.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0))(react@19.2.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.51.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.1
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.13.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.544.0(react@19.2.3))(next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0))(react-dom@19.2.3(react@19.2.3))(react-router@7.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@4.3.6)
+      fumadocs-core: 16.13.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.544.0(react@19.2.3))(next@16.3.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0))(react-dom@19.2.3(react@19.2.3))(react-router@7.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@4.3.6)
       js-yaml: 4.3.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
@@ -34934,7 +34927,7 @@ snapshots:
       '@types/mdx': 2.0.14
       '@types/react': 19.2.17
       mdast-util-directive: 3.1.0
-      next: 16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0)
+      next: 16.3.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0)
       react: 19.2.3
       vite: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.51.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -38516,10 +38509,10 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@16.2.11(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0):
+  next@16.3.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.51.0):
     dependencies:
-      '@next/env': 16.2.11
-      '@swc/helpers': 0.5.15
+      '@next/env': 16.3.3
+      '@swc/helpers': 0.5.23
       baseline-browser-mapping: 2.11.6
       caniuse-lite: 1.0.30001806
       postcss: 8.5.23
@@ -38527,14 +38520,14 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       styled-jsx: 5.1.6(react@19.2.3)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.11
-      '@next/swc-darwin-x64': 16.2.11
-      '@next/swc-linux-arm64-gnu': 16.2.11
-      '@next/swc-linux-arm64-musl': 16.2.11
-      '@next/swc-linux-x64-gnu': 16.2.11
-      '@next/swc-linux-x64-musl': 16.2.11
-      '@next/swc-win32-arm64-msvc': 16.2.11
-      '@next/swc-win32-x64-msvc': 16.2.11
+      '@next/swc-darwin-arm64': 16.3.3
+      '@next/swc-darwin-x64': 16.3.3
+      '@next/swc-linux-arm64-gnu': 16.3.3
+      '@next/swc-linux-arm64-musl': 16.3.3
+      '@next/swc-linux-x64-gnu': 16.3.3
+      '@next/swc-linux-x64-musl': 16.3.3
+      '@next/swc-win32-arm64-msvc': 16.3.3
+      '@next/swc-win32-x64-msvc': 16.3.3
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.59.1
       sass: 1.51.0
@@ -40458,7 +40451,7 @@ snapshots:
 
   recharts@3.10.1(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react-is@18.3.1)(react@19.2.3)(redux@5.0.1):
     dependencies:
-      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
       clsx: 2.1.1
       decimal.js-light: 2.5.1
       es-toolkit: 1.50.0


### PR DESCRIPTION
## Why

CI is red on the Trivy **CRITICAL** gate. Trivy's vuln DB picked up a new advisory for our pinned `next`:

- **CVE-2026-75604 / GHSA-2xp9-vwfh-vxw4** — unauthenticated RCE via the Image Optimization API (AVIF).
- Affected: `next@16.2.11` (our `pnpm.overrides` pin). Fixed in **16.3.3** (16.x) / 15.5.24 (15.x).

Trivy itself didn't change — the same gate started failing once the advisory published. The override (originally added to *fix* GitHub vulnerabilities) was pinning the workspace to a version that has since become vulnerable, so bumping `apps/site` alone wouldn't help.

## Change

- `package.json`: `pnpm.overrides.next` `16.2.11` → **`16.3.3`**
- `pnpm-lock.yaml`: regenerated on **node:22.22.3-slim** (Linux, matching CI) with pnpm `10.15.0`, validated with `--frozen-lockfile` (exit 0). No `16.2.11` remnants.

Backport of #1687 to `release-20260909`.