### PR TITLE
fix: XYNE-63092 include mentions in canvas search

### DIFF
--- a/apps/dashboard/src/components/Canvas/CanvasMentionSpec/CanvasMentionSpec.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasMentionSpec/CanvasMentionSpec.tsx
@@ -7,6 +7,7 @@ import { CanvasRole } from '@xyne/shared';
 import { HoverCard } from '../../ui/HoverCard/HoverCard';
 import Button from '../../ui/Button';
 import Avatar from '../../ui/Avatar/Avatar';
+import { getCanvasMentionDisplayText } from '../../../utils/canvasMentionUtils';
 
 function formatCanvasRoleLabel(role: CanvasRole): string {
   return role.charAt(0) + role.slice(1).toLowerCase();
@@ -108,7 +109,7 @@ const MentionAvatar = ({
 
 const MentionRender = ({ inlineContent }: MentionRenderProps) => {
   const props = inlineContent.props;
-  const displayName = props.groupId && props.groupName ? props.groupName : props.username || '';
+  const displayName = getCanvasMentionDisplayText(props);
   const {
     canGrantAccess,
     canGrantOwnerAccess,

--- a/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
@@ -104,6 +104,7 @@ import {
   useCanvasVersionSave,
 } from '../../../utils/canvasVersioning';
 import { useCanvasArchiveToggle } from '../useCanvasArchiveToggle';
+import { useScope } from '../../../shortcuts';
 
 interface LocationState {
   mode?: 'edit-message' | 'create-message';
@@ -203,6 +204,8 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
 
   const [selectedCanvas, setSelectedCanvas] = useState<Canvas | null>(null);
   const [openCommentCount, setOpenCommentCount] = useState(0);
+  useScope('canvas', Boolean(canvasId));
+
   useEffect(() => {
     setOpenCommentCount(0);
   }, [selectedCanvas?.id]);
@@ -432,6 +435,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
     }
   }, [
     singleCanvas,
+    singleCanvasDetails.type,
     user?.id,
     canvasId,
     state,

--- a/apps/dashboard/src/utils/canvasMentionUtils.ts
+++ b/apps/dashboard/src/utils/canvasMentionUtils.ts
@@ -1,0 +1,17 @@
+export type CanvasMentionDisplayProps = {
+  groupId?: unknown;
+  groupName?: unknown;
+  username?: unknown;
+};
+
+const getStringProp = (value: unknown): string => (typeof value === 'string' ? value : '');
+
+export const getCanvasMentionDisplayText = (
+  props: CanvasMentionDisplayProps | null | undefined,
+): string => {
+  const groupId = getStringProp(props?.groupId);
+  const groupName = getStringProp(props?.groupName);
+  const username = getStringProp(props?.username);
+
+  return groupId && groupName ? groupName : username;
+};

--- a/apps/dashboard/src/utils/searchUtils.ts
+++ b/apps/dashboard/src/utils/searchUtils.ts
@@ -1,4 +1,5 @@
 import { logger, Event as LogEvent } from './logger';
+import { getCanvasMentionDisplayText } from './canvasMentionUtils';
 import type {
   BlockNoteEditor,
   BlockSchema,
@@ -44,7 +45,7 @@ const getBlockText = (content: BlockContent[]): string => {
   return content
     .map(item => {
       if (item.type === 'mention') {
-        return getMentionDisplayText(item);
+        return getCanvasMentionDisplayText(item.props);
       }
       if (item.type === 'text' && item.text) {
         return item.text;
@@ -58,15 +59,6 @@ const getBlockText = (content: BlockContent[]): string => {
       return '';
     })
     .join('');
-};
-
-const getMentionDisplayText = (item: BlockContent): string => {
-  const props = item.props || {};
-  const groupId = typeof props['groupId'] === 'string' ? props['groupId'] : '';
-  const groupName = typeof props['groupName'] === 'string' ? props['groupName'] : '';
-  const username = typeof props['username'] === 'string' ? props['username'] : '';
-
-  return groupId && groupName ? groupName : username;
 };
 
 const getTableText = (tableContent: TableContent): string => {

--- a/apps/dashboard/src/utils/searchUtils.ts
+++ b/apps/dashboard/src/utils/searchUtils.ts
@@ -21,6 +21,7 @@ interface BlockContent {
   type?: string;
   text?: string;
   content?: BlockContent[];
+  props?: Record<string, unknown>;
 }
 
 interface TableCell {
@@ -42,6 +43,9 @@ const getBlockText = (content: BlockContent[]): string => {
 
   return content
     .map(item => {
+      if (item.type === 'mention') {
+        return getMentionDisplayText(item);
+      }
       if (item.type === 'text' && item.text) {
         return item.text;
       }
@@ -54,6 +58,15 @@ const getBlockText = (content: BlockContent[]): string => {
       return '';
     })
     .join('');
+};
+
+const getMentionDisplayText = (item: BlockContent): string => {
+  const props = item.props || {};
+  const groupId = typeof props['groupId'] === 'string' ? props['groupId'] : '';
+  const groupName = typeof props['groupName'] === 'string' ? props['groupName'] : '';
+  const username = typeof props['username'] === 'string' ? props['username'] : '';
+
+  return groupId && groupName ? groupName : username;
 };
 
 const getTableText = (tableContent: TableContent): string => {
@@ -145,6 +158,7 @@ const getDomPosition = (
   targetOffset: number,
 ): { node: Text; offset: number } | null => {
   let currentGlobalOffset = 0;
+  let lastTextNode: Text | null = null;
 
   for (const node of textNodes) {
     const rawText = node.textContent || '';
@@ -159,6 +173,9 @@ const getDomPosition = (
     }
 
     const validCharsInNode = mapping.length;
+    if (validCharsInNode > 0) {
+      lastTextNode = node;
+    }
 
     if (targetOffset < currentGlobalOffset + validCharsInNode) {
       const localCleanIndex = targetOffset - currentGlobalOffset;
@@ -173,7 +190,18 @@ const getDomPosition = (
     currentGlobalOffset += validCharsInNode;
   }
 
+  if (targetOffset === currentGlobalOffset && lastTextNode) {
+    return { node: lastTextNode, offset: lastTextNode.textContent?.length ?? 0 };
+  }
+
   return null;
+};
+
+const isSearchableTextNode = (node: Text): boolean => {
+  const parent = node.parentElement;
+  if (!parent) return false;
+
+  return !parent.closest('[data-slot="avatar"]');
 };
 
 export const applyHighlights = (
@@ -214,8 +242,13 @@ export const applyHighlights = (
       const walker = document.createTreeWalker(blockElement, NodeFilter.SHOW_TEXT, null);
       let node: Node | null;
       while ((node = walker.nextNode())) {
-        if (node.textContent && node.textContent.length > 0) {
-          textNodes.push(node as Text);
+        const textNode = node as Text;
+        if (
+          textNode.textContent &&
+          textNode.textContent.length > 0 &&
+          isSearchableTextNode(textNode)
+        ) {
+          textNodes.push(textNode);
         }
       }
 


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

Fixes XYNE-63092.

Canvas Cmd+F now opens Canvas search while viewing a canvas, instead of falling through to the global command/search palette. Canvas search also includes inline tagged mentions by reading mention display props, so tagged users/groups are counted like visible text.

## Areas Touched

- [x] `apps/dashboard`

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

### Automated

- [x] Not covered by tests
  - Small UI shortcut/search utility fix; verified with lint/typecheck and local manual smoke.

Ran:
- `pnpm --filter xyne-spaces-dashboard exec eslint --quiet src/components/Canvas/CanvasScreen/CanvasScreen.tsx src/utils/searchUtils.ts`
- `pnpm --filter xyne-spaces-dashboard run typecheck`

### Manual

**Run mode**
- [x] Local dev (`pnpm run dev:all`)

**Surface & data**
- [x] Web browser

Manual smoke:
- Opened local Canvas with plain text and tagged mention.
- Verified Cmd+F opens Canvas search instead of global palette.
- Verified searching a tagged user name is included in Canvas search matches.

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] No debug logging or commented-out code left behind


POT : https://drive.google.com/file/d/1bEDXkvl-Nf0eMIJiowU99CZ0RCnZAuEJ/view?usp=sharing