### PR TITLE
feat: XYNE-63112 Add remove option for decision items

### DIFF
--- a/apps/backend/src/controllers/summaryTemplateController.ts
+++ b/apps/backend/src/controllers/summaryTemplateController.ts
@@ -19,6 +19,8 @@ const SummaryTemplateSectionSchema = z.object({
   id: z.string().trim().min(1).max(200),
   title: z.string().trim().min(1).max(100),
   description: z.string().trim().min(1).max(500),
+  // Only honoured on the reserved Decisions / Action Items sections; see summaryTemplateService.
+  disabled: z.boolean().optional(),
 });
 
 const SummaryTemplateCreateSchema = z.object({

--- a/apps/backend/src/services/callDocumentService.ts
+++ b/apps/backend/src/services/callDocumentService.ts
@@ -31,10 +31,11 @@ import {
   parseSelectedSummaryTemplate,
   type SummaryTemplateCandidate,
 } from './summaryTemplateSelection';
+import { getMandatorySummarySectionState } from './summaryTemplateSections';
 import {
   DEFAULT_RECORDING_SUMMARY_TEMPLATE,
   DEFAULT_RECORDING_SUMMARY_FIELDS,
-  RECORDING_DETAILED_SUMMARY_PROMPT,
+  buildRecordingDetailedSummaryPrompt,
 } from './recordingSummaryTemplates';
 import {
   extractMarkedItemsFromRecordingSummary,
@@ -1052,13 +1053,16 @@ export class CallDocumentService {
       return null;
     }
 
+    // A Scribe admin may have switched off Decisions / Action Items on this template;
+    // the prompt must then stop asking for those sections and their annotations.
+    const mandatorySections = getMandatorySummarySectionState(template.sections);
     const rawSummary = await this.generateDetailedSummary(
       transcript,
       callId,
       template.autoTriggerPrompt ?? undefined,
       formatSummaryTemplateSections(template.sections),
       template.systemPrompt,
-      RECORDING_DETAILED_SUMMARY_PROMPT,
+      buildRecordingDetailedSummaryPrompt(mandatorySections),
       DEFAULT_RECORDING_SUMMARY_FIELDS,
       onDelta
         ? accumulated => onDelta(
@@ -1073,9 +1077,13 @@ export class CallDocumentService {
     if (!rawSummary) return null;
 
     const normalizedSummary = normalizeDetailedSummaryMarkdown(rawSummary);
-    const markedItems = citationSegments
-      ? extractMarkedItemsFromRecordingSummary(normalizedSummary, citationSegments)
-      : [];
+    const markedItems = (
+      citationSegments
+        ? extractMarkedItemsFromRecordingSummary(normalizedSummary, citationSegments)
+        : []
+    ).filter((item) =>
+      item.type === 'decision' ? mandatorySections.decisions : mandatorySections.actionItems,
+    );
     const summary = stripRecordingSummaryMarkedItemAnnotations(normalizedSummary);
 
     return { summary, template, markedItems };

--- a/apps/backend/src/services/recordingSummaryTemplates.ts
+++ b/apps/backend/src/services/recordingSummaryTemplates.ts
@@ -1,4 +1,66 @@
-export const RECORDING_DETAILED_SUMMARY_PROMPT = `You are creating a clear, structured meeting summary that follows the provided template.
+import type { MandatorySummarySectionState } from './summaryTemplateSections';
+
+/**
+ * Build the recording summary prompt. The Decisions and Action Items sections are
+ * normally mandatory, but a Scribe admin can disable either on a template; when
+ * that happens every instruction that would make the model produce, annotate, or
+ * cite that section is dropped so it never shows up in the summary.
+ */
+export function buildRecordingDetailedSummaryPrompt(
+  mandatorySections: MandatorySummarySectionState = { decisions: true, actionItems: true },
+): string {
+  const { decisions, actionItems } = mandatorySections;
+  const markedLabel =
+    decisions && actionItems
+      ? 'MARKED DECISIONS AND ACTIONS'
+      : decisions
+        ? 'MARKED DECISIONS'
+        : 'MARKED ACTIONS';
+  const headingRules = [
+    decisions &&
+      'Render the Decisions heading with a yellow dot (`### 🟡 Decisions`), replacing any existing emoji on that heading.',
+    actionItems &&
+      'Render the Action Items heading with an orange dot (`### 🟠 Action Items`), replacing any existing emoji on that heading.',
+    (decisions || actionItems) && 'Keep the dots on the headings, not on individual bullets.',
+  ].filter(Boolean);
+  const headingException =
+    decisions && actionItems
+      ? ', except for the Decisions and Action Items headings described below'
+      : decisions
+        ? ', except for the Decisions heading described below'
+        : actionItems
+          ? ', except for the Action Items heading described below'
+          : '';
+  const omittedSections = [
+    !decisions &&
+      '- This template intentionally has NO Decisions section. Do not add one, do not add any heading about decisions, and never use the `[xyne-decision]` annotation.',
+    !actionItems &&
+      '- This template intentionally has NO Action Items section. Do not add one, do not add any heading about action items or next steps, and never use the `[xyne-action]` annotation.',
+  ].filter(Boolean);
+  const annotationRules = [
+    decisions &&
+      '- Prefix every concrete decision bullet with the exact private annotation `[xyne-decision]` immediately after the bullet marker.',
+    actionItems &&
+      '- Prefix every concrete action-item bullet with the exact private annotation `[xyne-action]` immediately after the bullet marker.',
+    '- Every annotated bullet MUST end with at least one supporting transcript citation. The first citation must identify the moment most closely associated with that ' +
+      (decisions && actionItems ? 'decision or action' : decisions ? 'decision' : 'action') +
+      '.',
+    '- Never use these annotations for takeaways, discussion points, open questions, blockers, or other bullets.',
+    '- The annotations are internal metadata and will be removed before the summary is displayed.',
+    '- Examples:',
+    decisions && '  - `- [xyne-decision] The team approved the consolidated pipeline [clf-12]`',
+    actionItems && '  - `- [xyne-action] @Mayank Bansal will update the backend [clf-18]`',
+  ].filter(Boolean);
+  const annotatedBulletLabel =
+    decisions && actionItems ? 'Decision and action bullets' : decisions ? 'Decision bullets' : 'Action bullets';
+  const annotatedBulletMoment =
+    decisions && actionItems
+      ? 'the decision was actually made or the task actually assigned'
+      : decisions
+        ? 'the decision was actually made'
+        : 'the task was actually assigned';
+
+  return `You are creating a clear, structured meeting summary that follows the provided template.
 LANGUAGE: Generate this entire summary in English, regardless of the transcript language.
 
 BRAND NAME CORRECTION:
@@ -17,14 +79,14 @@ INSUFFICIENT TRANSCRIPT (check this first, before anything else below):
 FORMATTING:
 - Use Markdown headings, short paragraphs, and bullet lists. DO NOT use markdown tables anywhere.
 - Never leave a bare paragraph line as the last line of a section, directly above a \`---\` separator — Markdown turns it into a setext heading. Write such content as a bullet instead.
-- Preserve every section heading from the MARKDOWN TEMPLATE exactly, including its leading \`###\` marker and emoji, except for the Decisions and Action Items headings described below.
-- Render the Decisions heading with a yellow dot (\`### 🟡 Decisions\`) and the Action Items heading with an orange dot (\`### 🟠 Action Items\`), replacing any existing emoji on those two headings. Keep the dots on the headings, not on individual bullets.
+- Preserve every section heading from the MARKDOWN TEMPLATE exactly, including its leading \`###\` marker and emoji${headingException}.
+${headingRules.map((rule) => `- ${rule}`).join('\n')}
 - Never convert a template heading into plain text, bold text, or a list item.
 - Keep bullets concise; put supporting detail inline after an em dash.
 
 STRUCTURE:
 - Fill the sections defined in the MARKDOWN TEMPLATE below, directly from the transcript. Follow that structure exactly — do not rename, add, or reorder sections.
-- CHAPTERS (long calls only): Only if this is a LONG call — roughly 30+ minutes or a long transcript — add a "### 📍 Chapters" section that breaks the conversation into 4–7 chapters by topic shift. For short or medium calls, DO NOT add a Chapters section at all — just fill the template sections.
+${omittedSections.map((rule) => `${rule}\n`).join('')}- CHAPTERS (long calls only): Only if this is a LONG call — roughly 30+ minutes or a long transcript — add a "### 📍 Chapters" section that breaks the conversation into 4–7 chapters by topic shift. For short or medium calls, DO NOT add a Chapters section at all — just fill the template sections.
 - When included, place the Chapters section immediately after the first overview/takeaways section, using this format per chapter:
     #### [Chapter title — e.g. "Activation flow is fragmented"]
     [1-2 sentence summary]
@@ -40,7 +102,7 @@ CALL PARTICIPANTS (Correct Names):
 IMPORTANT - NAME ACCURACY:
 - The transcript may contain misspelled or incorrectly transcribed participant names
 - If a name in the transcript seems close to a participant name, use the correct version from the list
-- For @mentions in Action Items, use the full correct name (e.g., @Mayank Bansal)
+${actionItems ? '- For @mentions in Action Items, use the full correct name (e.g., @Mayank Bansal)' : ''}
 
 INSTRUCTIONS:
 - Capture ACTUAL content from the transcript - no generic placeholders
@@ -49,19 +111,20 @@ INSTRUCTIONS:
 - Keep all template section titles as level-three Markdown headings (\`###\`)
 - Skip sections that have no relevant content — write the single bullet \`- Not discussed\` rather than inventing detail. It MUST be a bullet: a bare \`Not discussed\` line sits directly above the template's \`---\` separator, which Markdown then parses as a setext heading and renders in huge heading text.
 - Add Chapters ONLY for long calls, per the STRUCTURE rule above; never force chapters onto a short or medium call
-- In Action Items: Use @ before FULL NAMES for participants in the call (e.g., @Mayank Bansal)
+${
+  actionItems
+    ? `- In Action Items: Use @ before FULL NAMES for participants in the call (e.g., @Mayank Bansal)
 - In Action Items: For people NOT in the participant list, write their name plainly with "(not in channel)" notation
-
-MARKED DECISIONS AND ACTIONS:
-- Prefix every concrete decision bullet with the exact private annotation \`[xyne-decision]\` immediately after the bullet marker.
-- Prefix every concrete action-item bullet with the exact private annotation \`[xyne-action]\` immediately after the bullet marker.
-- Every annotated bullet MUST end with at least one supporting transcript citation. The first citation must identify the moment most closely associated with that decision or action.
-- Never use these annotations for takeaways, discussion points, open questions, blockers, or other bullets.
-- The annotations are internal metadata and will be removed before the summary is displayed.
-- Examples:
-  - \`- [xyne-decision] The team approved the consolidated pipeline [clf-12]\`
-  - \`- [xyne-action] @Mayank Bansal will update the backend [clf-18]\`
-
+`
+    : ''
+}
+${
+  decisions || actionItems
+    ? `${markedLabel}:
+${annotationRules.join('\n')}
+`
+    : ''
+}
 CITATIONS (ACCURACY IS CRITICAL):
 - Each transcript line is prefixed with its segment number: "[12] [03:24] Alice: ...". The number 12 is that line's segment id.
 - A citation is a PROOF POINTER, not decoration. [clf-N] asserts: "the words that make this statement true are inside segment N." The reader clicks it and is taken to that exact moment in the transcript.
@@ -72,8 +135,12 @@ CITATIONS (ACCURACY IS CRITICAL):
 - Each token in a group must independently support the statement. Never pad with extra numbers to look thorough — one exact citation beats three approximate ones. At most 3 tokens together, e.g. "...scope was cut [clf-8][clf-9]", most direct evidence first.
 - For a roll-up statement that synthesises several moments (typical of Key Takeaways): cite only the 1-3 segments where that point is most explicitly stated. If no segment states it, RE-WORD the statement so it matches what a segment actually says — never attach an approximate citation just to satisfy the format.
 - An uncited statement is acceptable. A wrongly cited statement is a serious error, because it looks verified and is not.
-- Decision and action bullets MUST carry a citation (see MARKED DECISIONS AND ACTIONS). For those, pick the segment where the decision was actually made or the task actually assigned, and word the bullet to match that segment — do not fall back to a loose citation.
-- Copy N exactly. Never invent segment numbers, never use ranges like [clf-8-11], never cite a line that has no bracketed number. Write only the bare token — no links, URLs, footnotes, or a separate "Citations"/"Sources" section.
+${
+  decisions || actionItems
+    ? `- ${annotatedBulletLabel} MUST carry a citation (see ${markedLabel}). For those, pick the segment where ${annotatedBulletMoment}, and word the bullet to match that segment — do not fall back to a loose citation.
+`
+    : ''
+}- Copy N exactly. Never invent segment numbers, never use ranges like [clf-8-11], never cite a line that has no bracketed number. Write only the bare token — no links, URLs, footnotes, or a separate "Citations"/"Sources" section.
 - FINAL CHECK before you output: re-read every [clf-N] you wrote, look the segment up again, and delete or re-word any citation whose segment does not contain the claim it is attached to.
 
 Only output valid Markdown (headings, paragraphs, and bullet lists only — no tables).
@@ -83,7 +150,11 @@ TRANSCRIPT:
 {transcript}
 
 FINAL REMINDER — CITATIONS: every [clf-N] you write must point at a numbered segment above whose text actually states the claim it is attached to. Verify each one against the lines above before you output. Drop or re-word any you cannot verify — an uncited statement is fine, a wrongly cited one is not.
-`;
+`.replace(/\n{3,}/g, '\n\n');
+}
+
+/** Prompt with both mandatory sections enabled (the default template). */
+export const RECORDING_DETAILED_SUMMARY_PROMPT = buildRecordingDetailedSummaryPrompt();
 
 // AI Title prompt for headless recordings (Xyne Scribe) — separate from the
 // regular call title prompt (transcriptService.ts's CALL_TITLE_PROMPT) so the

--- a/apps/backend/src/services/summaryTemplatePublicationService.ts
+++ b/apps/backend/src/services/summaryTemplatePublicationService.ts
@@ -114,7 +114,7 @@ export class SummaryTemplatePublicationService {
     return { ...updated, canEdit: updated.createdBy === actor.userId, isSystem: false };
   }
 
-  private async isAdmin(workspaceId: string, userId: string): Promise<boolean> {
+  async isAdmin(workspaceId: string, userId: string): Promise<boolean> {
     return (await this.getAdmins(workspaceId)).some((admin) => admin.id === userId);
   }
 

--- a/apps/backend/src/services/summaryTemplateSections.ts
+++ b/apps/backend/src/services/summaryTemplateSections.ts
@@ -1,0 +1,80 @@
+import type { Prisma } from '@prisma/client';
+
+/**
+ * Reserved ids for the two sections the template editor always includes. They are
+ * stored in the regular `sections` payload; a Scribe admin can flag one as
+ * `disabled` so it is dropped from generation without being removed from the
+ * template, letting it be switched back on later.
+ */
+export const MANDATORY_SUMMARY_SECTION_IDS = {
+  decisions: 'mandatory-decisions',
+  actionItems: 'mandatory-action-items',
+} as const;
+
+export interface MandatorySummarySectionState {
+  decisions: boolean;
+  actionItems: boolean;
+}
+
+export type SummaryTemplateSectionRecord = Prisma.JsonObject & {
+  id?: string;
+  title?: string;
+  description?: string;
+  disabled?: boolean;
+};
+
+export function isSummaryTemplateSectionRecord(
+  section: Prisma.JsonValue
+): section is SummaryTemplateSectionRecord {
+  return typeof section === 'object' && section !== null && !Array.isArray(section);
+}
+
+export function isMandatorySummarySectionId(id: unknown): boolean {
+  return (
+    id === MANDATORY_SUMMARY_SECTION_IDS.decisions || id === MANDATORY_SUMMARY_SECTION_IDS.actionItems
+  );
+}
+
+export function isSummaryTemplateSectionDisabled(section: Prisma.JsonValue): boolean {
+  return isSummaryTemplateSectionRecord(section) && section.disabled === true;
+}
+
+/** Sections that should reach the prompt: everything not explicitly disabled. */
+export function getEnabledSummaryTemplateSections(sections: Prisma.JsonValue): Prisma.JsonValue {
+  if (!Array.isArray(sections)) return sections;
+  return sections.filter((section) => !isSummaryTemplateSectionDisabled(section));
+}
+
+/** Which of the mandatory sections are still enabled for a template. */
+export function getMandatorySummarySectionState(
+  sections: Prisma.JsonValue
+): MandatorySummarySectionState {
+  const state: MandatorySummarySectionState = { decisions: true, actionItems: true };
+  if (!Array.isArray(sections)) return state;
+  for (const section of sections) {
+    if (!isSummaryTemplateSectionRecord(section) || section.disabled !== true) continue;
+    if (section.id === MANDATORY_SUMMARY_SECTION_IDS.decisions) state.decisions = false;
+    if (section.id === MANDATORY_SUMMARY_SECTION_IDS.actionItems) state.actionItems = false;
+  }
+  return state;
+}
+
+/** Ids of the mandatory sections flagged as disabled, for change detection. */
+export function getDisabledMandatorySummarySectionIds(sections: Prisma.JsonValue): Set<string> {
+  const state = getMandatorySummarySectionState(sections);
+  const ids = new Set<string>();
+  if (!state.decisions) ids.add(MANDATORY_SUMMARY_SECTION_IDS.decisions);
+  if (!state.actionItems) ids.add(MANDATORY_SUMMARY_SECTION_IDS.actionItems);
+  return ids;
+}
+
+/** True when a non-mandatory section carries the `disabled` flag, which is never allowed. */
+export function hasDisabledNonMandatorySummarySection(sections: Prisma.JsonValue): boolean {
+  if (!Array.isArray(sections)) return false;
+  return sections.some(
+    (section) =>
+      isSummaryTemplateSectionRecord(section) &&
+      section.disabled === true &&
+      !isMandatorySummarySectionId(section.id)
+  );
+}

--- a/apps/backend/src/services/summaryTemplateSections.ts
+++ b/apps/backend/src/services/summaryTemplateSections.ts
@@ -1,15 +1,13 @@
 import type { Prisma } from '@prisma/client';
+import { MANDATORY_SUMMARY_SECTION_IDS } from '@xyne/shared';
 
 /**
- * Reserved ids for the two sections the template editor always includes. They are
- * stored in the regular `sections` payload; a Scribe admin can flag one as
- * `disabled` so it is dropped from generation without being removed from the
- * template, letting it be switched back on later.
+ * The two reserved sections the template editor always includes are stored in the
+ * regular `sections` payload; a Scribe admin can flag one as `disabled` so it is
+ * dropped from generation without being removed from the template, letting it be
+ * switched back on later.
  */
-export const MANDATORY_SUMMARY_SECTION_IDS = {
-  decisions: 'mandatory-decisions',
-  actionItems: 'mandatory-action-items',
-} as const;
+export { MANDATORY_SUMMARY_SECTION_IDS };
 
 export interface MandatorySummarySectionState {
   decisions: boolean;

--- a/apps/backend/src/services/summaryTemplateSelection.ts
+++ b/apps/backend/src/services/summaryTemplateSelection.ts
@@ -1,4 +1,5 @@
 import type { Prisma, SummaryTemplate } from '@prisma/client';
+import { getEnabledSummaryTemplateSections } from './summaryTemplateSections';
 
 const MAX_TRANSCRIPT_CHARS = 60_000;
 const MAX_STRUCTURE_CHARS = 2_000;
@@ -25,7 +26,9 @@ function isStructuredSection(
   );
 }
 
-export function formatSummaryTemplateSections(sections: Prisma.JsonValue): string {
+export function formatSummaryTemplateSections(rawSections: Prisma.JsonValue): string {
+  // Sections a Scribe admin disabled stay stored on the template but never reach a prompt.
+  const sections = getEnabledSummaryTemplateSections(rawSections);
   if (typeof sections === 'string') return sections.trim();
   if (sections === null) return '';
   if (Array.isArray(sections) && sections.length === 0) return '';

--- a/apps/backend/src/services/summaryTemplateService.ts
+++ b/apps/backend/src/services/summaryTemplateService.ts
@@ -9,6 +9,12 @@ import {
 } from '@xyne/shared';
 import { DEFAULT_RECORDING_SUMMARY_TEMPLATE } from './recordingSummaryTemplates';
 import { summaryTemplateAiService } from './summaryTemplateAiService';
+import { summaryTemplatePublicationService } from './summaryTemplatePublicationService';
+import {
+  getDisabledMandatorySummarySectionIds,
+  getEnabledSummaryTemplateSections,
+  hasDisabledNonMandatorySummarySection,
+} from './summaryTemplateSections';
 
 export type SummaryTemplateCreateInput = Pick<
   Prisma.SummaryTemplateUncheckedCreateInput,
@@ -29,7 +35,7 @@ const DEFAULT_TEMPLATE_CREATED_AT = new Date(0);
 export class SummaryTemplateError extends Error {
   constructor(
     message: string,
-    readonly statusCode: 403 | 404 | 502
+    readonly statusCode: 400 | 403 | 404 | 502
   ) {
     super(message);
     this.name = 'SummaryTemplateError';
@@ -38,7 +44,9 @@ export class SummaryTemplateError extends Error {
 
 function toPromptSections(value: unknown): Array<{ title: string; description: string }> {
   if (!Array.isArray(value)) return [];
-  return value.flatMap((section) => {
+  const enabled = getEnabledSummaryTemplateSections(value as Prisma.JsonValue);
+  if (!Array.isArray(enabled)) return [];
+  return enabled.flatMap((section) => {
     if (
       typeof section !== 'object' ||
       section === null ||
@@ -90,6 +98,43 @@ export class SummaryTemplateService {
       createdAt: DEFAULT_TEMPLATE_CREATED_AT,
       visibility: SummaryTemplateVisibility.PRIVATE,
     };
+  }
+
+  /**
+   * The Decisions / Action Items sections can only be switched off (or back on) by a
+   * Scribe admin, and only those two reserved sections may carry the flag at all.
+   * Non-admins may still save a template that already has a section disabled, as
+   * long as they leave that state untouched.
+   */
+  private async assertMandatorySectionChangesAllowed(
+    sections: unknown,
+    existingSections: Prisma.JsonValue | null,
+    workspaceId: string,
+    actorUserId: string
+  ): Promise<void> {
+    if (sections === undefined) return;
+    const next = sections as Prisma.JsonValue;
+    if (hasDisabledNonMandatorySummarySection(next)) {
+      throw new SummaryTemplateError(
+        'Only the Decisions and Action Items sections can be disabled',
+        400
+      );
+    }
+
+    const nextDisabled = getDisabledMandatorySummarySectionIds(next);
+    const previousDisabled = getDisabledMandatorySummarySectionIds(existingSections);
+    const changed =
+      nextDisabled.size !== previousDisabled.size ||
+      [...nextDisabled].some((id) => !previousDisabled.has(id));
+    if (!changed) return;
+
+    const isAdmin = await summaryTemplatePublicationService.isAdmin(workspaceId, actorUserId);
+    if (!isAdmin) {
+      throw new SummaryTemplateError(
+        'Only a Scribe admin can enable or disable the Decisions and Action Items sections',
+        403
+      );
+    }
   }
 
   private isDefaultTemplateId(templateId: string, workspaceId: string): boolean {
@@ -211,6 +256,8 @@ export class SummaryTemplateService {
     createdBy: string,
     input: SummaryTemplateCreateInput
   ): Promise<SummaryTemplateView> {
+    await this.assertMandatorySectionChangesAllowed(input.sections, null, workspaceId, createdBy);
+
     const systemPrompt =
       input.systemPrompt?.trim() ||
       (await summaryTemplateAiService.generateSystemPrompt(
@@ -253,6 +300,12 @@ export class SummaryTemplateService {
     if (existing.createdBy !== actorUserId || existing.createdBy === SYSTEM_TEMPLATE_CREATOR) {
       throw new SummaryTemplateError('Only the template creator can update it', 403);
     }
+    await this.assertMandatorySectionChangesAllowed(
+      input.sections,
+      existing.sections,
+      workspaceId,
+      actorUserId
+    );
 
     const { systemPrompt: requestedSystemPrompt, ...updates } = input;
     const promptSourceChanged =

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/SummaryTemplatesModal.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/SummaryTemplatesModal.tsx
@@ -38,6 +38,7 @@ import { XyneAIStar } from '../../../components/icons/xyne-ai';
 import Avatar from '../../../components/ui/Avatar/Avatar';
 import { Button } from '../../../components/ui/Button/Button';
 import { Popover } from '../../../components/ui/Popover';
+import { Switch } from '../../../components/ui/Switch';
 import { useHasResourceAccess } from '../../../hooks/usePermissions';
 import { useUser } from '../../../hooks/useUsers';
 import {
@@ -150,6 +151,9 @@ const isMandatorySection = (section: Pick<SummaryTemplateSection, 'id'>): boolea
  * Mandatory sections are stored in the regular sections payload so summary generation keeps
  * using the existing API contract. Runtime checks use reserved IDs rather than editable titles,
  * so a custom section named "Decisions" remains a normal editable section.
+ *
+ * A Scribe admin can switch a mandatory section off; the `disabled` flag is the only part of
+ * these sections that persists from the incoming payload, so title/description stay canonical.
  */
 const withMandatorySections = (sections: SummaryTemplateSection[]): SummaryTemplateSection[] => {
   const editableSections = sections.filter(section => !isMandatorySection(section));
@@ -157,10 +161,21 @@ const withMandatorySections = (sections: SummaryTemplateSection[]): SummaryTempl
     id: definition.id,
     title: definition.title,
     description: definition.description,
+    ...(sections.find(section => section.id === definition.id)?.disabled === true
+      ? { disabled: true }
+      : {}),
   }));
 
   return [...editableSections, ...mandatorySections];
 };
+
+/** Sections handed to the AI helpers: everything the summary will actually contain. */
+const toAiSections = (
+  sections: SummaryTemplateSection[],
+): Array<Pick<SummaryTemplateSection, 'title' | 'description'>> =>
+  sections
+    .filter(section => section.disabled !== true)
+    .map(({ title, description }) => ({ title, description }));
 
 // The default template is a static string so it can be used in the backend service to generate
 const normalizeIncomingSections = (
@@ -605,6 +620,25 @@ export function SummaryTemplatesModal({
     });
   };
 
+  // Only a Scribe admin editing their own template can switch Decisions / Action Items
+  // off (or back on); the backend enforces the same rule.
+  const canToggleMandatorySections = Boolean(draft?.canEdit) && isScribeAdmin;
+  const toggleMandatorySection = (sectionId: string, enabled: boolean): void => {
+    if (!canToggleMandatorySections) return;
+    setDraft(current =>
+      current
+        ? {
+            ...current,
+            sections: current.sections.map(section => {
+              if (section.id !== sectionId || !isMandatorySection(section)) return section;
+              const { disabled: _disabled, ...rest } = section;
+              return enabled ? rest : { ...rest, disabled: true };
+            }),
+          }
+        : current,
+    );
+  };
+
   const handleSectionDragEnd = ({ active, over }: DragEndEvent): void => {
     if (!over || active.id === over.id) return;
 
@@ -770,7 +804,7 @@ export function SummaryTemplatesModal({
       const context = await recordingService.draftSummaryTemplateContext({
         name: draft.name.trim() || 'Untitled template',
         meetingContext: draft.autoTriggerPrompt,
-        sections: draft.sections.map(({ title, description }) => ({ title, description })),
+        sections: toAiSections(draft.sections),
       });
       setDraft(current => (current ? { ...current, autoTriggerPrompt: context } : current));
     } catch (error) {
@@ -789,7 +823,7 @@ export function SummaryTemplatesModal({
       const sections = await recordingService.suggestSummaryTemplateSections({
         name: draft.name.trim() || 'Untitled template',
         meetingContext: draft.autoTriggerPrompt,
-        sections: draft.sections.map(({ title, description }) => ({ title, description })),
+        sections: toAiSections(draft.sections),
       });
       setDraft(current =>
         current ? { ...current, sections: normalizeIncomingSections(sections, true) } : current,
@@ -810,7 +844,7 @@ export function SummaryTemplatesModal({
       const systemPrompt = await recordingService.generateSummaryTemplateSystemPrompt({
         name: draft.name.trim() || 'Untitled template',
         meetingContext: draft.autoTriggerPrompt,
-        sections: draft.sections.map(({ title, description }) => ({ title, description })),
+        sections: toAiSections(draft.sections),
       });
       setDraft(current => (current ? { ...current, systemPrompt } : current));
     } catch (error) {
@@ -1241,30 +1275,69 @@ export function SummaryTemplatesModal({
                 )}
 
                 <div className='flex w-full flex-col gap-2.5 pt-1'>
-                  {MANDATORY_SECTIONS.map(section => (
-                    <div
-                      key={section.key}
-                      aria-disabled='true'
-                      className='flex flex-col gap-1.5 rounded-xl border border-dashed border-border bg-muted/35 px-4 py-3.5'
-                    >
-                      <div className='flex flex-wrap items-center gap-2'>
-                        <span
-                          className={cn('size-2 shrink-0 rounded-full', section.dotClassName)}
-                          aria-hidden='true'
-                        />
-                        <span className='text-sm font-semibold text-foreground'>
-                          {section.displayTitle}
-                        </span>
-                        <span className='inline-flex h-5 items-center gap-0.5 rounded-md border border-border bg-background/70 px-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/60'>
-                          <Lock02Close className='size-3' strokeWidth={2.5} aria-hidden='true' />
-                          Always included
-                        </span>
+                  {MANDATORY_SECTIONS.map(section => {
+                    const isSectionEnabled =
+                      draft?.sections.find(candidate => candidate.id === section.id)?.disabled !==
+                      true;
+                    // Only admins (who can switch it back on) see a disabled section at all.
+                    if (!isSectionEnabled && !canToggleMandatorySections) return null;
+                    return (
+                      <div
+                        key={section.key}
+                        aria-disabled={!canToggleMandatorySections}
+                        className={cn(
+                          'flex flex-col gap-1.5 rounded-xl border border-dashed border-border bg-muted/35 px-4 py-3.5',
+                          !isSectionEnabled && 'opacity-60',
+                        )}
+                      >
+                        <div className='flex flex-wrap items-center gap-2'>
+                          <span
+                            className={cn(
+                              'size-2 shrink-0 rounded-full',
+                              isSectionEnabled ? section.dotClassName : 'bg-muted-foreground/40',
+                            )}
+                            aria-hidden='true'
+                          />
+                          <span
+                            className={cn(
+                              'text-sm font-semibold text-foreground',
+                              !isSectionEnabled && 'line-through text-muted-foreground',
+                            )}
+                          >
+                            {section.displayTitle}
+                          </span>
+                          {/* Admins get the switch instead of a status badge. */}
+                          {!canToggleMandatorySections && (
+                            <span className='inline-flex h-5 items-center gap-0.5 rounded-md border border-border bg-background/70 px-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/60'>
+                              <Lock02Close
+                                className='size-3'
+                                strokeWidth={2.5}
+                                aria-hidden='true'
+                              />
+                              Always included
+                            </span>
+                          )}
+                          {canToggleMandatorySections && (
+                            <Switch
+                              checked={isSectionEnabled}
+                              onCheckedChange={enabled =>
+                                toggleMandatorySection(section.id, enabled)
+                              }
+                              aria-label={`${isSectionEnabled ? 'Disable' : 'Enable'} ${section.displayTitle} section`}
+                              className='ml-auto'
+                              data-track-category='SummaryTemplates'
+                              data-track-name='ToggleMandatorySection'
+                            />
+                          )}
+                        </div>
+                        <p className='pl-4 text-sm leading-normal text-muted-foreground'>
+                          {isSectionEnabled
+                            ? section.description
+                            : `This section is switched off for this template. Summaries generated with it will not include ${section.displayTitle.toLowerCase()}.`}
+                        </p>
                       </div>
-                      <p className='pl-4 text-sm leading-normal text-muted-foreground'>
-                        {section.description}
-                      </p>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </section>
 

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/SummaryTemplatesModal.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/SummaryTemplatesModal.tsx
@@ -33,7 +33,7 @@ import {
   UserTwo,
 } from '@xyne/icons';
 import { toast } from 'sonner';
-import { DefaultOutlet } from '@xyne/shared';
+import { DefaultOutlet, MANDATORY_SUMMARY_SECTION_IDS } from '@xyne/shared';
 import { XyneAIStar } from '../../../components/icons/xyne-ai';
 import Avatar from '../../../components/ui/Avatar/Avatar';
 import { Button } from '../../../components/ui/Button/Button';
@@ -106,7 +106,7 @@ const EMPTY_SECTION = (): SummaryTemplateSection => ({
 
 const MANDATORY_SECTIONS = [
   {
-    id: 'mandatory-decisions',
+    id: MANDATORY_SUMMARY_SECTION_IDS.decisions,
     key: 'decisions',
     title: '✅ Decisions',
     displayTitle: 'Decisions',
@@ -116,7 +116,7 @@ const MANDATORY_SECTIONS = [
     dotClassName: 'bg-primary',
   },
   {
-    id: 'mandatory-action-items',
+    id: MANDATORY_SUMMARY_SECTION_IDS.actionItems,
     key: 'action items',
     title: '📋 Action Items',
     displayTitle: 'Action items',

--- a/apps/dashboard/src/services/Recording/recordingService.ts
+++ b/apps/dashboard/src/services/Recording/recordingService.ts
@@ -58,6 +58,11 @@ export interface SummaryTemplateSection {
   id: string;
   title: string;
   description: string;
+  /**
+   * Only meaningful on the reserved Decisions / Action Items sections. A Scribe admin can
+   * switch one off; it stays on the template but is dropped from summary generation.
+   */
+  disabled?: boolean;
 }
 
 export type SummaryTemplateInput = Pick<

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -54,6 +54,7 @@ export * from './crypto/index.js';
 export * from './templates/callInvitation';
 export * from './templates/callInvitationIcs';
 export * from './templates/callSummary';
+export * from './templates/summaryTemplateSections';
 export * from './types/flowUI';
 export * from './validation/flowSchema';
 export * from './sdlc';

--- a/packages/shared/src/templates/summaryTemplateSections.ts
+++ b/packages/shared/src/templates/summaryTemplateSections.ts
@@ -1,0 +1,12 @@
+/**
+ * Reserved ids of the Decisions / Action Items sections that the summary template
+ * editor always includes. Shared so the dashboard payload and the backend's
+ * permission checks can never drift apart.
+ */
+export const MANDATORY_SUMMARY_SECTION_IDS = {
+  decisions: 'mandatory-decisions',
+  actionItems: 'mandatory-action-items',
+} as const;
+
+export type MandatorySummarySectionId =
+  (typeof MANDATORY_SUMMARY_SECTION_IDS)[keyof typeof MANDATORY_SUMMARY_SECTION_IDS];


### PR DESCRIPTION


https://github.com/user-attachments/assets/456f460c-e89c-4afa-aca8-aea949c908d5

<img width="1156" height="822" alt="Screenshot 2026-09-09 at 3 13 56 PM" src="https://github.com/user-attachments/assets/3bc559e2-fad5-4fe7-9952-f9c50ce232a9" />


Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
