### PR TITLE
fix: XYNE-61946 populate label filter from all projects in My Tickets view

### DIFF
--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -3208,11 +3208,19 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
   const lastSentFilteredTicketIdsRef = useRef<string | null>(null);
 
+  // Union of project-defined tags and tags already present on the visible
+  // tickets. In the My Tickets view the board spans multiple projects, so the
+  // label filter must include tags from every project the user has tickets in
+  // — not just the first board's project.
   const availableTags = useMemo(() => {
-    if (!projectTags || projectTags.length === 0) return undefined;
-    const uniqueTags = new Set(projectTags.map(tag => tag.name));
-    return Array.from(uniqueTags).sort();
-  }, [projectTags]);
+    const uniqueTags = new Set(projectTags?.map(tag => tag.name));
+    tagsByTicketId.forEach(tags => {
+      tags.forEach(tag => {
+        uniqueTags.add(tag.name);
+      });
+    });
+    return uniqueTags.size > 0 ? Array.from(uniqueTags).sort() : undefined;
+  }, [projectTags, tagsByTicketId]);
 
   const availableStages = useMemo(() => {
     if (!stages || stages.length === 0) return undefined;


### PR DESCRIPTION
## What
In the workspace-level **My Tickets** board (`/chat/dir/my-tickets`), the **Filters → Labels** submenu only offered labels defined on the first visible board's project. Labels attached to tickets from any *other* project in the merged view were un-selectable even though those tickets were right there on the board.

## Root cause
`availableTags` in `KanbanBoardScreen.tsx` was derived from `projectTags` only, i.e. the labels of ONE project (`tagsProjectId` = first ordered board's project). In the merged My Tickets view the board spans N projects, so any label defined solely on another project (or applied only on-ticket) never appeared.

## Fix
Union the label sources while building `availableTags` (`apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx:3211-3223`):
- `projectTags` (workspace labels of the first board's project), and
- `tagsByTicketId` — every tag actually applied to every ticket on the board, across all projects.

The set is deduplicated, sorted, and returns `undefined` when empty, preserving existing behavior. No changes to filtering mechanics, backend, or schema — `TicketFiltersDropdown` already accepts the computed list and drives the `?tags=` filter param.

## Proof of Testing (gated via pot-verifier — video + 8 TCs PASS)
Seeded a workspace with two projects: Alpha (labels `alpha-api`, `alpha-ui`, ticket UTALPHA-1 labeled `alpha-ui`) and Beta (labels `beta-infra`, `beta-docs`, ticket UTBETA-1 labeled `beta-infra`).

- **BEFORE (main)**: both tickets on the board, but Labels list = {alpha-api, alpha-ui} — `beta-infra` invisible → bug reproduced (stash flip).
- **AFTER**: Labels list = {alpha-api, alpha-ui, beta-infra} — union; `beta-docs` correctly absent (not applied to any visible ticket and foreign to the first project's label set).
- Selecting `beta-infra` filters the board to UTBETA-1 only (URL gains `?tags=beta-infra`); deselecting restores both tickets ("Select all").
- Round-trip stable after stash pop; independent fresh-browser video replay of the whole flow attached (`my-tickets-label-filter-union-pot.webm`).
- `apps/dashboard` typecheck A/B: WITH_FIX exit 0, MAIN exit 0, identical (empty) error sets — 0 errors added.

8/8 TCs verified on a live sandbox stack; full walkthrough video + per-TC artifacts captured.

Closes XYNE-61946
Supersedes #1123