### PR TITLE
feat: XYNE-61886 ticket type form field

### DIFF
--- a/apps/backend/src/controllers/ticketController.ts
+++ b/apps/backend/src/controllers/ticketController.ts
@@ -687,25 +687,6 @@ export class TicketController {
         }
       }
 
-      // Unlimited nesting is reserved for FLOW run graphs. Normal boards keep
-      // the existing one-level sub-ticket contract.
-      if (parentTicketId) {
-        const parent = await prisma.ticket.findUnique({
-          where: { id: parentTicketId },
-          select: { board: { select: { boardType: true } } },
-        });
-        if (parent?.board.boardType !== BoardType.FLOW) {
-          const parentAsSubTicket = await prisma.subTicket.findFirst({
-            where: { mappedTicketId: parentTicketId },
-            select: { id: true },
-          });
-          if (parentAsSubTicket) {
-            res.status(400).json({ error: 'Cannot create a sub-ticket under a sub-ticket.' });
-            return;
-          }
-        }
-      }
-
       // Determine the actual channel to check its type
       let actualChannelId = channelId;
       if (!actualChannelId && sourceConversationId) {

--- a/apps/backend/src/services/queryService/genericFieldRegistry.ts
+++ b/apps/backend/src/services/queryService/genericFieldRegistry.ts
@@ -11,7 +11,8 @@ const FORM_FIELD_TYPE_MAPPING: Record<FormFieldType, FieldType> = {
   SINGLE_SELECT: 'select',
   MULTI_SELECT: 'select',
   USER: 'string',
-  DOC: 'string'
+  DOC: 'string',
+  TICKET: 'string'
 };
 
 export type PrismaFieldType = 'String' | 'Int' | 'Float' | 'Boolean' | 'DateTime' | 'Json' | 'BigInt';

--- a/apps/backend/src/services/subTicketService.ts
+++ b/apps/backend/src/services/subTicketService.ts
@@ -44,20 +44,6 @@ export async function createSubTicket(
     throw new Error(`Parent ticket "${input.parentTicketId}" not found`);
   }
 
-  // Normal boards retain the historical one-level sub-ticket limit. FLOW is
-  // the sole override because its materialized run graph can be arbitrarily deep.
-  if (parent.board.boardType !== BoardType.FLOW) {
-    const parentAsSubTicket = await db.subTicket.findFirst({
-      where: { mappedTicketId: parent.id },
-      select: { id: true },
-    });
-    if (parentAsSubTicket) {
-      throw new Error(
-        `Cannot create a sub-ticket under a sub-ticket. Parent ticket ${parent.id} is already a sub-ticket.`,
-      );
-    }
-  }
-
   await db.$transaction(async (tx: Prisma.TransactionClient) => {
     await tx.subTicket.create({
       data: {

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -6950,19 +6950,8 @@ export function createMutators(
           subTicketXyneId: z.string().optional(),
         }),
         async ({ tx, args: { subTicketId, mappingId, timestamp, title, description, ticketId, conversationId, subTicketXyneId } }) => {
-          const parentAsSubTicket = await tx.run(
-            zql.sub_tickets.where('mappedTicketId', ticketId).one(),
-          );
           // Parent ticket is also needed below to denormalize channelId onto the activity.
           const parentTicket = await tx.run(zql.tickets.where('id', ticketId).one());
-          if (parentAsSubTicket) {
-            const parentBoard = parentTicket
-              ? await tx.run(zql.boards.where('id', parentTicket.boardId).one())
-              : null;
-            if (parentBoard?.boardType !== BoardType.FLOW) {
-              throw new Error('Cannot create a sub-ticket under a sub-ticket');
-            }
-          }
           // Create the subticket
           await tx.mutate.sub_tickets.insert({
             id: subTicketId,

--- a/apps/dashboard/src/components/Board/BoardEditScreen/BoardEditScreen.types.ts
+++ b/apps/dashboard/src/components/Board/BoardEditScreen/BoardEditScreen.types.ts
@@ -37,7 +37,8 @@ export interface TicketField {
     | 'boolean'
     | 'doc'
     | 'tags'
-    | 'ticketType';
+    | 'ticketType'
+    | 'ticket';
   label: string;
   required: boolean;
   order: number;
@@ -63,6 +64,8 @@ export const mapFromFormFieldType = (fieldType: FormFieldType): TicketField['typ
       return 'boolean';
     case FormFieldType.DOC:
       return 'doc';
+    case FormFieldType.TICKET:
+      return 'ticket';
     default:
       return 'text';
   }
@@ -85,6 +88,8 @@ export const mapToFormFieldType = (type: TicketField['type']): FormFieldType => 
       return FormFieldType.BOOLEAN;
     case 'doc':
       return FormFieldType.DOC;
+    case 'ticket':
+      return FormFieldType.TICKET;
     default:
       return FormFieldType.STRING;
   }

--- a/apps/dashboard/src/components/Board/BoardEditScreen/BoardEditScreen.utils.ts
+++ b/apps/dashboard/src/components/Board/BoardEditScreen/BoardEditScreen.utils.ts
@@ -37,6 +37,8 @@ export const getFieldTypeLabel = (fieldType: TicketField['type']): string => {
       return 'Boolean';
     case 'doc':
       return 'Document';
+    case 'ticket':
+      return 'Ticket';
     default:
       return 'String';
   }

--- a/apps/dashboard/src/components/Board/CustomField/CustomField.tsx
+++ b/apps/dashboard/src/components/Board/CustomField/CustomField.tsx
@@ -49,6 +49,7 @@ const fieldTypeOptions = [
   { value: 'boolean', label: 'Boolean' },
   { value: 'date', label: 'Date' },
   { value: 'user', label: 'User' },
+  { value: 'ticket', label: 'Ticket' },
 ];
 
 export const CustomField = ({

--- a/apps/dashboard/src/components/Board/CustomField/CustomField.types.tsx
+++ b/apps/dashboard/src/components/Board/CustomField/CustomField.types.tsx
@@ -1,6 +1,6 @@
 import type { TicketField } from '../BoardEditScreen/BoardEditScreen.types';
 
-export type FieldType = 'text' | 'select' | 'multiselect' | 'boolean' | 'date' | 'user';
+export type FieldType = 'text' | 'select' | 'multiselect' | 'boolean' | 'date' | 'user' | 'ticket';
 
 export interface CustomFieldProps {
   mode: 'create' | 'edit';

--- a/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
+++ b/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
@@ -123,7 +123,6 @@ interface ChatBubbleProps {
   context?: 'channel' | 'thread';
   isFirstInThread?: boolean;
   isTicketThread?: boolean;
-  isFlowStep?: boolean;
   onEmojiPickerOpenChange?: (isOpen: boolean) => void;
   allThreadAttachments?: AttachmentRef[];
   workflowNumber?: number | undefined;
@@ -139,7 +138,6 @@ interface ChatBubbleProps {
   /** Tag being inspected from the thread header; messages carrying it show a chip. */
   inspectedTag?: string | null;
   afterTextContent?: React.ReactNode;
-  isThreadTicketSubTicket?: boolean;
 }
 
 export const ChatBubble: React.FC<ChatBubbleProps> = ({
@@ -156,7 +154,6 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
   context = 'channel',
   isFirstInThread = false,
   isTicketThread = false,
-  isFlowStep = false,
   onEmojiPickerOpenChange,
   allThreadAttachments,
   workflowNumber,
@@ -170,7 +167,6 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
   highlightMessageId,
   inspectedTag = null,
   afterTextContent,
-  isThreadTicketSubTicket = false,
 }) => {
   const { user } = useAuthContext();
   const { copyImage } = useClipboard();
@@ -293,8 +289,6 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
     const initMsg = getInitialMessageFromConversation(conversation) ?? conversation.initialMessage;
     return ((initMsg?.metadata as Record<string, unknown>)?.['ticketId'] as string) || '';
   }, [context, isTicketThread, conversation]);
-
-  const canNestSubTicket = !isThreadTicketSubTicket || isFlowStep;
 
   // Mark activities as read when message becomes visible
   // const observerRef = useIntersectionObserver(() => {
@@ -1042,7 +1036,6 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
       ...(context === 'thread' &&
         !isMessageDeleted &&
         isTicketThread &&
-        canNestSubTicket &&
         !isFirstInThread &&
         !spawnedTicketMessageIds?.has(message.messageId) && {
           onCreateSubTicket: handleCreateSubTicket,
@@ -1502,11 +1495,7 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
       )}
 
       {/* SubTicket Modal for ticket threads */}
-      {conversation &&
-        context === 'thread' &&
-        isTicketThread &&
-        canNestSubTicket &&
-        isSubTicketModalOpen && (
+      {conversation && context === 'thread' && isTicketThread && isSubTicketModalOpen && (
           <SubTicketModal
             isOpen
             onClose={() => setIsSubTicketModalOpen(false)}

--- a/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
@@ -27,7 +27,6 @@ type ThreadListProps = {
   initialScrollOffset?: number;
   onScrollPositionChange?: (position: number) => void;
   isTicketThread?: boolean;
-  isFlowStep?: boolean;
   messagesWithSeparators?: ThreadListItemWithSeparator[] | undefined;
   channelScopeType?: ChannelScopeType | undefined;
   conversation?: ConversationWithTicket | undefined;
@@ -60,7 +59,6 @@ const ThreadList = ({
   initialScrollOffset,
   onScrollPositionChange,
   isTicketThread = false,
-  isFlowStep = false,
   messagesWithSeparators,
   channelScopeType,
   conversation,
@@ -161,19 +159,6 @@ const ThreadList = ({
   }, [isEditingHere]);
 
   const lastAutoScrolledMessageIdRef = useRef<string | null>(null);
-
-  const threadTicketId = useMemo(() => {
-    if (!isTicketThread || !conversation) return '';
-    const initMsg = getInitialMessageFromConversation(conversation) ?? conversation.initialMessage;
-    return ((initMsg?.metadata as Record<string, unknown>)?.['ticketId'] as string) || '';
-  }, [isTicketThread, conversation]);
-
-  // Subtickets cannot be nested: hide the action when the thread's ticket is itself a subticket.
-  const [threadTicketParentSubTicket] = useCachedQuery(
-    queries.subTicketByMappedTicketId({ mappedTicketId: threadTicketId }),
-    { enabled: !!threadTicketId },
-  );
-  const isThreadTicketSubTicket = !!threadTicketParentSubTicket;
 
   const {
     firstUnreadIndex,
@@ -525,8 +510,6 @@ const ThreadList = ({
                       {...(spawnedTicketMessageIds && { spawnedTicketMessageIds })}
                       isFirstInThread={messageIndex === 0}
                       isTicketThread={isTicketThread}
-                      isFlowStep={isFlowStep}
-                      isThreadTicketSubTicket={isThreadTicketSubTicket}
                       channelScopeType={channelScopeType}
                       allThreadAttachments={allThreadAttachments}
                       workflowNumber={workflowNumberMap?.get(threadMessage.messageId)}
@@ -627,8 +610,6 @@ const ThreadList = ({
                     {...(spawnedTicketMessageIds && { spawnedTicketMessageIds })}
                     isFirstInThread={index === 0}
                     isTicketThread={isTicketThread}
-                    isFlowStep={isFlowStep}
-                    isThreadTicketSubTicket={isThreadTicketSubTicket}
                     channelScopeType={channelScopeType}
                     allThreadAttachments={allThreadAttachments}
                     workflowNumber={workflowNumberMap?.get(threadMessage.messageId)}

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -261,10 +261,6 @@ export const ThreadMessages = ({
 
   const ticket = useMemo(() => parseTicketMd(conversation?.ticket_md), [conversation?.ticket_md]);
   const derivedTicketId = ticketId || conversation?.ticketId || '';
-  const [threadTicket] = useCachedQuery(queries.ticketRowById({ ticketId: derivedTicketId }), {
-    enabled: !!derivedTicketId,
-  });
-  const isFlowStep = !!threadTicket?.rootId;
 
   const [threadSubTicketMappings] = useCachedQuery(
     queries.subTicketsForTicket({ ticketId: derivedTicketId }),
@@ -1656,7 +1652,6 @@ export const ThreadMessages = ({
                     initialScrollOffset={0}
                     isTicketThread={true}
                     spawnedTicketMessageIds={spawnedTicketMessageIds}
-                    isFlowStep={isFlowStep}
                     channelScopeType={channel?.scopeType}
                     conversation={conversation}
                     enableCollapsing={previewCardMode}

--- a/apps/dashboard/src/components/Project/ViewBoardPicker/ViewBoardPicker.tsx
+++ b/apps/dashboard/src/components/Project/ViewBoardPicker/ViewBoardPicker.tsx
@@ -169,7 +169,7 @@ export function ViewBoardPicker({
       data-track-name='OpenBoardPicker'
       className={cn('rounded-[10px] border-border hover:bg-muted', className)}
     >
-      <Layers className='w-3 h-3 text-muted-foreground' />
+      <Layers className='w-3 h-3' />
       <span className='font-medium'>
         {count === 0 ? 'Select boards' : `${count} board${count > 1 ? 's' : ''}`}
       </span>

--- a/apps/dashboard/src/components/Tickets/CreateTicketModal/CreateTicketModal.tsx
+++ b/apps/dashboard/src/components/Tickets/CreateTicketModal/CreateTicketModal.tsx
@@ -89,6 +89,7 @@ import {
 import { DatePicker } from '../../ui/DatePicker/DatePicker';
 import { TextShimmer } from '../../ui/ShimmerText';
 import { SearchUserV2 } from '../../ui/SearchUser/SearchUserV2';
+import { TicketFieldSelector } from '../../ui/TicketFieldSelector/TicketFieldSelector';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import type { BoardMetadata } from '../../Board/BoardTicketFormConfig';
 import { isReleaseBoard, isMainReleaseBoard } from '../../../utils/boardUtils';
@@ -2718,6 +2719,38 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
                                 [fieldName]: isOpen,
                               }));
                             }}
+                          />
+                        </div>
+                        {error && <p className='text-xs text-red-600 mt-1'>{error}</p>}
+                      </>
+                    )}
+                    {fieldType === FormFieldType.TICKET && (
+                      <>
+                        <label className='text-sm font-medium text-foreground'>{`${fieldName}${!isOptional ? ' *' : ''}`}</label>
+                        <div className='border border-input rounded'>
+                          <TicketFieldSelector
+                            selectedValue={stringValue || null}
+                            onSelect={ticketId => {
+                              form.setFieldValue('dynamicFields', {
+                                ...formValues?.dynamicFields,
+                                [fieldName]: ticketId ?? '',
+                              });
+                              if (ticketId && error) {
+                                setDynamicFieldErrors(prev => {
+                                  const next = { ...prev };
+                                  delete next[fieldName];
+                                  return next;
+                                });
+                              } else if (!isOptional && !ticketId) {
+                                setDynamicFieldErrors(prev => ({
+                                  ...prev,
+                                  [fieldName]: `${fieldName} is required`,
+                                }));
+                              }
+                            }}
+                            projectId={projectId}
+                            placeholder={`Search ${fieldName.toLowerCase()}`}
+                            testId={`ticket-field-selector-${fieldName}`}
                           />
                         </div>
                         {error && <p className='text-xs text-red-600 mt-1'>{error}</p>}

--- a/apps/dashboard/src/components/Tickets/StageFormFields/StageFormFields.tsx
+++ b/apps/dashboard/src/components/Tickets/StageFormFields/StageFormFields.tsx
@@ -173,7 +173,7 @@ export const StageFormFields = ({
                 <p className='text-xs font-medium leading-4 text-muted-foreground'>
                   {field.fieldName}
                 </p>
-                <p className='mt-1 text-sm font-semibold leading-5 text-foreground'>
+                <p className='mt-1 break-all text-sm font-semibold leading-5 text-foreground'>
                   {displayValue}
                 </p>
               </div>

--- a/apps/dashboard/src/components/Tickets/StageFormFields/StageFormFields.tsx
+++ b/apps/dashboard/src/components/Tickets/StageFormFields/StageFormFields.tsx
@@ -4,7 +4,15 @@ import { FormFieldType, isFieldActive, parseFieldOptionValues } from '@xyne/shar
 import type { FormEntityValues, MessageAttachment } from '@xyne/shared';
 import { StageFormDocField } from '../StageFormModal/StageFormDocField';
 import { MultiSelect } from '../../ui/MultiSelect/MultiSelect';
+import { TicketFieldSelector } from '../../ui/TicketFieldSelector/TicketFieldSelector';
+import { TicketLinkField } from '../TicketLinkField/TicketLinkField';
+import {
+  toDateInputValue,
+  formatShortDate,
+  looksLikeXyneId,
+} from '../TicketLinkField/ticketLinkUtils';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
+import { useAuth } from '../../../hooks/useAuth';
 import { queries } from '../../../zero/queries';
 import type { ResolvedDisplayFormField } from '../../../utils/board/resolveDisplayFormFields';
 
@@ -34,6 +42,8 @@ interface StageFormFieldsProps {
   setLocalDocChanges: Dispatch<SetStateAction<Map<string, StageFormDocLocalChange>>>;
   valuesForRender: readonly FormEntityValueForRender[];
   targetStageId: string;
+  /** The desk ticket the form belongs to — enables the sub-ticket experience for TICKET fields. */
+  parentTicketId?: string;
   disabled?: boolean;
   readOnlyDocs?: boolean;
   showPersistedDocValues?: boolean;
@@ -54,6 +64,7 @@ export const StageFormFields = ({
   setLocalDocChanges,
   valuesForRender,
   targetStageId,
+  parentTicketId,
   disabled = false,
   readOnlyDocs = false,
   showPersistedDocValues = true,
@@ -99,6 +110,42 @@ export const StageFormFields = ({
   // keyed by fieldName — no name lookup needed to find a parent's current value.
   const getFieldEffectiveValue = (fieldId: string): string | undefined => formData[fieldId]?.[0];
 
+  // ETA hint: resolve the linked ticket of the first TICKET field with a value so DATE
+  // fields can offer "linked ticket is due X — use that date".
+  const linkedTicketIdForEta = useMemo(() => {
+    for (const field of fields) {
+      if (field.fieldType !== FormFieldType.TICKET) continue;
+      const candidate = formData[field.id]?.[0]?.trim() ?? '';
+      if (
+        candidate.length > 0 &&
+        !candidate.startsWith('http://') &&
+        !candidate.startsWith('https://')
+      ) {
+        return candidate;
+      }
+    }
+    return '';
+  }, [fields, formData]);
+
+  // Stored TICKET values are xyneIds; resolve those in the active workspace
+  // (legacy uuid values keep resolving by ticket id).
+  const etaValueIsXyneId = looksLikeXyneId(linkedTicketIdForEta);
+  const { user } = useAuth();
+  const workspaceId = user?.workspaceId ?? '';
+
+  const [etaSourceById] = useCachedQuery(
+    queries.ticketRowById({ ticketId: !etaValueIsXyneId ? linkedTicketIdForEta : '' }),
+    { enabled: Boolean(linkedTicketIdForEta) && !etaValueIsXyneId },
+  );
+  const [etaSourceByXyneId] = useCachedQuery(
+    queries.ticketByXyneIdV3({
+      xyneId: etaValueIsXyneId ? linkedTicketIdForEta : '',
+      workspaceId,
+    }),
+    { enabled: etaValueIsXyneId && Boolean(workspaceId) },
+  );
+  const etaSourceTicket = etaValueIsXyneId ? etaSourceByXyneId : etaSourceById;
+
   return (
     <>
       {fields
@@ -135,10 +182,12 @@ export const StageFormFields = ({
 
           return (
             <div key={field.id} className={readOnlySummary ? 'py-3 first:pt-0 last:pb-0' : 'mb-4'}>
-              <label className='mb-1 block text-sm font-medium text-foreground'>
-                {field.fieldName}
-                {!field.isOptional && <span className='text-red-500'>*</span>}
-              </label>
+              {!(field.fieldType === FormFieldType.TICKET && parentTicketId) && (
+                <label className='mb-1 block text-sm font-medium text-foreground'>
+                  {field.fieldName}
+                  {!field.isOptional && <span className='text-red-500'>*</span>}
+                </label>
+              )}
 
               {field.fieldType === FormFieldType.STRING && (
                 <input
@@ -198,18 +247,46 @@ export const StageFormFields = ({
                 </div>
               )}
 
-              {field.fieldType === FormFieldType.DATE && (
-                <input
-                  type='date'
-                  value={fieldValue[0] ?? ''}
-                  onChange={event => updateFieldValue(field.id, [event.target.value])}
-                  disabled={disabled}
-                  className={stageFormControlClassName}
-                  data-track-category='Tickets'
-                  data-track-name={`${trackNamePrefix}DateInput`}
-                  data-track-metadata={trackMetadata}
-                />
-              )}
+              {field.fieldType === FormFieldType.DATE &&
+                ((): React.JSX.Element => {
+                  const etaTimestamp = etaSourceTicket?.eta ?? null;
+                  const etaDateValue = etaTimestamp ? toDateInputValue(etaTimestamp) : '';
+                  const etaCurrentValue = fieldValue[0] ?? '';
+                  const showEtaHint =
+                    etaTimestamp !== null &&
+                    etaDateValue.length > 0 &&
+                    etaCurrentValue.length === 0;
+
+                  return (
+                    <>
+                      <input
+                        type='date'
+                        value={etaCurrentValue}
+                        onChange={event => updateFieldValue(field.id, [event.target.value])}
+                        disabled={disabled}
+                        className={stageFormControlClassName}
+                        data-track-category='Tickets'
+                        data-track-name={`${trackNamePrefix}DateInput`}
+                        data-track-metadata={trackMetadata}
+                      />
+                      {showEtaHint && etaTimestamp !== null ? (
+                        <p className='mt-1 text-xs text-muted-foreground'>
+                          {`${etaSourceTicket?.xyneId || 'Linked ticket'} is due ${formatShortDate(etaTimestamp)}. `}
+                          <button
+                            type='button'
+                            onClick={() => updateFieldValue(field.id, [etaDateValue])}
+                            className='font-medium text-red-600 underline-offset-2 hover:underline'
+                            data-track-category='Tickets'
+                            data-track-name={`${trackNamePrefix}UseLinkedTicketEta`}
+                            data-track-metadata={trackMetadata}
+                          >
+                            Use that date
+                          </button>
+                        </p>
+                      ) : null}
+                    </>
+                  );
+                })()}
 
               {field.fieldType === FormFieldType.SINGLE_SELECT && (
                 <div
@@ -267,6 +344,32 @@ export const StageFormFields = ({
                   data-track-metadata={trackMetadata}
                 />
               )}
+
+              {field.fieldType === FormFieldType.TICKET &&
+                (parentTicketId ? (
+                  <TicketLinkField
+                    parentTicketId={parentTicketId}
+                    value={fieldValue[0] || null}
+                    onChange={ticketId => updateFieldValue(field.id, ticketId ? [ticketId] : [])}
+                    label={field.fieldName}
+                    isOptional={field.isOptional === true}
+                    disabled={disabled}
+                    trackName={`${trackNamePrefix}TicketLinkField`}
+                  />
+                ) : (
+                  <div
+                    data-track-category='Tickets'
+                    data-track-name={`${trackNamePrefix}TicketSelector`}
+                    data-track-metadata={trackMetadata}
+                  >
+                    <TicketFieldSelector
+                      selectedValue={fieldValue[0] || null}
+                      onSelect={ticketId => updateFieldValue(field.id, ticketId ? [ticketId] : [])}
+                      disabled={disabled}
+                      placeholder='Search ticket by ID or name'
+                    />
+                  </div>
+                ))}
 
               {field.fieldType === FormFieldType.DOC &&
                 ((): React.JSX.Element => {

--- a/apps/dashboard/src/components/Tickets/StageFormFields/useStageForm.ts
+++ b/apps/dashboard/src/components/Tickets/StageFormFields/useStageForm.ts
@@ -5,6 +5,7 @@ import {
   FormEntityType,
   FormFieldType,
   isFieldActive,
+  isManualSubTicketBoard,
   ReenterMode,
   TicketStageRequestStatus,
 } from '@xyne/shared';
@@ -13,9 +14,11 @@ import type { Stage } from '../../../routes/KanbanBoardScreen/KanbanBoardScreen.
 import { useAuth } from '../../../hooks/useAuth';
 import { useZero } from '../../../hooks/useZero';
 import { apiInstance } from '../../../services/clients/apiClient';
+import { subTicketService } from '../../../services/subTicketService';
 import { mutators } from '../../../zero/mutators';
 import { queries } from '../../../zero/queries';
 import type { StageFormDocLocalChange } from './StageFormFields';
+import { isExternalHttpUrl, looksLikeXyneId } from '../TicketLinkField/ticketLinkUtils';
 import {
   resolveDisplayFormFields,
   type ResolvedDisplayFormField,
@@ -361,6 +364,83 @@ export const useStageForm = ({
     [shouldReuseExistingValueIds, targetStage.id, values],
   );
 
+  // TICKET-field values link the selected ticket as a sub-ticket of the desk ticket (the
+  // "Will be added as a sub-ticket of X" promise). Best-effort: never blocks or fails a save.
+  const linkTicketFieldSubTickets = useCallback(
+    (persistedData: Record<string, string[]>): void => {
+      void (async (): Promise<void> => {
+        try {
+          // Values are xyneIds ("TOKEN-4127"); values stored before that switch are ticket uuids.
+          const candidateValues = Array.from(
+            new Set(
+              fields
+                .filter(field => field.fieldType === FormFieldType.TICKET)
+                .map(field => persistedData[field.id]?.[0]?.trim())
+                .filter(
+                  (candidate): candidate is string =>
+                    Boolean(candidate) && !isExternalHttpUrl(candidate!),
+                ),
+            ),
+          );
+          if (candidateValues.length === 0) return;
+
+          const parentTicketRow = await zero.run(queries.ticketRowById({ ticketId: ticket.id }), {
+            type: 'complete',
+          });
+          if (!parentTicketRow) return;
+          const boardRow = parentTicketRow.boardId
+            ? await zero.run(queries.boardDetailById({ boardId: parentTicketRow.boardId }), {
+                type: 'complete',
+              })
+            : undefined;
+          if (!isManualSubTicketBoard(boardRow?.boardType)) return;
+
+          const resolvedCandidates: Array<{ id: string; label: string }> = [];
+          const seenIds = new Set<string>();
+          for (const candidateValue of candidateValues) {
+            const row = looksLikeXyneId(candidateValue)
+              ? await zero.run(
+                  queries.ticketByXyneIdV3({
+                    xyneId: candidateValue,
+                    workspaceId: parentTicketRow.workspaceId ?? '',
+                  }),
+                  { type: 'complete' },
+                )
+              : await zero.run(queries.ticketRowById({ ticketId: candidateValue }), {
+                  type: 'complete',
+                });
+            if (!row || row.id === ticket.id || seenIds.has(row.id)) continue;
+            seenIds.add(row.id);
+            resolvedCandidates.push({ id: row.id, label: row.xyneId || row.title || 'Sub-ticket' });
+          }
+          if (resolvedCandidates.length === 0) return;
+
+          const mappings = await zero.run(
+            queries.subTicketMappingsForTickets({ ticketIds: [ticket.id] }),
+            { type: 'complete' },
+          );
+          const alreadyLinked = new Set(
+            (mappings ?? [])
+              .map(mapping => mapping.subTicket?.mappedTicketId)
+              .filter((id): id is string => Boolean(id)),
+          );
+
+          for (const candidate of resolvedCandidates) {
+            if (alreadyLinked.has(candidate.id)) continue;
+            try {
+              await subTicketService.link(ticket.id, candidate.id, candidate.label);
+            } catch {
+              // Duplicate/concurrent links are rejected server-side; the stored value stands.
+            }
+          }
+        } catch {
+          // Best-effort wiring; a failed link never fails the form save itself.
+        }
+      })();
+    },
+    [fields, ticket.id, zero],
+  );
+
   const persistForm = useCallback(
     async (
       mode: PersistMode,
@@ -571,6 +651,7 @@ export const useStageForm = ({
           });
           return next;
         });
+        linkTicketFieldSubTickets(effectiveFormData);
         return effectiveFormData;
       } catch (error) {
         toast.error(error instanceof Error ? error.message : 'Failed to save form');
@@ -588,6 +669,7 @@ export const useStageForm = ({
       formData,
       formId,
       hasApprovers,
+      linkTicketFieldSubTickets,
       localDocChanges,
       requestForStage?.id,
       resolveDraftVisitVersion,

--- a/apps/dashboard/src/components/Tickets/StageFormInlinePanel/StageFormInlinePanel.tsx
+++ b/apps/dashboard/src/components/Tickets/StageFormInlinePanel/StageFormInlinePanel.tsx
@@ -343,6 +343,7 @@ export const StageFormInlinePanel: React.FC<StageFormInlinePanelProps> = ({
               setLocalDocChanges={setLocalDocChanges}
               valuesForRender={valuesForRender}
               targetStageId={targetStage.id}
+              parentTicketId={ticket.id}
               disabled={isApproved || isSubmitted || !isEditing}
               readOnlyDocs={!isEditing}
               readOnlySummary={!isEditing}

--- a/apps/dashboard/src/components/Tickets/StageFormInlinePanel/StageFormInlinePanel.tsx
+++ b/apps/dashboard/src/components/Tickets/StageFormInlinePanel/StageFormInlinePanel.tsx
@@ -317,7 +317,7 @@ export const StageFormInlinePanel: React.FC<StageFormInlinePanelProps> = ({
         <div
           className={
             embedded
-              ? `min-h-0 flex-1 overflow-y-auto ${submittedHeader && !isEditing ? 'px-3 py-3' : 'p-4'}`
+              ? `min-h-0 flex-1 overflow-x-hidden overflow-y-auto ${submittedHeader && !isEditing ? 'px-3 py-3' : 'p-4'}`
               : 'p-4'
           }
         >

--- a/apps/dashboard/src/components/Tickets/StageFormModal/StageFormModal.tsx
+++ b/apps/dashboard/src/components/Tickets/StageFormModal/StageFormModal.tsx
@@ -235,7 +235,7 @@ export const StageFormModal: React.FC<StageFormModalProps> = ({
         onOpenChange={onClose}
         title={isReviewer ? `${targetStage.name} Form Review` : `${targetStage.name} Form`}
       >
-        <div className='max-h-[80vh] overflow-y-auto p-6'>
+        <div className='max-h-[80vh] overflow-x-hidden overflow-y-auto p-6'>
           <div className='mb-6 flex items-center justify-between gap-4 border-b border-border pb-4'>
             <div className='flex items-center gap-3'>
               <span className='rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground'>

--- a/apps/dashboard/src/components/Tickets/StageFormModal/StageFormModal.tsx
+++ b/apps/dashboard/src/components/Tickets/StageFormModal/StageFormModal.tsx
@@ -304,6 +304,7 @@ export const StageFormModal: React.FC<StageFormModalProps> = ({
             setLocalDocChanges={setLocalDocChanges}
             valuesForRender={valuesForRender}
             targetStageId={targetStage.id}
+            parentTicketId={ticket.id}
             disabled={isFormReadOnly}
             readOnlyDocs={isReviewer}
             showPersistedDocValues={shouldShowPersistedDocValues}

--- a/apps/dashboard/src/components/Tickets/SubTicketModal/SubTicketModal.tsx
+++ b/apps/dashboard/src/components/Tickets/SubTicketModal/SubTicketModal.tsx
@@ -13,7 +13,10 @@ interface SubTicketModalProps {
   ticketId: string;
   conversationId: string;
   sourceMessageId?: string;
-  onSuccess?: () => void;
+  initialTitle?: string;
+  initialDescription?: string;
+  /** Receives the created ticket, after the sub-ticket mapping is wired. */
+  onSuccess?: (createdTicket: { id: string; xyneId?: string | undefined }) => void;
 }
 
 type InitialAssignee = { type: 'assigneeTo' | 'userGroup'; value: string } | null;
@@ -24,6 +27,8 @@ export const SubTicketModal = ({
   ticketId,
   conversationId,
   sourceMessageId,
+  initialTitle,
+  initialDescription,
   onSuccess,
 }: SubTicketModalProps): ReactElement | null => {
   const zero = useZero();
@@ -63,6 +68,8 @@ export const SubTicketModal = ({
       initialTags={initialTags}
       isFromSubTicket={true}
       {...(sourceMessageId && { sourceMessageId })}
+      {...(initialTitle && { initialTitle })}
+      {...(initialDescription && { initialDescription })}
       parentTicketId={ticketId}
       onTicketCreated={createdTicket => {
         // Create SubTicket and mapping using Zero mutators
@@ -103,7 +110,7 @@ export const SubTicketModal = ({
         );
 
         onClose();
-        onSuccess?.();
+        onSuccess?.(createdTicket);
       }}
     />
   );

--- a/apps/dashboard/src/components/Tickets/TicketDetails/EditableFormField.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketDetails/EditableFormField.tsx
@@ -5,8 +5,13 @@ import { FormFieldType, User } from '@xyne/shared';
 import type { ReadonlyJSONValue } from '@rocicorp/zero';
 import UserAvatar from '../../UserAvatar/UserAvatar';
 import { useUsers } from '../../../hooks/useUsers';
+import { useCachedQuery } from '../../../hooks/useCachedQuery';
+import { useAuth } from '../../../hooks/useAuth';
+import { queries } from '../../../zero/queries';
 import { MultiSelect } from '../../ui/MultiSelect';
 import { SearchUserV2 } from '../../ui/SearchUser/SearchUserV2';
+import { TicketFieldSelector } from '../../ui/TicketFieldSelector/TicketFieldSelector';
+import { looksLikeXyneId } from '../TicketLinkField/ticketLinkUtils';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
 
 interface EditableFormFieldProps {
@@ -194,6 +199,31 @@ export const EditableFormField: React.FC<EditableFormFieldProps> = ({
       .filter((user): user is User => user !== undefined);
   }, [selectedUserIds, userMap]);
 
+  // For TICKET field, resolve the selected ticket for display. Values are
+  // xyneIds; legacy stored values (ticket uuids) still resolve by id.
+  const selectedTicketValue = useMemo(() => {
+    if (fieldType === FormFieldType.TICKET) {
+      return jsonToString(fieldValue);
+    }
+    return '';
+  }, [fieldValue, fieldType]);
+
+  const { user } = useAuth();
+  const workspaceId = user?.workspaceId ?? '';
+  const selectedValueIsXyneId = looksLikeXyneId(selectedTicketValue);
+  const [selectedTicketById] = useCachedQuery(
+    queries.ticketRowById({ ticketId: !selectedValueIsXyneId ? selectedTicketValue : '' }),
+    { enabled: Boolean(selectedTicketValue) && !selectedValueIsXyneId },
+  );
+  const [selectedTicketByXyneId] = useCachedQuery(
+    queries.ticketByXyneIdV3({
+      xyneId: selectedValueIsXyneId ? selectedTicketValue : '',
+      workspaceId,
+    }),
+    { enabled: selectedValueIsXyneId && Boolean(workspaceId) },
+  );
+  const selectedTicket = selectedValueIsXyneId ? selectedTicketByXyneId : selectedTicketById;
+
   if (isEditing) {
     if (fieldType === FormFieldType.BOOLEAN) {
       const booleanOptions = [
@@ -343,6 +373,28 @@ export const EditableFormField: React.FC<EditableFormFieldProps> = ({
       );
     }
 
+    // TICKET field - TicketFieldSelector with vespa search
+    if (fieldType === FormFieldType.TICKET) {
+      return (
+        <div className='flex items-start gap-2 w-full'>
+          <span
+            className='text-sm text-muted-foreground w-[120px] flex-shrink-0 overflow-x-auto whitespace-nowrap'
+            title={fieldName}
+          >
+            {fieldName}
+          </span>
+          <div className='flex-1 bg-background border border-input rounded outline-none focus:border-blue-500 focus-within:border-blue-500'>
+            <TicketFieldSelector
+              selectedValue={selectedTicketValue || null}
+              onSelect={ticketXyneId => {
+                onSave(ticketXyneId ? [ticketXyneId] : []);
+              }}
+            />
+          </div>
+        </div>
+      );
+    }
+
     // STRING or NUMBER fields (fallback for MULTI_SELECT without fieldEnum)
     return (
       <div className='flex items-center gap-2 w-full'>
@@ -414,6 +466,41 @@ export const EditableFormField: React.FC<EditableFormFieldProps> = ({
           ) : (
             <span className='text-sm text-muted-foreground'>—</span>
           )}
+        </div>
+      </div>
+    );
+  }
+
+  // Read mode for TICKET field - display the linked ticket's title
+  if (fieldType === FormFieldType.TICKET) {
+    const ticketLabel = selectedTicket
+      ? selectedTicket.title || selectedTicket.xyneId || selectedTicket.id
+      : selectedTicketValue;
+
+    return (
+      <div className='flex items-center gap-2 w-full'>
+        <span
+          className='text-sm text-muted-foreground w-[120px] flex-shrink-0 overflow-x-auto whitespace-nowrap'
+          title={fieldName}
+        >
+          {fieldName}
+        </span>
+        <div
+          role='button'
+          tabIndex={0}
+          className='flex-1 text-sm text-muted-foreground break-all cursor-text hover:bg-muted rounded px-1 py-0.5 -mx-1'
+          onClick={() => setIsEditing(true)}
+          onKeyDown={e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              setIsEditing(true);
+            }
+          }}
+          data-track-category='TicketDetails'
+          data-track-name='EditTicketField'
+          data-track-metadata={JSON.stringify({ fieldName, fieldType, fieldValue })}
+        >
+          {ticketLabel || '—'}
         </div>
       </div>
     );

--- a/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
@@ -1375,10 +1375,6 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
   const [parentSubTickets] = useCachedQuery(
     queries.subTicketsByMappedTicketId({ mappedTicketId: ticketId }),
   );
-  // Gates the Create Sub-Ticket button only, mirroring subTicket.create's row-existence
-  // guard. linkExisting has no depth limit, so the picker below is deliberately not gated.
-  const canCreateNestedSubTicket =
-    (parentSubTickets?.length ?? 0) === 0 || boardData?.boardType === BoardType.FLOW;
 
   // Query parent tickets through the mappings
   const parentTicketIds = useMemo(
@@ -3267,17 +3263,12 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
     boardData?.boardType === BoardType.FLOW ? null : (
       <button
         onClick={() => setIsSubTicketModalOpen(true)}
-        disabled={!canCreateNestedSubTicket}
         data-testid='create-sub-ticket-button'
         data-track-event='BUTTON_CLICK'
         data-track-category='Tickets'
         data-track-name='CREATE_SUB_TICKET'
         data-track-metadata={JSON.stringify({ ticketId: ticket.id })}
-        title={canCreateNestedSubTicket ? undefined : 'Sub-tickets cannot be nested on this board'}
-        className={cn(
-          'flex items-center gap-2 mt-3 text-sm text-muted-foreground transition-colors',
-          canCreateNestedSubTicket ? 'hover:text-foreground' : 'cursor-not-allowed opacity-50',
-        )}
+        className='flex items-center gap-2 mt-3 text-sm text-muted-foreground transition-colors hover:text-foreground'
       >
         <Plus size={16} />
         Create Sub-Ticket

--- a/apps/dashboard/src/components/Tickets/TicketFilters/TicketFiltersDropdown.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/TicketFiltersDropdown.tsx
@@ -291,6 +291,11 @@ export const TicketFiltersDropdown = ({
         : [];
 
       fields.forEach(field => {
+        // The filter submenu has no UI for these field types — keep them out of
+        // the menu instead of dead-ending on "Unsupported field type".
+        if (field.fieldType === FormFieldType.TICKET || field.fieldType === FormFieldType.DOC) {
+          return;
+        }
         // Use field ID as key to ensure uniqueness
         if (!fieldsMap.has(field.id)) {
           fieldsMap.set(field.id, { field });

--- a/apps/dashboard/src/components/Tickets/TicketFilters/fieldTypeIcons.ts
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/fieldTypeIcons.ts
@@ -4,6 +4,7 @@ import {
   CalendarDefault as Calendar,
   FileText,
   Hashtag as Hash,
+  TicketToken,
   UserDefault as User,
 } from '@xyne/icons';
 import { FormFieldType } from '@xyne/shared';
@@ -22,6 +23,8 @@ export const getIconForFieldType = (fieldType: FormFieldType): typeof BarChart3 
       return BarChart3;
     case FormFieldType.USER:
       return User;
+    case FormFieldType.TICKET:
+      return TicketToken;
     default:
       return Hash;
   }

--- a/apps/dashboard/src/components/Tickets/TicketLinkField/TicketLinkChip.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketLinkField/TicketLinkChip.tsx
@@ -1,0 +1,92 @@
+import {
+  CheckTickCircle as CircleCheck,
+  CircleDashed,
+  CircleDot,
+  MultipleCrossCancelDefault as X,
+  PauseCircle,
+} from '@xyne/icons';
+import { TicketStatusV2 } from '@xyne/shared';
+import UserAvatar, { AvatarShape, AvatarSize } from '../../UserAvatar/UserAvatar';
+import { cn } from '../../../utils/classNames';
+
+interface TicketLinkChipProps {
+  xyneId: string;
+  title: string;
+  assignedTo?: string | null | undefined;
+  statusV2?: string | null | undefined;
+  removable?: boolean;
+  onClear?: (() => void) | undefined;
+  onClick?: (() => void) | undefined;
+  className?: string;
+}
+
+const statusIconFor = (statusV2?: string | null): React.ReactElement => {
+  const className = 'size-[18px] shrink-0';
+  switch (statusV2) {
+    case TicketStatusV2.COMPLETED:
+      return <CircleCheck className={cn(className, 'text-green-600')} />;
+    case TicketStatusV2.STARTED:
+      return <CircleDot className={cn(className, 'text-blue-600')} />;
+    case TicketStatusV2.PAUSED:
+    case TicketStatusV2.CANCELLED:
+      return <PauseCircle className={cn(className, 'text-muted-foreground')} />;
+    case TicketStatusV2.TODO:
+    default:
+      return <CircleDashed className={cn(className, 'text-muted-foreground')} />;
+  }
+};
+
+export const TicketLinkChip: React.FC<TicketLinkChipProps> = ({
+  xyneId,
+  title,
+  assignedTo,
+  statusV2,
+  removable = true,
+  onClear,
+  onClick,
+  className,
+}) => {
+  return (
+    <div
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onClick={onClick}
+      onKeyDown={e => {
+        if (onClick && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      className={cn(
+        'flex w-full items-center gap-2.5 rounded-lg border border-input bg-background px-3 py-2',
+        onClick && 'cursor-pointer hover:border-ring',
+        className,
+      )}
+      data-track-category='Tickets'
+      data-track-name='TicketLinkChipOpen'
+      data-track-metadata={JSON.stringify({ xyneId })}
+    >
+      {statusIconFor(statusV2)}
+      <span className='shrink-0 font-mono text-[13px] text-muted-foreground'>{xyneId}</span>
+      <span className='min-w-0 flex-1 truncate text-sm font-medium text-foreground'>{title}</span>
+      {assignedTo ? (
+        <UserAvatar userId={assignedTo} size={AvatarSize.SM} shape={AvatarShape.CIRCULAR} />
+      ) : null}
+      {removable && onClear ? (
+        <button
+          type='button'
+          onClick={e => {
+            e.stopPropagation();
+            onClear();
+          }}
+          className='rounded-full p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+          aria-label='Clear linked ticket'
+          data-track-category='Tickets'
+          data-track-name='ClearTicketLink'
+        >
+          <X className='size-3.5' />
+        </button>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/Tickets/TicketLinkField/TicketLinkChip.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketLinkField/TicketLinkChip.tsx
@@ -67,7 +67,9 @@ export const TicketLinkChip: React.FC<TicketLinkChipProps> = ({
       data-track-metadata={JSON.stringify({ xyneId })}
     >
       {statusIconFor(statusV2)}
-      <span className='shrink-0 font-mono text-[13px] text-muted-foreground'>{xyneId}</span>
+      <span className='max-w-[45%] shrink-0 truncate font-mono text-[13px] text-muted-foreground'>
+        {xyneId}
+      </span>
       <span className='min-w-0 flex-1 truncate text-sm font-medium text-foreground'>{title}</span>
       {assignedTo ? (
         <UserAvatar userId={assignedTo} size={AvatarSize.SM} shape={AvatarShape.CIRCULAR} />

--- a/apps/dashboard/src/components/Tickets/TicketLinkField/TicketLinkField.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketLinkField/TicketLinkField.tsx
@@ -1,0 +1,693 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AlertTriangle, Plus, Globe } from 'lucide-react';
+import {
+  CheckTickCircle as CircleCheck,
+  LinkChainHorizontal as LinkIcon,
+  Spinner as Loader2,
+} from '@xyne/icons';
+import { isManualSubTicketBoard } from '@xyne/shared';
+import { useCachedQuery } from '../../../hooks/useCachedQuery';
+import {
+  useTicketFieldSearch,
+  type TicketFieldSearchResult,
+} from '../../../hooks/useTicketFieldSearch';
+import { queries } from '../../../zero/queries';
+import { cn } from '../../../utils/classNames';
+import { CreateTicketModal } from '../CreateTicketModal/CreateTicketModal';
+import { TicketLinkChip } from './TicketLinkChip';
+import { TicketLinkPicker, type TicketLinkHighlight } from './TicketLinkPicker';
+import {
+  extractTicketRefFromUrl,
+  formatShortDate,
+  isExternalHttpUrl,
+  looksLikeXyneId,
+  type PastedTicketRef,
+} from './ticketLinkUtils';
+
+interface ExistingSubEntry {
+  mappingId: string;
+  addedAt: number;
+  ticket: {
+    id: string;
+    xyneId?: string | null;
+    title?: string | null;
+    assignedTo?: string | null;
+    statusV2?: string | null;
+  };
+}
+
+interface TicketLinkFieldProps {
+  /** The desk ticket whose form contains this field — drives sub-ticket context. */
+  parentTicketId: string;
+  value: string | null;
+  onChange: (value: string | null) => void;
+  label: string;
+  isOptional: boolean;
+  disabled?: boolean;
+  trackName: string;
+}
+
+/**
+ * Rich TICKET form-field control: search a ticket, paste a link, or create one;
+ * the selection becomes a sub-ticket of the parent desk ticket on form submit.
+ */
+export const TicketLinkField: React.FC<TicketLinkFieldProps> = ({
+  parentTicketId,
+  value,
+  onChange,
+  label,
+  isOptional,
+  disabled = false,
+  trackName,
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const [highlight, setHighlight] = useState<TicketLinkHighlight>(null);
+  const [resolveTarget, setResolveTarget] = useState<PastedTicketRef | null>(null);
+  const [resolveErrorUrl, setResolveErrorUrl] = useState<string | null>(null);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [createSeed, setCreateSeed] = useState<{
+    initialTitle?: string;
+    initialDescription?: string;
+  }>({});
+  const hasPrefilledRef = useRef(false);
+
+  // ── Parent ticket + board context ──────────────────────────────────────────
+  const [parentTicket] = useCachedQuery(queries.ticketRowById({ ticketId: parentTicketId }), {
+    enabled: Boolean(parentTicketId),
+  });
+  const parentXyneId = parentTicket?.xyneId ?? '';
+  const parentChannelId = parentTicket?.channelId ?? '';
+  const parentProjectId = parentTicket?.projectId ?? undefined;
+  const workspaceId = parentTicket?.workspaceId ?? '';
+
+  const [parentBoard] = useCachedQuery(
+    queries.boardDetailById({ boardId: parentTicket?.boardId ?? '' }),
+    { enabled: Boolean(parentTicket?.boardId) },
+  );
+  const manualLinksAllowed = isManualSubTicketBoard(parentBoard?.boardType);
+
+  // ── Existing sub-tickets of the parent ─────────────────────────────────────
+  const [subTicketMappings] = useCachedQuery(
+    queries.subTicketsForTicket({ ticketId: parentTicketId }),
+    {
+      enabled: Boolean(parentTicketId) && manualLinksAllowed,
+    },
+  );
+
+  const existingSubEntries = useMemo<ExistingSubEntry[]>(() => {
+    const rows: ExistingSubEntry[] = [];
+    subTicketMappings?.forEach(mapping => {
+      const ticket = mapping.subTicket?.mappedTicket;
+      if (!ticket) return;
+      rows.push({
+        mappingId: mapping.id,
+        addedAt: mapping.subTicket?.createdAt ?? 0,
+        ticket: {
+          id: ticket.id,
+          xyneId: ticket.xyneId ?? null,
+          title: ticket.title ?? null,
+          assignedTo: ticket.assignedTo ?? null,
+          statusV2: ticket.statusV2 ?? null,
+        },
+      });
+    });
+    return rows.sort((a, b) => b.addedAt - a.addedAt);
+  }, [subTicketMappings]);
+
+  // ── Value modes ────────────────────────────────────────────────────────────
+  // The stored value is the ticket's xyneId ("TOKEN-4127") — what users search
+  // and see across the dashboard. Legacy values (ticket uuids) still resolve.
+  const externalUrl = value && isExternalHttpUrl(value) ? value : null;
+  const linkedValue = value && !isExternalHttpUrl(value) ? value : null;
+  const linkedIsXyneId = linkedValue ? looksLikeXyneId(linkedValue) : false;
+
+  const [linkedTicketById] = useCachedQuery(
+    queries.ticketRowById({ ticketId: linkedValue && !linkedIsXyneId ? linkedValue : '' }),
+    { enabled: Boolean(linkedValue) && !linkedIsXyneId },
+  );
+  const [linkedTicketByXyneId] = useCachedQuery(
+    queries.ticketByXyneIdV3({
+      xyneId: linkedIsXyneId ? (linkedValue ?? '') : '',
+      workspaceId,
+    }),
+    { enabled: linkedIsXyneId && Boolean(workspaceId) },
+  );
+  const linkedTicket = linkedIsXyneId ? linkedTicketByXyneId : linkedTicketById;
+
+  const existingEntryForValue = useMemo(
+    () =>
+      linkedValue
+        ? existingSubEntries.find(
+            e => e.ticket.id === linkedValue || e.ticket.xyneId === linkedValue,
+          )
+        : undefined,
+    [linkedValue, existingSubEntries],
+  );
+
+  // ── Design 2a/2b: prefill the newest existing sub-ticket on open ───────────
+  useEffect(() => {
+    if (
+      disabled ||
+      value ||
+      hasPrefilledRef.current ||
+      !manualLinksAllowed ||
+      existingSubEntries.length === 0
+    ) {
+      return;
+    }
+    const newest = existingSubEntries[0]?.ticket;
+    if (!newest) return;
+    hasPrefilledRef.current = true;
+    onChange(newest.xyneId ?? newest.id);
+  }, [disabled, value, manualLinksAllowed, existingSubEntries, onChange]);
+
+  // ── Vespa search (Design 1d/1e) ────────────────────────────────────────────
+  const {
+    results: searchResults,
+    isLoading: isSearchLoading,
+    hasMore,
+    totalCount,
+    boardsSearched,
+    searchQuery,
+    handleSearchChange,
+    handleScrollEnd,
+  } = useTicketFieldSearch({ isActive: isDropdownOpen, projectId: parentProjectId });
+
+  // ── Pasted link resolution (Design 1f/1h) ──────────────────────────────────
+  const resolvingId = resolveTarget?.kind === 'id' ? resolveTarget.value : '';
+  const resolvingXyneId = resolveTarget?.kind === 'xyneId' ? resolveTarget.value : '';
+  const [resolvedById, byIdDetails] = useCachedQuery(
+    queries.ticketRowById({ ticketId: resolvingId }),
+    {
+      enabled: resolveTarget?.kind === 'id',
+    },
+  );
+  const [resolvedByXyneId, byXyneIdDetails] = useCachedQuery(
+    queries.ticketByXyneIdV3({ xyneId: resolvingXyneId, workspaceId }),
+    { enabled: resolveTarget?.kind === 'xyneId' && Boolean(workspaceId) },
+  );
+
+  const [pendingResolveUrl, setPendingResolveUrl] = useState('');
+
+  // Close the dropdown/sub-picker when the user clicks outside the field.
+  useEffect(() => {
+    if (!isDropdownOpen && !isPickerOpen) return;
+    const handleDocumentMouseDown = (event: MouseEvent): void => {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
+        setIsDropdownOpen(false);
+        setIsPickerOpen(false);
+        setHighlight(null);
+      }
+    };
+    document.addEventListener('mousedown', handleDocumentMouseDown);
+    return (): void => document.removeEventListener('mousedown', handleDocumentMouseDown);
+  }, [isDropdownOpen, isPickerOpen]);
+
+  useEffect(() => {
+    if (!resolveTarget) return;
+    const details = resolveTarget.kind === 'id' ? byIdDetails : byXyneIdDetails;
+    if (details.type !== 'complete') return;
+    const resolved = resolveTarget.kind === 'id' ? resolvedById : resolvedByXyneId;
+
+    if (resolved) {
+      onChange(resolved.xyneId || resolved.id);
+      setResolveTarget(null);
+      setPendingResolveUrl('');
+      setResolveErrorUrl(null);
+      setInputValue('');
+      handleSearchChange('');
+    } else {
+      setResolveErrorUrl(pendingResolveUrl);
+      setInputValue(pendingResolveUrl);
+      setResolveTarget(null);
+      setPendingResolveUrl('');
+    }
+  }, [
+    resolveTarget,
+    resolvedById,
+    resolvedByXyneId,
+    byIdDetails,
+    byXyneIdDetails,
+    onChange,
+    pendingResolveUrl,
+    handleSearchChange,
+  ]);
+
+  // ── Handlers ───────────────────────────────────────────────────────────────
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const next = event.target.value;
+    setInputValue(next);
+    setHighlight(null);
+
+    const trimmed = next.trim();
+    if (isExternalHttpUrl(trimmed)) {
+      const ref = extractTicketRefFromUrl(trimmed);
+      if (ref) {
+        setPendingResolveUrl(trimmed);
+        setResolveTarget(ref);
+        setResolveErrorUrl(null);
+        setIsDropdownOpen(false);
+      } else {
+        // Design 1g — non-Xyne URL: kept as an external link.
+        setResolveErrorUrl(null);
+        setResolveTarget(null);
+        setIsDropdownOpen(false);
+        onChange(trimmed);
+      }
+    } else {
+      setResolveTarget(null);
+      setResolveErrorUrl(null);
+      handleSearchChange(next);
+    }
+  };
+
+  const openSearch = useCallback((): void => {
+    setIsPickerOpen(false);
+    setIsDropdownOpen(true);
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSelectSearchOption = (ticket: TicketFieldSearchResult): void => {
+    onChange(ticket.xyneId || ticket.id);
+    setIsDropdownOpen(false);
+    setHighlight(null);
+    setInputValue('');
+    handleSearchChange('');
+  };
+
+  const handleClear = (): void => {
+    onChange(null);
+    setInputValue('');
+    handleSearchChange('');
+    setResolveErrorUrl(null);
+    setIsDropdownOpen(false);
+  };
+
+  const openCreateTicket = useCallback(
+    (seed: { initialTitle?: string; initialDescription?: string } = {}): void => {
+      if (!parentTicket?.channelId) return;
+      setCreateSeed(seed);
+      setIsDropdownOpen(false);
+      setIsPickerOpen(false);
+      setResolveErrorUrl(null);
+      setIsCreateModalOpen(true);
+    },
+    [parentTicket?.channelId],
+  );
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (!isDropdownOpen && (event.key === 'ArrowDown' || event.key === 'Enter')) {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setIsDropdownOpen(true);
+      }
+      return;
+    }
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        setHighlight(previous =>
+          previous === null
+            ? parentChannelId
+              ? 'create'
+              : 0
+            : previous === 'create'
+              ? 0
+              : Math.min(previous + 1, searchResults.length - 1),
+        );
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        setHighlight(previous =>
+          previous === null
+            ? searchResults.length - 1
+            : previous === 0
+              ? parentChannelId
+                ? 'create'
+                : searchResults.length - 1
+              : previous === 'create'
+                ? searchResults.length - 1
+                : previous - 1,
+        );
+        break;
+      case 'Enter': {
+        event.preventDefault();
+        if (highlight === 'create') {
+          openCreateTicket(inputValue.trim() ? { initialTitle: inputValue.trim() } : {});
+          return;
+        }
+        const target = highlight === null ? searchResults[0] : searchResults[highlight];
+        if (target) {
+          handleSelectSearchOption(target);
+        } else if (parentChannelId) {
+          openCreateTicket(inputValue.trim() ? { initialTitle: inputValue.trim() } : {});
+        }
+        break;
+      }
+      case 'Escape':
+        setIsDropdownOpen(false);
+        setHighlight(null);
+        break;
+      default:
+        break;
+    }
+  };
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  const isResolving = resolveTarget !== null;
+  const showErrorState = resolveErrorUrl !== null;
+
+  return (
+    <div ref={rootRef} className='relative'>
+      <div className='mb-1 flex items-center gap-2'>
+        <label className='text-sm font-medium text-foreground'>
+          {label}
+          {!isOptional && <span className='text-red-500'>*</span>}
+        </label>
+        {existingEntryForValue ? (
+          <span className='rounded-full bg-green-50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-green-700'>
+            Existing sub-ticket
+          </span>
+        ) : null}
+        {existingSubEntries.length > 1 ? (
+          <span className='ml-auto text-xs text-muted-foreground'>
+            {existingSubEntries.length} on this ticket
+          </span>
+        ) : null}
+      </div>
+
+      {/* ── Linked ticket (Design 1b/2a) ── */}
+      {linkedValue ? (
+        <>
+          <TicketLinkChip
+            xyneId={linkedTicket?.xyneId || linkedValue}
+            title={linkedTicket?.title || 'Resolving ticket…'}
+            assignedTo={linkedTicket?.assignedTo}
+            statusV2={linkedTicket?.statusV2}
+            removable={!disabled}
+            onClear={disabled ? undefined : handleClear}
+            onClick={
+              disabled
+                ? undefined
+                : (): void => {
+                    if (existingSubEntries.length > 1) {
+                      setIsPickerOpen(previous => !previous);
+                      setIsDropdownOpen(false);
+                    } else {
+                      openSearch();
+                    }
+                  }
+            }
+          />
+          {manualLinksAllowed ? (
+            <p className='mt-1 flex items-center gap-1 text-xs text-muted-foreground'>
+              <CircleCheck className='size-3.5 text-green-600' />
+              {existingEntryForValue
+                ? `Already a sub-ticket of ${parentXyneId}, added ${formatShortDate(existingEntryForValue.addedAt)}.`
+                : `Will be added as a sub-ticket of ${parentXyneId}.`}
+            </p>
+          ) : null}
+        </>
+      ) : null}
+
+      {/* ── External link (Design 1g) ── */}
+      {externalUrl ? (
+        <>
+          <div className='flex w-full items-center gap-2.5 rounded-lg border border-input bg-background px-3 py-2'>
+            <Globe className='size-4 shrink-0 text-muted-foreground' />
+            <ExternalLinkBits url={externalUrl} />
+            {!disabled ? (
+              <button
+                type='button'
+                onClick={handleClear}
+                className='ml-auto rounded-full p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+                aria-label='Clear link'
+                data-track-category='Tickets'
+                data-track-name={`${trackName}ClearExternalLink`}
+              >
+                ×
+              </button>
+            ) : null}
+          </div>
+          <p className='mt-1 flex items-start gap-1 text-xs text-muted-foreground'>
+            <AlertTriangle className='mt-0.5 size-3 shrink-0 text-amber-500' />
+            Kept as an external link — no status comes back.{' '}
+            {parentTicket?.channelId ? (
+              <button
+                type='button'
+                onClick={() => {
+                  try {
+                    const parsed = new URL(externalUrl);
+                    openCreateTicket({
+                      initialTitle: `${parsed.host}${parsed.pathname}`,
+                      initialDescription: externalUrl,
+                    });
+                  } catch {
+                    openCreateTicket({ initialTitle: externalUrl });
+                  }
+                }}
+                className='font-medium text-red-600 underline-offset-2 hover:underline'
+                data-track-category='Tickets'
+                data-track-name={`${trackName}CreateTicketFromExternalLink`}
+              >
+                Create a ticket from it
+              </button>
+            ) : null}{' '}
+            to get updates on this ticket.
+          </p>
+        </>
+      ) : null}
+
+      {/* ── Resolving (Design 1f) ── */}
+      {isResolving ? (
+        <div className='flex w-full items-center gap-2.5 rounded-lg border border-input bg-background px-3 py-2'>
+          <Loader2 className='size-4 animate-spin text-muted-foreground' />
+          <span className='min-w-0 flex-1 truncate font-mono text-[13px] text-muted-foreground'>
+            {pendingResolveUrl || inputValue}
+          </span>
+          <span className='shrink-0 text-xs text-muted-foreground'>Resolving…</span>
+        </div>
+      ) : null}
+
+      {/* ── Search input (Design 1a/1d/1e) + paste-error state (1h) ── */}
+      {!linkedValue && !externalUrl && !isResolving ? (
+        <>
+          <div
+            className={cn(
+              'flex w-full items-center gap-2 rounded-lg border bg-background px-3 shadow-sm transition-colors',
+              showErrorState
+                ? 'border-red-500 focus-within:ring-2 focus-within:ring-red-200'
+                : 'border-input focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/30',
+            )}
+          >
+            {showErrorState ? (
+              <AlertTriangle className='size-4 shrink-0 text-red-500' />
+            ) : (
+              <LinkIcon className='size-4 shrink-0 text-muted-foreground' />
+            )}
+            <input
+              ref={inputRef}
+              type='text'
+              value={inputValue}
+              disabled={disabled}
+              onChange={handleInputChange}
+              onFocus={() => setIsDropdownOpen(true)}
+              onKeyDown={handleKeyDown}
+              placeholder='Search, paste a link, or create a ticket'
+              className='w-full bg-transparent py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed'
+              data-track-category='Tickets'
+              data-track-name={trackName}
+            />
+            {inputValue ? (
+              <button
+                type='button'
+                onClick={handleClear}
+                className='shrink-0 text-sm text-muted-foreground hover:text-foreground'
+                aria-label='Clear input'
+                data-track-category='Tickets'
+                data-track-name={`${trackName}ClearInput`}
+              >
+                ×
+              </button>
+            ) : null}
+          </div>
+
+          {showErrorState ? (
+            <div className='mt-2'>
+              <p className='mb-2 text-xs text-red-600'>
+                Couldn&rsquo;t resolve this link. Check it, search by ticket ID, or create the
+                ticket.
+              </p>
+              <div className='flex gap-2'>
+                <button
+                  type='button'
+                  onClick={() => {
+                    const ref = extractTicketRefFromUrl(resolveErrorUrl);
+                    if (ref) {
+                      setPendingResolveUrl(resolveErrorUrl);
+                      setResolveTarget(ref);
+                      setResolveErrorUrl(null);
+                    }
+                  }}
+                  className='rounded-lg border border-border bg-background px-3 py-1.5 text-sm text-foreground transition-colors hover:bg-muted'
+                  data-track-category='Tickets'
+                  data-track-name={`${trackName}RetryResolve`}
+                >
+                  Try again
+                </button>
+                <button
+                  type='button'
+                  onClick={() => {
+                    handleSearchChange(resolveErrorUrl);
+                    setResolveErrorUrl(null);
+                    setIsDropdownOpen(true);
+                    inputRef.current?.focus();
+                  }}
+                  className='rounded-lg border border-border bg-background px-3 py-1.5 text-sm text-foreground transition-colors hover:bg-muted'
+                  data-track-category='Tickets'
+                  data-track-name={`${trackName}SearchInstead`}
+                >
+                  Search instead
+                </button>
+              </div>
+            </div>
+          ) : null}
+
+          {!showErrorState && !isDropdownOpen ? (
+            <p className='mt-1 text-xs text-muted-foreground'>
+              A Xyne ticket is linked as a sub-ticket, so its status shows up on this ticket.
+            </p>
+          ) : null}
+
+          {isDropdownOpen ? (
+            <TicketLinkPicker
+              query={searchQuery}
+              results={searchResults}
+              isLoading={isSearchLoading}
+              hasMore={hasMore}
+              totalCount={totalCount}
+              boardsSearched={boardsSearched}
+              highlight={highlight}
+              onHighlight={setHighlight}
+              onSelect={handleSelectSearchOption}
+              onScrollEnd={handleScrollEnd}
+              onCreateTicket={() =>
+                openCreateTicket(inputValue.trim() ? { initialTitle: inputValue.trim() } : {})
+              }
+              canCreateTicket={Boolean(parentChannelId)}
+            />
+          ) : null}
+        </>
+      ) : null}
+
+      {/* ── Sub-ticket chooser (Design 2b/1c) ── */}
+      {isPickerOpen && existingSubEntries.length > 1 ? (
+        <div className='mt-1 rounded-lg border border-border bg-background'>
+          <p className='px-3 pt-2 text-[10px] uppercase tracking-wide text-muted-foreground'>
+            If there is more than one
+          </p>
+          <ul className='py-1'>
+            {existingSubEntries.map((entry, index) => {
+              const checked = entry.ticket.id === value;
+              return (
+                <li key={entry.mappingId}>
+                  <button
+                    type='button'
+                    onClick={() => {
+                      if (entry.ticket.xyneId || entry.ticket.id) {
+                        onChange(entry.ticket.xyneId || entry.ticket.id);
+                      }
+                      setIsPickerOpen(false);
+                    }}
+                    className={cn(
+                      'flex w-full items-center gap-3 px-3 py-2 text-left transition-colors',
+                      checked ? 'bg-accent/60' : 'hover:bg-muted',
+                    )}
+                    data-track-category='Tickets'
+                    data-track-name={`${trackName}PickExistingSubTicket`}
+                    data-track-metadata={JSON.stringify({ ticketId: entry.ticket.id })}
+                  >
+                    <span
+                      className={cn(
+                        'flex size-4 shrink-0 items-center justify-center rounded-full border',
+                        checked ? 'border-blue-600' : 'border-input',
+                      )}
+                    >
+                      {checked ? <span className='size-2 rounded-full bg-blue-600' /> : null}
+                    </span>
+                    <span className='w-[96px] shrink-0 truncate font-mono text-[13px] text-muted-foreground'>
+                      {entry.ticket.xyneId || entry.ticket.id}
+                    </span>
+                    <span className='min-w-0 flex-1 truncate text-sm text-foreground'>
+                      {entry.ticket.title || entry.ticket.xyneId || entry.ticket.id}
+                    </span>
+                    <span className='shrink-0 text-[11px] text-muted-foreground'>
+                      {index === 0 ? 'most recent' : formatShortDate(entry.addedAt)}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+          <button
+            type='button'
+            onClick={openSearch}
+            className='flex w-full items-center gap-2 border-t border-border px-3 py-2.5 text-left text-sm text-muted-foreground transition-colors hover:bg-muted'
+            data-track-category='Tickets'
+            data-track-name={`${trackName}LinkDifferentTicket`}
+          >
+            <Plus className='size-4 shrink-0' />
+            Link a different ticket instead
+          </button>
+          <p className='px-3 pb-2.5 pt-1 text-xs text-muted-foreground'>
+            The newest sub-ticket is filled in; pick another if this move is waiting on that one
+            instead.
+          </p>
+        </div>
+      ) : null}
+
+      {isCreateModalOpen && parentTicket?.channelId ? (
+        <CreateTicketModal
+          isOpen
+          onClose={() => setIsCreateModalOpen(false)}
+          channelId={parentTicket.channelId}
+          {...(parentProjectId ? { projectId: parentProjectId } : {})}
+          parentTicketId={parentTicketId}
+          {...(createSeed.initialTitle ? { initialTitle: createSeed.initialTitle } : {})}
+          {...(createSeed.initialDescription
+            ? { initialDescription: createSeed.initialDescription }
+            : {})}
+          onTicketCreated={created => {
+            setIsCreateModalOpen(false);
+            onChange(created.xyneId || created.id);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+};
+
+const ExternalLinkBits: React.FC<{ url: string }> = ({ url }) => {
+  let host = url;
+  let path = '';
+  try {
+    const parsed = new URL(url);
+    host = parsed.host;
+    path = parsed.pathname;
+  } catch {
+    // raw string — show as-is
+  }
+  return (
+    <>
+      <span className='shrink-0 text-sm font-medium text-foreground'>{host}</span>
+      {path && path !== '/' ? (
+        <span className='min-w-0 truncate font-mono text-[12px] text-muted-foreground'>{path}</span>
+      ) : null}
+    </>
+  );
+};

--- a/apps/dashboard/src/components/Tickets/TicketLinkField/TicketLinkField.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketLinkField/TicketLinkField.tsx
@@ -564,7 +564,7 @@ export const TicketLinkField: React.FC<TicketLinkFieldProps> = ({
               onFocus={() => setIsDropdownOpen(true)}
               onKeyDown={handleKeyDown}
               placeholder='Search, paste a link, or create a ticket'
-              className='w-full bg-transparent py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed'
+              className='min-w-0 flex-1 bg-transparent py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed'
               data-track-category='Tickets'
               data-track-name={trackName}
             />
@@ -686,9 +686,19 @@ const ExternalLinkBits: React.FC<{ url: string }> = ({ url }) => {
   }
   return (
     <>
-      <span className='shrink-0 text-sm font-medium text-foreground'>{host}</span>
+      <span
+        title={host}
+        className='min-w-0 max-w-[60%] shrink-0 truncate text-sm font-medium text-foreground'
+      >
+        {host}
+      </span>
       {path && path !== '/' ? (
-        <span className='min-w-0 truncate font-mono text-[12px] text-muted-foreground'>{path}</span>
+        <span
+          title={path}
+          className='min-w-0 flex-1 truncate font-mono text-[12px] text-muted-foreground'
+        >
+          {path}
+        </span>
       ) : null}
     </>
   );

--- a/apps/dashboard/src/components/Tickets/TicketLinkField/TicketLinkField.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketLinkField/TicketLinkField.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { AlertTriangle, Plus, Globe } from 'lucide-react';
+import { AlertTriangle, Globe } from 'lucide-react';
 import {
   CheckTickCircle as CircleCheck,
   LinkChainHorizontal as LinkIcon,
@@ -13,9 +13,13 @@ import {
 } from '../../../hooks/useTicketFieldSearch';
 import { queries } from '../../../zero/queries';
 import { cn } from '../../../utils/classNames';
-import { CreateTicketModal } from '../CreateTicketModal/CreateTicketModal';
+import { SubTicketModal } from '../SubTicketModal/SubTicketModal';
 import { TicketLinkChip } from './TicketLinkChip';
-import { TicketLinkPicker, type TicketLinkHighlight } from './TicketLinkPicker';
+import {
+  TicketLinkPicker,
+  type ExistingSubTicketOption,
+  type TicketLinkHighlight,
+} from './TicketLinkPicker';
 import {
   extractTicketRefFromUrl,
   formatShortDate,
@@ -23,6 +27,14 @@ import {
   looksLikeXyneId,
   type PastedTicketRef,
 } from './ticketLinkUtils';
+
+type TicketLinkHighlightValue = Exclude<TicketLinkHighlight, null>;
+
+const isSameHighlight = (a: TicketLinkHighlightValue, b: TicketLinkHighlightValue): boolean => {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === 'create' || b.kind === 'create') return true;
+  return a.index === b.index;
+};
 
 interface ExistingSubEntry {
   mappingId: string;
@@ -62,8 +74,8 @@ export const TicketLinkField: React.FC<TicketLinkFieldProps> = ({
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [isPickerOpen, setIsPickerOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [highlight, setHighlight] = useState<TicketLinkHighlight>(null);
   const [resolveTarget, setResolveTarget] = useState<PastedTicketRef | null>(null);
@@ -74,6 +86,9 @@ export const TicketLinkField: React.FC<TicketLinkFieldProps> = ({
     initialDescription?: string;
   }>({});
   const hasPrefilledRef = useRef(false);
+  // Set when the input is about to mount (opened from the chip or after clear);
+  // focuses it once the dropdown renders.
+  const shouldFocusInputRef = useRef(false);
 
   // ── Parent ticket + board context ──────────────────────────────────────────
   const [parentTicket] = useCachedQuery(queries.ticketRowById({ ticketId: parentTicketId }), {
@@ -117,6 +132,19 @@ export const TicketLinkField: React.FC<TicketLinkFieldProps> = ({
     });
     return rows.sort((a, b) => b.addedAt - a.addedAt);
   }, [subTicketMappings]);
+
+  // Selectable form of the existing sub-tickets, shown inside the dropdown so
+  // they stay pickable (single-select) whenever it is open — including right
+  // after clearing the current selection.
+  const existingSubTicketOptions = useMemo<ExistingSubTicketOption[]>(
+    () =>
+      existingSubEntries.map(entry => ({
+        value: entry.ticket.xyneId || entry.ticket.id,
+        title: entry.ticket.title || entry.ticket.xyneId || entry.ticket.id,
+        addedAt: entry.addedAt,
+      })),
+    [existingSubEntries],
+  );
 
   // ── Value modes ────────────────────────────────────────────────────────────
   // The stored value is the ticket's xyneId ("TOKEN-4127") — what users search
@@ -193,19 +221,36 @@ export const TicketLinkField: React.FC<TicketLinkFieldProps> = ({
 
   const [pendingResolveUrl, setPendingResolveUrl] = useState('');
 
-  // Close the dropdown/sub-picker when the user clicks outside the field.
+  // Close the dropdown when the user clicks outside the field.
   useEffect(() => {
-    if (!isDropdownOpen && !isPickerOpen) return;
+    if (!isDropdownOpen) return;
     const handleDocumentMouseDown = (event: MouseEvent): void => {
       if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
         setIsDropdownOpen(false);
-        setIsPickerOpen(false);
         setHighlight(null);
       }
     };
     document.addEventListener('mousedown', handleDocumentMouseDown);
     return (): void => document.removeEventListener('mousedown', handleDocumentMouseDown);
-  }, [isDropdownOpen, isPickerOpen]);
+  }, [isDropdownOpen]);
+
+  // Focus the freshly mounted input when the dropdown was opened from the chip
+  // or via the clear (×) button — at click time the input is not yet rendered.
+  useEffect(() => {
+    if (!shouldFocusInputRef.current || !isDropdownOpen) return;
+    shouldFocusInputRef.current = false;
+    inputRef.current?.focus();
+  }, [isDropdownOpen]);
+
+  // The dropdown is in-flow; when the field sits low in the modal, bring the
+  // freshly opened dropdown into the visible area.
+  useEffect(() => {
+    if (!isDropdownOpen) return;
+    const frame = requestAnimationFrame(() => {
+      dropdownRef.current?.scrollIntoView({ block: 'nearest' });
+    });
+    return (): void => cancelAnimationFrame(frame);
+  }, [isDropdownOpen]);
 
   useEffect(() => {
     if (!resolveTarget) return;
@@ -266,9 +311,9 @@ export const TicketLinkField: React.FC<TicketLinkFieldProps> = ({
   };
 
   const openSearch = useCallback((): void => {
-    setIsPickerOpen(false);
-    setIsDropdownOpen(true);
     inputRef.current?.focus();
+    if (!inputRef.current) shouldFocusInputRef.current = true;
+    setIsDropdownOpen(true);
   }, []);
 
   const handleSelectSearchOption = (ticket: TicketFieldSearchResult): void => {
@@ -279,12 +324,24 @@ export const TicketLinkField: React.FC<TicketLinkFieldProps> = ({
     handleSearchChange('');
   };
 
+  const handleSelectExistingSubTicket = (option: ExistingSubTicketOption): void => {
+    onChange(option.value);
+    setIsDropdownOpen(false);
+    setHighlight(null);
+    setInputValue('');
+    handleSearchChange('');
+  };
+
   const handleClear = (): void => {
+    // An explicit removal stops the auto-prefill from re-selecting a sub-ticket.
+    hasPrefilledRef.current = true;
     onChange(null);
     setInputValue('');
     handleSearchChange('');
     setResolveErrorUrl(null);
-    setIsDropdownOpen(false);
+    // Show the search input again with the existing sub-tickets ready to pick.
+    shouldFocusInputRef.current = true;
+    setIsDropdownOpen(true);
   };
 
   const openCreateTicket = useCallback(
@@ -292,12 +349,20 @@ export const TicketLinkField: React.FC<TicketLinkFieldProps> = ({
       if (!parentTicket?.channelId) return;
       setCreateSeed(seed);
       setIsDropdownOpen(false);
-      setIsPickerOpen(false);
       setResolveErrorUrl(null);
       setIsCreateModalOpen(true);
     },
     [parentTicket?.channelId],
   );
+
+  // Keyboard order: create row → existing sub-tickets → search results.
+  const buildHighlightSequence = useCallback((): TicketLinkHighlightValue[] => {
+    const sequence: TicketLinkHighlightValue[] = [];
+    if (parentChannelId) sequence.push({ kind: 'create' });
+    existingSubTicketOptions.forEach((_, index) => sequence.push({ kind: 'sub', index }));
+    searchResults.forEach((_, index) => sequence.push({ kind: 'result', index }));
+    return sequence;
+  }, [parentChannelId, existingSubTicketOptions, searchResults]);
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
     if (!isDropdownOpen && (event.key === 'ArrowDown' || event.key === 'Enter')) {
@@ -309,39 +374,48 @@ export const TicketLinkField: React.FC<TicketLinkFieldProps> = ({
     }
 
     switch (event.key) {
-      case 'ArrowDown':
+      case 'ArrowDown': {
         event.preventDefault();
-        setHighlight(previous =>
-          previous === null
-            ? parentChannelId
-              ? 'create'
-              : 0
-            : previous === 'create'
-              ? 0
-              : Math.min(previous + 1, searchResults.length - 1),
-        );
+        const sequence = buildHighlightSequence();
+        if (sequence.length === 0) break;
+        const currentIndex =
+          highlight === null ? -1 : sequence.findIndex(item => isSameHighlight(item, highlight));
+        const nextIndex = currentIndex === -1 ? 0 : Math.min(currentIndex + 1, sequence.length - 1);
+        setHighlight(sequence[nextIndex] ?? null);
         break;
-      case 'ArrowUp':
+      }
+      case 'ArrowUp': {
         event.preventDefault();
-        setHighlight(previous =>
-          previous === null
-            ? searchResults.length - 1
-            : previous === 0
-              ? parentChannelId
-                ? 'create'
-                : searchResults.length - 1
-              : previous === 'create'
-                ? searchResults.length - 1
-                : previous - 1,
-        );
+        const sequence = buildHighlightSequence();
+        if (sequence.length === 0) break;
+        const currentIndex =
+          highlight === null ? -1 : sequence.findIndex(item => isSameHighlight(item, highlight));
+        const nextIndex = currentIndex <= 0 ? sequence.length - 1 : currentIndex - 1;
+        setHighlight(sequence[nextIndex] ?? null);
         break;
+      }
       case 'Enter': {
         event.preventDefault();
-        if (highlight === 'create') {
+        const active: TicketLinkHighlight =
+          highlight ??
+          (existingSubTicketOptions.length > 0
+            ? { kind: 'sub', index: 0 }
+            : searchResults.length > 0
+              ? { kind: 'result', index: 0 }
+              : parentChannelId
+                ? { kind: 'create' }
+                : null);
+        if (!active) return;
+        if (active.kind === 'create') {
           openCreateTicket(inputValue.trim() ? { initialTitle: inputValue.trim() } : {});
           return;
         }
-        const target = highlight === null ? searchResults[0] : searchResults[highlight];
+        if (active.kind === 'sub') {
+          const option = existingSubTicketOptions[active.index];
+          if (option) handleSelectExistingSubTicket(option);
+          return;
+        }
+        const target = searchResults[active.index];
         if (target) {
           handleSelectSearchOption(target);
         } else if (parentChannelId) {
@@ -381,8 +455,8 @@ export const TicketLinkField: React.FC<TicketLinkFieldProps> = ({
         ) : null}
       </div>
 
-      {/* ── Linked ticket (Design 1b/2a) ── */}
-      {linkedValue ? (
+      {/* ── Linked ticket (Design 1b/2a) — hidden while the dropdown is open ── */}
+      {linkedValue && !isDropdownOpen ? (
         <>
           <TicketLinkChip
             xyneId={linkedTicket?.xyneId || linkedValue}
@@ -391,18 +465,7 @@ export const TicketLinkField: React.FC<TicketLinkFieldProps> = ({
             statusV2={linkedTicket?.statusV2}
             removable={!disabled}
             onClear={disabled ? undefined : handleClear}
-            onClick={
-              disabled
-                ? undefined
-                : (): void => {
-                    if (existingSubEntries.length > 1) {
-                      setIsPickerOpen(previous => !previous);
-                      setIsDropdownOpen(false);
-                    } else {
-                      openSearch();
-                    }
-                  }
-            }
+            onClick={disabled ? undefined : openSearch}
           />
           {manualLinksAllowed ? (
             <p className='mt-1 flex items-center gap-1 text-xs text-muted-foreground'>
@@ -474,8 +537,10 @@ export const TicketLinkField: React.FC<TicketLinkFieldProps> = ({
         </div>
       ) : null}
 
-      {/* ── Search input (Design 1a/1d/1e) + paste-error state (1h) ── */}
-      {!linkedValue && !externalUrl && !isResolving ? (
+      {/* ── Search input (Design 1a/1d/1e) + paste-error state (1h) ──
+          Also rendered while a value is linked and the dropdown is open, so
+          clicking the chip (or ×) swaps the chip for the searchable picker. */}
+      {!externalUrl && !isResolving && (!linkedValue || isDropdownOpen) ? (
         <>
           <div
             className={cn(
@@ -565,105 +630,42 @@ export const TicketLinkField: React.FC<TicketLinkFieldProps> = ({
           ) : null}
 
           {isDropdownOpen ? (
-            <TicketLinkPicker
-              query={searchQuery}
-              results={searchResults}
-              isLoading={isSearchLoading}
-              hasMore={hasMore}
-              totalCount={totalCount}
-              boardsSearched={boardsSearched}
-              highlight={highlight}
-              onHighlight={setHighlight}
-              onSelect={handleSelectSearchOption}
-              onScrollEnd={handleScrollEnd}
-              onCreateTicket={() =>
-                openCreateTicket(inputValue.trim() ? { initialTitle: inputValue.trim() } : {})
-              }
-              canCreateTicket={Boolean(parentChannelId)}
-            />
+            <div ref={dropdownRef}>
+              <TicketLinkPicker
+                query={searchQuery}
+                results={searchResults}
+                existingSubTickets={existingSubTicketOptions}
+                selectedValue={linkedValue}
+                isLoading={isSearchLoading}
+                hasMore={hasMore}
+                totalCount={totalCount}
+                boardsSearched={boardsSearched}
+                highlight={highlight}
+                onHighlight={setHighlight}
+                onSelect={handleSelectSearchOption}
+                onSelectExisting={handleSelectExistingSubTicket}
+                onScrollEnd={handleScrollEnd}
+                onCreateTicket={() =>
+                  openCreateTicket(inputValue.trim() ? { initialTitle: inputValue.trim() } : {})
+                }
+                canCreateTicket={Boolean(parentChannelId)}
+              />
+            </div>
           ) : null}
         </>
       ) : null}
 
-      {/* ── Sub-ticket chooser (Design 2b/1c) ── */}
-      {isPickerOpen && existingSubEntries.length > 1 ? (
-        <div className='mt-1 rounded-lg border border-border bg-background'>
-          <p className='px-3 pt-2 text-[10px] uppercase tracking-wide text-muted-foreground'>
-            If there is more than one
-          </p>
-          <ul className='py-1'>
-            {existingSubEntries.map((entry, index) => {
-              const checked = entry.ticket.id === value;
-              return (
-                <li key={entry.mappingId}>
-                  <button
-                    type='button'
-                    onClick={() => {
-                      if (entry.ticket.xyneId || entry.ticket.id) {
-                        onChange(entry.ticket.xyneId || entry.ticket.id);
-                      }
-                      setIsPickerOpen(false);
-                    }}
-                    className={cn(
-                      'flex w-full items-center gap-3 px-3 py-2 text-left transition-colors',
-                      checked ? 'bg-accent/60' : 'hover:bg-muted',
-                    )}
-                    data-track-category='Tickets'
-                    data-track-name={`${trackName}PickExistingSubTicket`}
-                    data-track-metadata={JSON.stringify({ ticketId: entry.ticket.id })}
-                  >
-                    <span
-                      className={cn(
-                        'flex size-4 shrink-0 items-center justify-center rounded-full border',
-                        checked ? 'border-blue-600' : 'border-input',
-                      )}
-                    >
-                      {checked ? <span className='size-2 rounded-full bg-blue-600' /> : null}
-                    </span>
-                    <span className='w-[96px] shrink-0 truncate font-mono text-[13px] text-muted-foreground'>
-                      {entry.ticket.xyneId || entry.ticket.id}
-                    </span>
-                    <span className='min-w-0 flex-1 truncate text-sm text-foreground'>
-                      {entry.ticket.title || entry.ticket.xyneId || entry.ticket.id}
-                    </span>
-                    <span className='shrink-0 text-[11px] text-muted-foreground'>
-                      {index === 0 ? 'most recent' : formatShortDate(entry.addedAt)}
-                    </span>
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
-          <button
-            type='button'
-            onClick={openSearch}
-            className='flex w-full items-center gap-2 border-t border-border px-3 py-2.5 text-left text-sm text-muted-foreground transition-colors hover:bg-muted'
-            data-track-category='Tickets'
-            data-track-name={`${trackName}LinkDifferentTicket`}
-          >
-            <Plus className='size-4 shrink-0' />
-            Link a different ticket instead
-          </button>
-          <p className='px-3 pb-2.5 pt-1 text-xs text-muted-foreground'>
-            The newest sub-ticket is filled in; pick another if this move is waiting on that one
-            instead.
-          </p>
-        </div>
-      ) : null}
-
-      {isCreateModalOpen && parentTicket?.channelId ? (
-        <CreateTicketModal
+      {isCreateModalOpen ? (
+        <SubTicketModal
           isOpen
           onClose={() => setIsCreateModalOpen(false)}
-          channelId={parentTicket.channelId}
-          {...(parentProjectId ? { projectId: parentProjectId } : {})}
-          parentTicketId={parentTicketId}
+          ticketId={parentTicketId}
+          conversationId={parentTicket?.conversationId ?? ''}
           {...(createSeed.initialTitle ? { initialTitle: createSeed.initialTitle } : {})}
           {...(createSeed.initialDescription
             ? { initialDescription: createSeed.initialDescription }
             : {})}
-          onTicketCreated={created => {
-            setIsCreateModalOpen(false);
+          onSuccess={created => {
             onChange(created.xyneId || created.id);
           }}
         />

--- a/apps/dashboard/src/components/Tickets/TicketLinkField/TicketLinkPicker.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketLinkField/TicketLinkPicker.tsx
@@ -2,13 +2,28 @@ import { Plus } from 'lucide-react';
 import type { TicketFieldSearchResult } from '../../../hooks/useTicketFieldSearch';
 import UserAvatar, { AvatarShape, AvatarSize } from '../../UserAvatar/UserAvatar';
 import { cn } from '../../../utils/classNames';
-import { splitTitleByQuery } from './ticketLinkUtils';
+import { formatShortDate, splitTitleByQuery } from './ticketLinkUtils';
 
-export type TicketLinkHighlight = number | 'create' | null;
+export type TicketLinkHighlight =
+  | { kind: 'create' }
+  | { kind: 'sub'; index: number }
+  | { kind: 'result'; index: number }
+  | null;
+
+export interface ExistingSubTicketOption {
+  /** Stored-value form (xyneId, or ticket id as a legacy fallback). */
+  value: string;
+  title: string;
+  addedAt: number;
+}
 
 interface TicketLinkPickerProps {
   query: string;
   results: TicketFieldSearchResult[];
+  /** Existing sub-tickets of the parent ticket — always offered for quick re-selection. */
+  existingSubTickets: ExistingSubTicketOption[];
+  /** Current field value, to mark the matching sub-ticket row as checked. */
+  selectedValue: string | null;
   isLoading: boolean;
   hasMore: boolean;
   totalCount: number;
@@ -16,6 +31,7 @@ interface TicketLinkPickerProps {
   highlight: TicketLinkHighlight;
   onHighlight: (highlight: TicketLinkHighlight) => void;
   onSelect: (ticket: TicketFieldSearchResult) => void;
+  onSelectExisting: (option: ExistingSubTicketOption) => void;
   onScrollEnd: () => void;
   onCreateTicket: () => void;
   canCreateTicket: boolean;
@@ -38,6 +54,8 @@ const HighlightedTitle: React.FC<{ title: string; query: string }> = ({ title, q
 export const TicketLinkPicker: React.FC<TicketLinkPickerProps> = ({
   query,
   results,
+  existingSubTickets,
+  selectedValue,
   isLoading,
   hasMore,
   totalCount,
@@ -45,14 +63,16 @@ export const TicketLinkPicker: React.FC<TicketLinkPickerProps> = ({
   highlight,
   onHighlight,
   onSelect,
+  onSelectExisting,
   onScrollEnd,
   onCreateTicket,
   canCreateTicket,
 }) => {
   const trimmedQuery = query.trim();
   const hasQuery = trimmedQuery.length > 0;
+  const hasSubTickets = existingSubTickets.length > 0;
 
-  const handleScroll = (event: React.UIEvent<HTMLUListElement>): void => {
+  const handleScroll = (event: React.UIEvent<HTMLDivElement>): void => {
     const target = event.currentTarget;
     if (target.scrollHeight - target.scrollTop - target.clientHeight < 40) {
       onScrollEnd();
@@ -60,21 +80,23 @@ export const TicketLinkPicker: React.FC<TicketLinkPickerProps> = ({
   };
 
   return (
-    <div className='absolute left-0 right-0 top-full z-40 mt-1 overflow-hidden rounded-xl border border-border bg-background shadow-lg'>
+    // In-flow (not absolute): the stage-form modal grows to fit the open
+    // dropdown and only scrolls once its own max-height is reached.
+    <div className='mt-1 overflow-hidden rounded-xl border border-border bg-background shadow-lg'>
       {canCreateTicket ? (
         <button
           type='button'
-          onMouseEnter={() => onHighlight('create')}
+          onMouseEnter={() => onHighlight({ kind: 'create' })}
           onClick={onCreateTicket}
           className={cn(
             'flex w-full items-center gap-2 border-b border-border px-3 py-2.5 text-left text-sm text-foreground transition-colors',
-            highlight === 'create' && 'bg-accent',
+            highlight?.kind === 'create' && 'bg-accent',
           )}
           data-track-category='Tickets'
           data-track-name='TicketLinkCreateOption'
         >
           <Plus className='size-4 shrink-0 text-muted-foreground' />
-          <span className='min-w-0 truncate'>Create ticket on a board…</span>
+          <span className='min-w-0 truncate'>Create sub-ticket on a board…</span>
           {hasQuery ? (
             <span className='ml-auto max-w-[45%] shrink-0 truncate text-muted-foreground'>
               “{trimmedQuery}”
@@ -83,60 +105,113 @@ export const TicketLinkPicker: React.FC<TicketLinkPickerProps> = ({
         </button>
       ) : null}
 
-      {!hasQuery ? (
-        <p className='px-3 pt-2 text-[11px] uppercase tracking-wide text-muted-foreground'>
-          Recent
-        </p>
-      ) : null}
-
-      <ul className='max-h-60 overflow-y-auto py-1' onScroll={handleScroll} role='listbox'>
-        {results.length === 0 && !isLoading ? (
-          <li className='px-3 py-4 text-center text-sm text-muted-foreground'>
-            {hasQuery ? 'No tickets found' : 'Start typing to search tickets'}
-          </li>
-        ) : (
-          results.map((ticket, index) => {
-            const selected = highlight === index;
-            return (
-              <li key={ticket.id} role='option' aria-selected={selected}>
-                <button
-                  type='button'
-                  onMouseEnter={() => onHighlight(index)}
-                  onClick={() => onSelect(ticket)}
-                  className={cn(
-                    'flex w-full items-center gap-3 px-3 py-2 text-left',
-                    selected && 'bg-accent',
-                  )}
-                  data-track-category='Tickets'
-                  data-track-name='TicketLinkSelectOption'
-                  data-track-metadata={JSON.stringify({ ticketId: ticket.id })}
-                >
-                  <span className='w-[96px] shrink-0 truncate font-mono text-[13px] text-muted-foreground'>
-                    {ticket.xyneId || ticket.id}
-                  </span>
-                  <span className='min-w-0 flex-1 truncate text-sm text-foreground'>
-                    <HighlightedTitle
-                      title={ticket.title || ticket.xyneId || ticket.id}
-                      query={hasQuery ? trimmedQuery : ''}
-                    />
-                  </span>
-                  {ticket.assignedTo ? (
-                    <UserAvatar
-                      userId={ticket.assignedTo}
-                      size={AvatarSize.SM}
-                      shape={AvatarShape.CIRCULAR}
-                    />
-                  ) : null}
-                </button>
-              </li>
-            );
-          })
-        )}
-        {isLoading ? <li className='px-3 py-2 text-sm text-muted-foreground'>Searching…</li> : null}
-        {hasMore && !isLoading ? (
-          <li className='px-3 py-2 text-center text-xs text-muted-foreground'>Scroll for more</li>
+      {/* Options area: up to half the screen; the modal scrolls beyond that. */}
+      <div className='max-h-[50vh] overflow-y-auto' onScroll={handleScroll}>
+        {hasSubTickets ? (
+          <>
+            <p className='px-3 pt-2 text-[11px] uppercase tracking-wide text-muted-foreground'>
+              Existing sub-tickets
+            </p>
+            <ul className='py-1'>
+              {existingSubTickets.map((option, index) => {
+                const selected = highlight?.kind === 'sub' && highlight.index === index;
+                const checked = option.value === selectedValue;
+                return (
+                  <li key={option.value}>
+                    <button
+                      type='button'
+                      onMouseEnter={() => onHighlight({ kind: 'sub', index })}
+                      onClick={() => onSelectExisting(option)}
+                      className={cn(
+                        'flex w-full items-center gap-3 px-3 py-2 text-left transition-colors',
+                        selected ? 'bg-accent' : 'hover:bg-muted',
+                      )}
+                      data-track-category='Tickets'
+                      data-track-name='TicketLinkSelectExistingSubTicket'
+                      data-track-metadata={JSON.stringify({ ticketValue: option.value })}
+                    >
+                      <span
+                        className={cn(
+                          'flex size-4 shrink-0 items-center justify-center rounded-full border',
+                          checked ? 'border-blue-600' : 'border-input',
+                        )}
+                      >
+                        {checked ? <span className='size-2 rounded-full bg-blue-600' /> : null}
+                      </span>
+                      <span className='w-[96px] shrink-0 truncate font-mono text-[13px] text-muted-foreground'>
+                        {option.value}
+                      </span>
+                      <span className='min-w-0 flex-1 truncate text-sm text-foreground'>
+                        {option.title}
+                      </span>
+                      <span className='shrink-0 text-[11px] text-muted-foreground'>
+                        {index === 0 ? 'most recent' : formatShortDate(option.addedAt)}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </>
         ) : null}
-      </ul>
+
+        {!hasQuery ? (
+          <p className='px-3 pt-2 text-[11px] uppercase tracking-wide text-muted-foreground'>
+            Recent
+          </p>
+        ) : null}
+
+        <ul className='py-1' role='listbox'>
+          {results.length === 0 && !isLoading ? (
+            <li className='px-3 py-4 text-center text-sm text-muted-foreground'>
+              {hasQuery ? 'No tickets found' : 'Start typing to search tickets'}
+            </li>
+          ) : (
+            results.map((ticket, index) => {
+              const selected = highlight?.kind === 'result' && highlight.index === index;
+              return (
+                <li key={ticket.id} role='option' aria-selected={selected}>
+                  <button
+                    type='button'
+                    onMouseEnter={() => onHighlight({ kind: 'result', index })}
+                    onClick={() => onSelect(ticket)}
+                    className={cn(
+                      'flex w-full items-center gap-3 px-3 py-2 text-left',
+                      selected && 'bg-accent',
+                    )}
+                    data-track-category='Tickets'
+                    data-track-name='TicketLinkSelectOption'
+                    data-track-metadata={JSON.stringify({ ticketId: ticket.id })}
+                  >
+                    <span className='w-[96px] shrink-0 truncate font-mono text-[13px] text-muted-foreground'>
+                      {ticket.xyneId || ticket.id}
+                    </span>
+                    <span className='min-w-0 flex-1 truncate text-sm text-foreground'>
+                      <HighlightedTitle
+                        title={ticket.title || ticket.xyneId || ticket.id}
+                        query={hasQuery ? trimmedQuery : ''}
+                      />
+                    </span>
+                    {ticket.assignedTo ? (
+                      <UserAvatar
+                        userId={ticket.assignedTo}
+                        size={AvatarSize.SM}
+                        shape={AvatarShape.CIRCULAR}
+                      />
+                    ) : null}
+                  </button>
+                </li>
+              );
+            })
+          )}
+          {isLoading ? (
+            <li className='px-3 py-2 text-sm text-muted-foreground'>Searching…</li>
+          ) : null}
+          {hasMore && !isLoading ? (
+            <li className='px-3 py-2 text-center text-xs text-muted-foreground'>Scroll for more</li>
+          ) : null}
+        </ul>
+      </div>
 
       <div className='border-t border-border px-3 py-1.5 text-[11px] text-muted-foreground'>
         {hasQuery ? (

--- a/apps/dashboard/src/components/Tickets/TicketLinkField/TicketLinkPicker.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketLinkField/TicketLinkPicker.tsx
@@ -106,7 +106,7 @@ export const TicketLinkPicker: React.FC<TicketLinkPickerProps> = ({
       ) : null}
 
       {/* Options area: up to half the screen; the modal scrolls beyond that. */}
-      <div className='max-h-[50vh] overflow-y-auto' onScroll={handleScroll}>
+      <div className='max-h-[50vh] overflow-x-hidden overflow-y-auto' onScroll={handleScroll}>
         {hasSubTickets ? (
           <>
             <p className='px-3 pt-2 text-[11px] uppercase tracking-wide text-muted-foreground'>

--- a/apps/dashboard/src/components/Tickets/TicketLinkField/TicketLinkPicker.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketLinkField/TicketLinkPicker.tsx
@@ -1,0 +1,155 @@
+import { Plus } from 'lucide-react';
+import type { TicketFieldSearchResult } from '../../../hooks/useTicketFieldSearch';
+import UserAvatar, { AvatarShape, AvatarSize } from '../../UserAvatar/UserAvatar';
+import { cn } from '../../../utils/classNames';
+import { splitTitleByQuery } from './ticketLinkUtils';
+
+export type TicketLinkHighlight = number | 'create' | null;
+
+interface TicketLinkPickerProps {
+  query: string;
+  results: TicketFieldSearchResult[];
+  isLoading: boolean;
+  hasMore: boolean;
+  totalCount: number;
+  boardsSearched: number;
+  highlight: TicketLinkHighlight;
+  onHighlight: (highlight: TicketLinkHighlight) => void;
+  onSelect: (ticket: TicketFieldSearchResult) => void;
+  onScrollEnd: () => void;
+  onCreateTicket: () => void;
+  canCreateTicket: boolean;
+}
+
+const HighlightedTitle: React.FC<{ title: string; query: string }> = ({ title, query }) => (
+  <>
+    {splitTitleByQuery(title, query).map((part, index) =>
+      part.match ? (
+        <mark key={index} className='rounded-sm bg-rose-100 font-medium text-rose-700'>
+          {part.text}
+        </mark>
+      ) : (
+        <span key={index}>{part.text}</span>
+      ),
+    )}
+  </>
+);
+
+export const TicketLinkPicker: React.FC<TicketLinkPickerProps> = ({
+  query,
+  results,
+  isLoading,
+  hasMore,
+  totalCount,
+  boardsSearched,
+  highlight,
+  onHighlight,
+  onSelect,
+  onScrollEnd,
+  onCreateTicket,
+  canCreateTicket,
+}) => {
+  const trimmedQuery = query.trim();
+  const hasQuery = trimmedQuery.length > 0;
+
+  const handleScroll = (event: React.UIEvent<HTMLUListElement>): void => {
+    const target = event.currentTarget;
+    if (target.scrollHeight - target.scrollTop - target.clientHeight < 40) {
+      onScrollEnd();
+    }
+  };
+
+  return (
+    <div className='absolute left-0 right-0 top-full z-40 mt-1 overflow-hidden rounded-xl border border-border bg-background shadow-lg'>
+      {canCreateTicket ? (
+        <button
+          type='button'
+          onMouseEnter={() => onHighlight('create')}
+          onClick={onCreateTicket}
+          className={cn(
+            'flex w-full items-center gap-2 border-b border-border px-3 py-2.5 text-left text-sm text-foreground transition-colors',
+            highlight === 'create' && 'bg-accent',
+          )}
+          data-track-category='Tickets'
+          data-track-name='TicketLinkCreateOption'
+        >
+          <Plus className='size-4 shrink-0 text-muted-foreground' />
+          <span className='min-w-0 truncate'>Create ticket on a board…</span>
+          {hasQuery ? (
+            <span className='ml-auto max-w-[45%] shrink-0 truncate text-muted-foreground'>
+              “{trimmedQuery}”
+            </span>
+          ) : null}
+        </button>
+      ) : null}
+
+      {!hasQuery ? (
+        <p className='px-3 pt-2 text-[11px] uppercase tracking-wide text-muted-foreground'>
+          Recent
+        </p>
+      ) : null}
+
+      <ul className='max-h-60 overflow-y-auto py-1' onScroll={handleScroll} role='listbox'>
+        {results.length === 0 && !isLoading ? (
+          <li className='px-3 py-4 text-center text-sm text-muted-foreground'>
+            {hasQuery ? 'No tickets found' : 'Start typing to search tickets'}
+          </li>
+        ) : (
+          results.map((ticket, index) => {
+            const selected = highlight === index;
+            return (
+              <li key={ticket.id} role='option' aria-selected={selected}>
+                <button
+                  type='button'
+                  onMouseEnter={() => onHighlight(index)}
+                  onClick={() => onSelect(ticket)}
+                  className={cn(
+                    'flex w-full items-center gap-3 px-3 py-2 text-left',
+                    selected && 'bg-accent',
+                  )}
+                  data-track-category='Tickets'
+                  data-track-name='TicketLinkSelectOption'
+                  data-track-metadata={JSON.stringify({ ticketId: ticket.id })}
+                >
+                  <span className='w-[96px] shrink-0 truncate font-mono text-[13px] text-muted-foreground'>
+                    {ticket.xyneId || ticket.id}
+                  </span>
+                  <span className='min-w-0 flex-1 truncate text-sm text-foreground'>
+                    <HighlightedTitle
+                      title={ticket.title || ticket.xyneId || ticket.id}
+                      query={hasQuery ? trimmedQuery : ''}
+                    />
+                  </span>
+                  {ticket.assignedTo ? (
+                    <UserAvatar
+                      userId={ticket.assignedTo}
+                      size={AvatarSize.SM}
+                      shape={AvatarShape.CIRCULAR}
+                    />
+                  ) : null}
+                </button>
+              </li>
+            );
+          })
+        )}
+        {isLoading ? <li className='px-3 py-2 text-sm text-muted-foreground'>Searching…</li> : null}
+        {hasMore && !isLoading ? (
+          <li className='px-3 py-2 text-center text-xs text-muted-foreground'>Scroll for more</li>
+        ) : null}
+      </ul>
+
+      <div className='border-t border-border px-3 py-1.5 text-[11px] text-muted-foreground'>
+        {hasQuery ? (
+          <span>
+            {totalCount} {totalCount === 1 ? 'ticket' : 'tickets'}
+            {boardsSearched > 0
+              ? ` · ${boardsSearched} ${boardsSearched === 1 ? 'board' : 'boards'} searched`
+              : ''}
+          </span>
+        ) : (
+          <span>↑↓ to move ↵ to link esc to close</span>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/Tickets/TicketLinkField/ticketLinkUtils.ts
+++ b/apps/dashboard/src/components/Tickets/TicketLinkField/ticketLinkUtils.ts
@@ -1,0 +1,78 @@
+export const EXTERNAL_URL_PATTERN = /^https?:\/\/\S+$/i;
+
+const XYNE_ID_PATTERN = /^[A-Z][A-Z0-9]*-\d+$/i;
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Values stored by the TICKET field are xyneIds ("TOKEN-4127"); legacy uuids stay valid. */
+export const looksLikeXyneId = (value: string): boolean => XYNE_ID_PATTERN.test(value);
+
+export const looksLikeTicketId = (value: string): boolean => UUID_PATTERN.test(value);
+
+export type PastedTicketRef = { kind: 'id' | 'xyneId'; value: string };
+
+export const isExternalHttpUrl = (value: string): boolean => EXTERNAL_URL_PATTERN.test(value);
+
+/**
+ * Pull a ticket reference out of a pasted URL: an xyneId segment anywhere in the
+ * path, then the last path segment if it's a ticket uuid, then a `ticketId` query param.
+ */
+export const extractTicketRefFromUrl = (rawUrl: string): PastedTicketRef | null => {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  const segments = url.pathname.split('/').filter(Boolean);
+  const xyneIdSegment = segments.find(segment => XYNE_ID_PATTERN.test(segment));
+  if (xyneIdSegment) {
+    return { kind: 'xyneId', value: xyneIdSegment.toUpperCase() };
+  }
+
+  const ticketIdParam = url.searchParams.get('ticketId');
+  if (ticketIdParam) {
+    return { kind: 'id', value: ticketIdParam };
+  }
+
+  const lastSegment = segments[segments.length - 1];
+  if (lastSegment) {
+    const decoded = decodeURIComponent(lastSegment);
+    if (UUID_PATTERN.test(decoded)) {
+      return { kind: 'id', value: decoded };
+    }
+  }
+
+  return null;
+};
+
+export const formatShortDate = (timestamp: number): string =>
+  new Date(timestamp).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+
+export const toDateInputValue = (timestamp: number): string =>
+  new Date(timestamp).toISOString().slice(0, 10);
+
+export type HighlightPart = { text: string; match: boolean };
+
+/** Split a title into parts, flagging case-insensitive substring matches of the query. */
+export const splitTitleByQuery = (title: string, query: string): HighlightPart[] => {
+  const trimmed = query.trim();
+  if (!trimmed) return [{ text: title, match: false }];
+
+  const parts: HighlightPart[] = [];
+  const lowerTitle = title.toLowerCase();
+  const lowerQuery = trimmed.toLowerCase();
+  let cursor = 0;
+
+  for (;;) {
+    const index = lowerTitle.indexOf(lowerQuery, cursor);
+    if (index === -1) {
+      if (cursor < title.length) parts.push({ text: title.slice(cursor), match: false });
+      return parts;
+    }
+    if (index > cursor) parts.push({ text: title.slice(cursor, index), match: false });
+    parts.push({ text: title.slice(index, index + trimmed.length), match: true });
+    cursor = index + trimmed.length;
+  }
+};

--- a/apps/dashboard/src/components/ui/TicketFieldSelector/TicketFieldSelector.tsx
+++ b/apps/dashboard/src/components/ui/TicketFieldSelector/TicketFieldSelector.tsx
@@ -1,0 +1,104 @@
+import { useMemo, useState } from 'react';
+import { useTicketFieldSearch } from '../../../hooks/useTicketFieldSearch';
+import { useCachedQuery } from '../../../hooks/useCachedQuery';
+import { useAuth } from '../../../hooks/useAuth';
+import { queries } from '../../../zero/queries';
+import { EntitySelector } from '../EntitySelector/EntitySelector';
+import type { SelectorOption } from '../EntitySelector/EntitySelector.types';
+import { looksLikeXyneId } from '../../Tickets/TicketLinkField/ticketLinkUtils';
+import { cn } from '../../../utils/classNames';
+
+export interface TicketFieldSelectorProps {
+  /** Selected ticket xyneId ("TOKEN-4127") — the value stored for the form field. */
+  selectedValue?: string | null;
+  /** Emits the selected ticket's xyneId, or null when the selection is cleared. */
+  onSelect: (ticketXyneId: string | null) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  /** Scope the search to a project; omit to search across the workspace. */
+  projectId?: string | undefined;
+  disabled?: boolean;
+  className?: string;
+  testId?: string | undefined;
+}
+
+/**
+ * TicketFieldSelector - a form-field control that searches tickets via Vespa
+ * and stores the selected ticket's xyneId (what users search and see) as the
+ * field's string value. Built on EntitySelector; search is fully server-side.
+ */
+export const TicketFieldSelector: React.FC<TicketFieldSelectorProps> = ({
+  selectedValue,
+  onSelect,
+  placeholder,
+  searchPlaceholder,
+  projectId,
+  disabled = false,
+  className,
+  testId,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { results, isLoading, hasMore, handleSearchChange, handleScrollEnd } = useTicketFieldSearch(
+    { isActive: isOpen, projectId },
+  );
+
+  // Resolve the selected ticket so the closed trigger can display its title.
+  // Values are xyneIds; legacy stored values (ticket uuids) still resolve by id.
+  const { user } = useAuth();
+  const workspaceId = user?.workspaceId ?? '';
+  const selectedIsXyneId = selectedValue ? looksLikeXyneId(selectedValue) : false;
+  const [selectedTicketById] = useCachedQuery(
+    queries.ticketRowById({ ticketId: !selectedIsXyneId ? (selectedValue ?? '') : '' }),
+    { enabled: Boolean(selectedValue) && !selectedIsXyneId },
+  );
+  const [selectedTicketByXyneId] = useCachedQuery(
+    queries.ticketByXyneIdV3({
+      xyneId: selectedIsXyneId ? (selectedValue ?? '') : '',
+      workspaceId,
+    }),
+    { enabled: selectedIsXyneId && Boolean(workspaceId) },
+  );
+  const selectedTicket = selectedIsXyneId ? selectedTicketByXyneId : selectedTicketById;
+
+  const options = useMemo<SelectorOption[]>(() => {
+    const base: SelectorOption[] = results.map(ticket => ({
+      value: ticket.xyneId || ticket.id,
+      label: ticket.title || ticket.xyneId || ticket.id,
+      subtitle: ticket.xyneId || ticket.id,
+      icon: null,
+    }));
+
+    if (selectedValue && selectedTicket && !base.some(option => option.value === selectedValue)) {
+      base.unshift({
+        value: selectedValue,
+        label: selectedTicket.title || selectedTicket.xyneId || selectedTicket.id,
+        subtitle: selectedTicket.xyneId || selectedTicket.id,
+        icon: null,
+      });
+    }
+
+    return base;
+  }, [results, selectedValue, selectedTicket]);
+
+  return (
+    <div className={cn(disabled && 'pointer-events-none opacity-70', className)}>
+      <EntitySelector
+        options={options}
+        selectedValue={selectedValue ?? null}
+        onSelect={onSelect}
+        placeholder={placeholder ?? 'Select a ticket'}
+        searchPlaceholder={searchPlaceholder ?? 'Search by ticket ID or name'}
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        onSearchChange={handleSearchChange}
+        onScrollEnd={handleScrollEnd}
+        hasMore={hasMore}
+        isLoading={isLoading}
+        disableClientFiltering
+        width='100%'
+        showClearButton
+        {...(testId ? { testId } : {})}
+      />
+    </div>
+  );
+};

--- a/apps/dashboard/src/hooks/useTicketFieldSearch.ts
+++ b/apps/dashboard/src/hooks/useTicketFieldSearch.ts
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { searchService } from '../services/searchService';
+import { stripHighlightMarkup } from './useVespaTicketSearch';
+import { useDebouncedValue } from './useDebouncedValue';
+
+const TICKET_FIELD_SEARCH_DEBOUNCE_MS = 300;
+const TICKET_FIELD_PAGE_SIZE = 20;
+const TICKET_FIELD_MAX_OFFSET = 1000;
+
+export interface TicketFieldSearchResult {
+  id: string;
+  title?: string;
+  xyneId?: string | null;
+  boardId?: string | null;
+  assignedTo?: string;
+}
+
+interface UseTicketFieldSearchParams {
+  /** Only fetch while the dropdown that owns this search is open. */
+  isActive: boolean;
+  /** Scope the search to a project; omit to search across the workspace. */
+  projectId?: string | undefined;
+}
+
+interface UseTicketFieldSearchResult {
+  results: TicketFieldSearchResult[];
+  isLoading: boolean;
+  hasMore: boolean;
+  totalCount: number;
+  /** Distinct boards present in the fetched result set ("N boards searched"). */
+  boardsSearched: number;
+  searchQuery: string;
+  handleSearchChange: (searchValue: string) => void;
+  handleScrollEnd: () => void;
+}
+
+const fetchPage = async (
+  query: string,
+  offset: number,
+  projectId?: string,
+): Promise<{
+  results: TicketFieldSearchResult[];
+  totalCount: number;
+  offset: number;
+  limit: number;
+}> => {
+  const response = await searchService.vespaSearch({
+    query: query || '*',
+    type: 'tickets',
+    apps: 'ticket',
+    ...(projectId ? { projectId } : {}),
+    limit: TICKET_FIELD_PAGE_SIZE,
+    offset,
+  });
+
+  return {
+    results: response.results.map(result => ({
+      id: result.id,
+      title: stripHighlightMarkup(result.title),
+      ...(result.searchContext?.xyneId !== undefined
+        ? { xyneId: result.searchContext.xyneId ?? null }
+        : {}),
+      ...(result.searchContext?.boardId !== undefined
+        ? { boardId: result.searchContext.boardId ?? null }
+        : {}),
+      ...(result.searchContext?.assignedTo ? { assignedTo: result.searchContext.assignedTo } : {}),
+    })),
+    totalCount: response.totalCount,
+    offset: response.offset,
+    limit: response.limit,
+  };
+};
+
+/** Debounced, paged Vespa search over tickets, scoped to one dropdown instance. */
+export const useTicketFieldSearch = ({
+  isActive,
+  projectId,
+}: UseTicketFieldSearchParams): UseTicketFieldSearchResult => {
+  const [searchQuery, setSearchQuery] = useState('');
+  const debouncedSearch = useDebouncedValue(searchQuery, TICKET_FIELD_SEARCH_DEBOUNCE_MS);
+  const [results, setResults] = useState<TicketFieldSearchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [totalCount, setTotalCount] = useState(0);
+  const [nextOffset, setNextOffset] = useState(0);
+  // Bumped on every reset so a superseded response cannot overwrite newer results.
+  const requestIdRef = useRef(0);
+
+  const loadPage = useCallback(
+    async (offset: number, replace: boolean): Promise<void> => {
+      const requestId = ++requestIdRef.current;
+      const isInitialLoad = replace || offset === 0;
+      if (isInitialLoad) {
+        setIsLoading(true);
+      } else {
+        setIsLoadingMore(true);
+      }
+
+      try {
+        const response = await fetchPage(debouncedSearch.trim(), offset, projectId);
+        if (requestId !== requestIdRef.current) return;
+
+        const rawNextOffset = response.offset + response.limit;
+        setResults(previous => {
+          const base = replace ? [] : previous;
+          return Array.from(
+            new Map([...base, ...response.results].map(ticket => [ticket.id, ticket])).values(),
+          );
+        });
+        setTotalCount(response.totalCount);
+        setNextOffset(Math.min(rawNextOffset, TICKET_FIELD_MAX_OFFSET));
+        setHasMore(
+          response.results.length > 0 &&
+            rawNextOffset < response.totalCount &&
+            rawNextOffset < TICKET_FIELD_MAX_OFFSET,
+        );
+      } catch {
+        if (requestId !== requestIdRef.current) return;
+
+        // The picker renders an empty list as "No results" — a toast keeps the failure visible.
+        toast.error('Failed to search tickets', { id: 'ticket-field-search-error' });
+        if (isInitialLoad) {
+          setResults([]);
+          setTotalCount(0);
+          setNextOffset(0);
+          setHasMore(false);
+        }
+      } finally {
+        if (requestId === requestIdRef.current) {
+          setIsLoading(false);
+          setIsLoadingMore(false);
+        }
+      }
+    },
+    [debouncedSearch, projectId],
+  );
+
+  // Re-query whenever the dropdown opens or the debounced term settles.
+  useEffect(() => {
+    if (!isActive) return;
+
+    setResults([]);
+    setTotalCount(0);
+    setNextOffset(0);
+    setHasMore(false);
+    void loadPage(0, true);
+  }, [isActive, debouncedSearch, loadPage]);
+
+  const handleScrollEnd = useCallback((): void => {
+    if (!hasMore || isLoading || isLoadingMore) return;
+
+    if (nextOffset >= TICKET_FIELD_MAX_OFFSET) {
+      setHasMore(false);
+      return;
+    }
+
+    void loadPage(nextOffset, false);
+  }, [hasMore, isLoading, isLoadingMore, loadPage, nextOffset]);
+
+  const boardsSearched = new Set(
+    results.map(result => result.boardId).filter((boardId): boardId is string => !!boardId),
+  ).size;
+
+  return {
+    results,
+    isLoading,
+    hasMore,
+    totalCount,
+    boardsSearched,
+    searchQuery,
+    handleSearchChange: setSearchQuery,
+    handleScrollEnd,
+  };
+};

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -35,7 +35,6 @@ import {
   SearchDefault as Search,
   KanbanBoard as SquareKanban,
   GridTable,
-  LayerTwo as Layers,
 } from '@xyne/icons';
 import { CalendarView } from '../../components/Tickets/CalendarView';
 import TicketReportsScreen from '../../routes/TicketReportsScreen/TicketReportsScreen';
@@ -847,12 +846,9 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
   // Don't query until:
   // 1. Machine is initialized (filters loaded from URL/storage)
-  // 2. For workspace views: seeding is complete AND a board is picked
-  const workspaceViewReady =
-    isMachineInitialized &&
-    (!isWorkspaceView || (hasSeededWorkspaceView && (filters.boards?.length ?? 0) > 0));
-  const isWorkspaceViewWithoutBoards =
-    isWorkspaceView && hasSeededWorkspaceView && (filters.boards?.length ?? 0) === 0;
+  // 2. For workspace views: seeding is complete (a view with no boards picked
+  //    queries every accessible board, matching "All boards" in a project view)
+  const workspaceViewReady = isMachineInitialized && (!isWorkspaceView || hasSeededWorkspaceView);
   const showSubStatus = state.context.showSubStatus;
 
   const setShowOverdueOnly = useCallback(
@@ -1770,9 +1766,9 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         ((viewMode === 'board' && !!boardId) ||
           (viewMode === 'project' && !!effectiveProjectId) ||
           // A workspace view has no channel or project to key on; `workspaceViewReady`
-          // is the equivalent guard (at least one board picked), the same one the
-          // kanban pagination path uses. Without this clause the table, calendar and
-          // flow layouts render no rows at all in a saved view.
+          // is the equivalent guard (view seeded), the same one the kanban pagination
+          // path uses. Without this clause the table, calendar and flow layouts render
+          // no rows at all in a saved view.
           (isWorkspaceView && workspaceViewReady) ||
           viewMode === 'my-tickets' ||
           (viewMode === 'user-tickets' && !!filterByUserId) ||
@@ -5102,11 +5098,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         <div className='flex-1 overflow-y-auto p-4 space-y-4 bg-background pb-14'>
           {isTableEmpty && (
             <div className='rounded-lg border border-border bg-muted p-4 text-sm text-muted-foreground'>
-              {isTicketsSyncing
-                ? 'Loading tickets…'
-                : isWorkspaceViewWithoutBoards
-                  ? 'Select boards to build your view.'
-                  : 'No tickets match the current filters.'}
+              {isTicketsSyncing ? 'Loading tickets…' : 'No tickets match the current filters.'}
             </div>
           )}
           {tableGroups.map(group => {
@@ -5186,23 +5178,6 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
             sensors={sensors}
           >
             <div className={`h-full flex flex-col space-y-5 ${groupBy !== 'none' ? 'mb-12' : ''}`}>
-              {isWorkspaceViewWithoutBoards && (
-                <div className='flex-1 flex flex-col items-center justify-center gap-4 p-8 text-center'>
-                  <Layers className='w-10 h-10 text-muted-foreground/60' />
-                  <div className='space-y-1'>
-                    <p className='text-sm font-semibold text-foreground'>
-                      Select boards to build your view
-                    </p>
-                    <p className='text-[13px] text-muted-foreground'>
-                      Pick the boards this view should track, then apply filters to refine it.
-                    </p>
-                  </div>
-                  <ViewBoardPicker
-                    selectedBoardIds={filters.boards ?? []}
-                    onChange={boardIds => setFilters({ ...filters, boards: boardIds })}
-                  />
-                </div>
-              )}
               {processedGroups.map(group => {
                 const isExpanded = expandedGroups.has(group.key);
                 const showGroupHeader = groupBy !== 'none';

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -35,6 +35,7 @@ import {
   SearchDefault as Search,
   KanbanBoard as SquareKanban,
   GridTable,
+  LayerTwo as Layers,
 } from '@xyne/icons';
 import { CalendarView } from '../../components/Tickets/CalendarView';
 import TicketReportsScreen from '../../routes/TicketReportsScreen/TicketReportsScreen';
@@ -493,10 +494,8 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const [flowGroupBacklogPendingId, setFlowGroupBacklogPendingId] = useState<string | null>(null);
   const collapseInitRunRef = useRef<string | null>(null);
   // When mounted from the project route (AppRoot.tsx → :projectId / :projectId/:boardId),
-  // no channelId prop is passed. The Create Ticket button at the bottom of this file
-  // gates on `channel`, so without a fallback the button stays hidden on that route.
-  // Fall back to the first non-archived channel of the project so the modal has a
-  // channel to write into.
+  // no channelId prop is passed. Fall back to the first non-archived channel of the
+  // project so the Create Ticket modal has a channel to write into.
   const projectChannels = useChannelsByProjectId(channelId ? undefined : projectIdParam);
   const fallbackChannelId = projectChannels.find(c => !c.isArchived)?.id ?? '';
   const channel = useChannel(channelId || fallbackChannelId);
@@ -852,6 +851,8 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const workspaceViewReady =
     isMachineInitialized &&
     (!isWorkspaceView || (hasSeededWorkspaceView && (filters.boards?.length ?? 0) > 0));
+  const isWorkspaceViewWithoutBoards =
+    isWorkspaceView && hasSeededWorkspaceView && (filters.boards?.length ?? 0) === 0;
   const showSubStatus = state.context.showSubStatus;
 
   const setShowOverdueOnly = useCallback(
@@ -1188,18 +1189,26 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const handleConfirmSaveWorkspaceView = useCallback((): void => {
     const name = workspaceViewNameDraft.trim();
     if (!name) return;
+    if ((filters.boards?.length ?? 0) === 0) {
+      toast.error('Select at least one board to save this view');
+      return;
+    }
     setIsSavePopoverOpen(false);
     setWorkspaceViewNameDraft('');
     void persistWorkspaceView(name);
-  }, [workspaceViewNameDraft, persistWorkspaceView]);
+  }, [workspaceViewNameDraft, persistWorkspaceView, filters.boards]);
 
   const savedViewName = initialName?.trim() ?? '';
   const canSaveInPlace = !!viewId && !!savedViewName;
 
   const handleSaveExistingView = useCallback((): void => {
     if (!savedViewName) return;
+    if ((filters.boards?.length ?? 0) === 0) {
+      toast.error('Select at least one board to save this view');
+      return;
+    }
     void persistWorkspaceView(savedViewName);
-  }, [savedViewName, persistWorkspaceView]);
+  }, [savedViewName, persistWorkspaceView, filters.boards]);
 
   const handleResetWorkspaceView = useCallback((): void => {
     clearViewDraft(viewDraftKey);
@@ -3803,7 +3812,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                 <Button
                   size='sm'
                   onClick={handleSaveExistingView}
-                  disabled={!workspaceViewReady || isSavingWorkspaceView || !isViewDirty}
+                  disabled={isSavingWorkspaceView || !isViewDirty}
                   className='rounded-[10px]'
                   data-track-category='Projects'
                   data-track-name='SaveView'
@@ -3820,7 +3829,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                   trigger={
                     <Button
                       size='sm'
-                      disabled={!workspaceViewReady || isSavingWorkspaceView}
+                      disabled={!hasSeededWorkspaceView || isSavingWorkspaceView}
                       className='rounded-[10px]'
                       data-track-category='Projects'
                       data-track-name='SaveView'
@@ -3873,24 +3882,25 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
               )}
             </div>
           )}
-          {canCreateTicket && ((channel && !channel.isArchived) || isMyTicketsView) && (
-            <button
-              data-testid='kanban-create-ticket-button'
-              data-track-event='BUTTON_CLICK'
-              data-track-category='Tickets'
-              data-track-name='CREATE_TICKET_KANBAN'
-              data-track-metadata={JSON.stringify({ boardId, channelId })}
-              onClick={() => {
-                setCreateTicketSeed(null);
-                setIsCreateModalOpen(true);
-              }}
-              className='flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-primary-foreground bg-primary rounded-lg transition-colors flex-shrink-0'
-            >
-              <Plus className='w-4 h-4' />
-              <span className='hidden sm:inline font-semibold text-sm'>Create Ticket</span>
-              <span className='sm:hidden'>Create</span>
-            </button>
-          )}
+          {canCreateTicket &&
+            ((channel && !channel.isArchived) || isMyTicketsView || isWorkspaceView) && (
+              <button
+                data-testid='kanban-create-ticket-button'
+                data-track-event='BUTTON_CLICK'
+                data-track-category='Tickets'
+                data-track-name='CREATE_TICKET_KANBAN'
+                data-track-metadata={JSON.stringify({ boardId, channelId })}
+                onClick={() => {
+                  setCreateTicketSeed(null);
+                  setIsCreateModalOpen(true);
+                }}
+                className='flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-primary-foreground bg-primary rounded-lg transition-colors flex-shrink-0'
+              >
+                <Plus className='w-4 h-4' />
+                <span className='hidden sm:inline font-semibold text-sm'>Create Ticket</span>
+                <span className='sm:hidden'>Create</span>
+              </button>
+            )}
           {/* Layout View Toggle (flow boards only have the flow view) */}
           <div className='flex items-center gap-2'>
             {!isFlowBoard && (
@@ -5092,7 +5102,11 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         <div className='flex-1 overflow-y-auto p-4 space-y-4 bg-background pb-14'>
           {isTableEmpty && (
             <div className='rounded-lg border border-border bg-muted p-4 text-sm text-muted-foreground'>
-              {isTicketsSyncing ? 'Loading tickets…' : 'No tickets match the current filters.'}
+              {isTicketsSyncing
+                ? 'Loading tickets…'
+                : isWorkspaceViewWithoutBoards
+                  ? 'Select boards to build your view.'
+                  : 'No tickets match the current filters.'}
             </div>
           )}
           {tableGroups.map(group => {
@@ -5172,6 +5186,23 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
             sensors={sensors}
           >
             <div className={`h-full flex flex-col space-y-5 ${groupBy !== 'none' ? 'mb-12' : ''}`}>
+              {isWorkspaceViewWithoutBoards && (
+                <div className='flex-1 flex flex-col items-center justify-center gap-4 p-8 text-center'>
+                  <Layers className='w-10 h-10 text-muted-foreground/60' />
+                  <div className='space-y-1'>
+                    <p className='text-sm font-semibold text-foreground'>
+                      Select boards to build your view
+                    </p>
+                    <p className='text-[13px] text-muted-foreground'>
+                      Pick the boards this view should track, then apply filters to refine it.
+                    </p>
+                  </div>
+                  <ViewBoardPicker
+                    selectedBoardIds={filters.boards ?? []}
+                    onChange={boardIds => setFilters({ ...filters, boards: boardIds })}
+                  />
+                </div>
+              )}
               {processedGroups.map(group => {
                 const isExpanded = expandedGroups.has(group.key);
                 const showGroupHeader = groupBy !== 'none';
@@ -5310,7 +5341,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
       )}
 
       {/* Create Ticket Modal */}
-      {effectiveProjectId && channel && isCreateModalOpen && (
+      {effectiveProjectId && channel && !channel.isArchived && isCreateModalOpen && (
         <CreateTicketModal
           isOpen={isCreateModalOpen}
           enableUrlSync
@@ -5331,8 +5362,9 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         />
       )}
 
-      {/* Create Ticket Modal — my-tickets view (no channel context, user picks channel + board) */}
-      {isMyTicketsView && !channel && isCreateModalOpen && (
+      {/* Create Ticket Modal — no usable channel context (my-tickets, workspace views,
+          archived channel); the user picks channel + board */}
+      {(!channel || channel.isArchived || !effectiveProjectId) && isCreateModalOpen && (
         <CreateTicketModal
           isOpen={isCreateModalOpen}
           onClose={() => {

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -846,9 +846,11 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
   // Don't query until:
   // 1. Machine is initialized (filters loaded from URL/storage)
-  // 2. For workspace views: seeding is complete (a view with no boards picked
-  //    queries every accessible board, matching "All boards" in a project view)
-  const workspaceViewReady = isMachineInitialized && (!isWorkspaceView || hasSeededWorkspaceView);
+  // 2. For workspace views: seeding is complete AND a board is picked
+  const workspaceViewReady =
+    isMachineInitialized &&
+    (!isWorkspaceView || (hasSeededWorkspaceView && (filters.boards?.length ?? 0) > 0));
+  const isWorkspaceViewWithoutBoards = isWorkspaceView && (filters.boards?.length ?? 0) === 0;
   const showSubStatus = state.context.showSubStatus;
 
   const setShowOverdueOnly = useCallback(
@@ -1766,9 +1768,9 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         ((viewMode === 'board' && !!boardId) ||
           (viewMode === 'project' && !!effectiveProjectId) ||
           // A workspace view has no channel or project to key on; `workspaceViewReady`
-          // is the equivalent guard (view seeded), the same one the kanban pagination
-          // path uses. Without this clause the table, calendar and flow layouts render
-          // no rows at all in a saved view.
+          // is the equivalent guard (at least one board picked), the same one the
+          // kanban pagination path uses. Without this clause the table, calendar and
+          // flow layouts render no rows at all in a saved view.
           (isWorkspaceView && workspaceViewReady) ||
           viewMode === 'my-tickets' ||
           (viewMode === 'user-tickets' && !!filterByUserId) ||
@@ -3761,6 +3763,12 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                       <ViewBoardPicker
                         selectedBoardIds={filters.boards ?? []}
                         onChange={boardIds => setFilters({ ...filters, boards: boardIds })}
+                        {...(isWorkspaceViewWithoutBoards
+                          ? {
+                              className:
+                                'border-orange-500 text-orange-600 hover:bg-orange-50 hover:text-orange-700',
+                            }
+                          : {})}
                       />
                     ),
                   }
@@ -5098,7 +5106,13 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         <div className='flex-1 overflow-y-auto p-4 space-y-4 bg-background pb-14'>
           {isTableEmpty && (
             <div className='rounded-lg border border-border bg-muted p-4 text-sm text-muted-foreground'>
-              {isTicketsSyncing ? 'Loading tickets…' : 'No tickets match the current filters.'}
+              {/* Board-less workspace views disable the tickets query, so
+                  isTicketsSyncing never clears — check that case first. */}
+              {isWorkspaceViewWithoutBoards
+                ? 'Select at least one board to build your view.'
+                : isTicketsSyncing
+                  ? 'Loading tickets…'
+                  : 'No tickets match the current filters.'}
             </div>
           )}
           {tableGroups.map(group => {

--- a/apps/dashboard/src/utils/board/formFieldApiMapper.ts
+++ b/apps/dashboard/src/utils/board/formFieldApiMapper.ts
@@ -120,6 +120,8 @@ export const getFieldTypeLabel = (fieldType: FormFieldType): string => {
       return 'User';
     case FormFieldType.DOC:
       return 'Document';
+    case FormFieldType.TICKET:
+      return 'Ticket';
     default:
       return fieldType;
   }

--- a/apps/dashboard/src/utils/board/stageConfigUtils.tsx
+++ b/apps/dashboard/src/utils/board/stageConfigUtils.tsx
@@ -55,6 +55,7 @@ export const FIELD_TYPE_OPTIONS: FieldTypeOption[] = [
   { value: FormFieldType.DATE, label: 'Date' },
   { value: FormFieldType.BOOLEAN, label: 'Boolean' },
   { value: FormFieldType.DOC, label: 'Document' },
+  { value: FormFieldType.TICKET, label: 'Ticket' },
 ];
 
 // ─── Helper Functions ───────────────────────────────────────────────────────

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -4418,18 +4418,6 @@ export const mutators = defineMutators({
         ctx,
         args: { subTicketId, timestamp, mappingId, title, description, ticketId, conversationId },
       }) => {
-        const parentTicket = await tx.run(zql.tickets.where('id', ticketId).one());
-        const parentBoard = parentTicket
-          ? await tx.run(zql.boards.where('id', parentTicket.boardId).one())
-          : null;
-        if (parentBoard?.boardType !== BoardType.FLOW) {
-          const parentAsSubTicket = await tx.run(
-            zql.sub_tickets.where('mappedTicketId', ticketId).one(),
-          );
-          if (parentAsSubTicket) {
-            throw new Error('Cannot create a sub-ticket under a sub-ticket');
-          }
-        }
         // Create the subticket
         await tx.mutate.sub_tickets.insert({
           id: subTicketId,

--- a/packages/shared/src/zero/types.ts
+++ b/packages/shared/src/zero/types.ts
@@ -777,6 +777,7 @@ export enum FormFieldType {
   MULTI_SELECT = 'MULTI_SELECT',
   USER = 'USER',
   DOC = 'DOC',
+  TICKET = 'TICKET',
 }
 
 // @ts-ignore TS1294


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
