### PR TITLE
fix: stop 300s undici cutoff on long MCP calls (hypersage)

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/mcp.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/mcp.ts
@@ -1336,8 +1336,17 @@ router.get("/:sessionId/mcp/tools", async (req: Request<{ sessionId: string }>, 
   }
 });
 
+// Heartbeat cadence for the streaming /mcp/call response. Kept well under
+// undici's (disabled here) and the in-mesh Envoy sidecar's stream_idle_timeout
+// (~5 min default) so a long, silent vendor MCP call never idles the hop.
+const MCP_STREAM_HEARTBEAT_MS = 15_000;
+
 router.post("/:sessionId/mcp/call", async (req: Request<{ sessionId: string }>, res: Response) => {
   const startedAt = Date.now();
+  // Opt-in NDJSON streaming (client sends x-mcp-stream: 1 on /mcp/call). Only
+  // the long vendor-MCP path below streams; every fast branch still res.json().
+  let heartbeat: ReturnType<typeof setInterval> | undefined;
+  const wantsStream = req.get("x-mcp-stream") === "1";
   try {
     const userId = req.session!.userId;
     const agentSlug = req.session?.agentSlug;
@@ -2003,6 +2012,36 @@ router.post("/:sessionId/mcp/call", async (req: Request<{ sessionId: string }>, 
     // access failure. The wrapper caps per-token concurrency to avoid tripping
     // the limit, and on error surfaces the true HTTP status (429 vs 403).
     const callStartedAt = Date.now();
+
+    // Long-running vendor MCP calls (e.g. hypersage, 5-15 min) make the
+    // xyne-claw -> claw-auth hop a single silent request: no bytes flow until
+    // callTool settles, so the in-mesh Envoy sidecar stream_idle_timeout and
+    // undici body timeout can sever it mid-call. When the caller opted in
+    // (x-mcp-stream: 1), switch to a chunked NDJSON response and emit our OWN
+    // heartbeat frames on a timer so the hop never idles - independent of
+    // whether the upstream MCP sends transport keep-alives (hypersage's is a
+    // transport ping the MCP client consumes, never re-emitted onto this hop).
+    // The client drops ping frames and resolves on the terminal frame; the
+    // real ceiling stays MCP_REQUEST_TIMEOUT_MS enforced inside callTool.
+    if (wantsStream) {
+      res.setHeader("Content-Type", "application/x-ndjson");
+      res.setHeader("Cache-Control", "no-cache, no-transform");
+      res.setHeader("X-Accel-Buffering", "no");
+      res.flushHeaders();
+      heartbeat = setInterval(() => {
+        if (res.writableEnded) return;
+        res.write(`${JSON.stringify({ type: "ping", t: Date.now() })}\n`);
+        (res as unknown as { flush?: () => void }).flush?.();
+      }, MCP_STREAM_HEARTBEAT_MS);
+      (heartbeat as unknown as { unref?: () => void }).unref?.();
+      req.on("close", () => {
+        if (heartbeat) {
+          clearInterval(heartbeat);
+          heartbeat = undefined;
+        }
+      });
+    }
+
     const upstreamResult =
       serverType === "bitbucket"
         ? await callBitbucketThrottled(userId, credentials, tool, effectiveParams, agentSlug)
@@ -2063,8 +2102,24 @@ router.post("/:sessionId/mcp/call", async (req: Request<{ sessionId: string }>, 
       resultBytes: result.content?.length,
     });
 
-    res.json({ success: true, data: result });
+    if (heartbeat) {
+      clearInterval(heartbeat);
+      heartbeat = undefined;
+    }
+    if (res.headersSent) {
+      // Streaming mode: deliver the result as the terminal NDJSON frame.
+      if (!res.writableEnded) {
+        res.write(`${JSON.stringify({ type: "result", success: true, data: result })}\n`);
+        res.end();
+      }
+    } else {
+      res.json({ success: true, data: result });
+    }
   } catch (err) {
+    if (heartbeat) {
+      clearInterval(heartbeat);
+      heartbeat = undefined;
+    }
     const msg = errMsg(err);
     // serverType/tool are block-scoped to the try above; re-read from the body
     // so the error is attributable to a server/tool in the structured log.
@@ -2080,6 +2135,17 @@ router.post("/:sessionId/mcp/call", async (req: Request<{ sessionId: string }>, 
       httpStatus,
       errorMessage: msg,
     });
+    if (res.headersSent) {
+      // Streaming already began - the HTTP status is locked at 200, so deliver
+      // the failure as a terminal error frame instead of res.status(500).
+      if (!res.writableEnded) {
+        res.write(
+          `${JSON.stringify({ type: "error", success: false, error: err instanceof Error ? err.message : "Internal server error" })}\n`,
+        );
+        res.end();
+      }
+      return;
+    }
     res
       .status(500)
       .json({ success: false, error: err instanceof Error ? err.message : "Internal server error" });

--- a/apps/xyne-claw/src/mcp.ts
+++ b/apps/xyne-claw/src/mcp.ts
@@ -129,11 +129,67 @@ async function authFetch<T>(path: string, sessionToken: string, init?: RequestIn
       ...init?.headers,
     },
   } as unknown as RequestInit);
-  const body = (await res.json()) as AuthResponse<T>;
+  // `/mcp/call` answers long tool calls as an NDJSON stream (Content-Type
+  // application/x-ndjson): heartbeat `ping` frames keep the hop warm, then a
+  // single terminal `result`/`error` frame. Every other endpoint (and every
+  // fast /mcp/call branch) still returns one JSON object. `bodyTimeout: 0` on
+  // authDispatcher is what lets the stream stay open for minutes.
+  const contentType = res.headers.get("content-type") ?? "";
+  const body = contentType.includes("application/x-ndjson")
+    ? await readMcpStream<T>(res)
+    : ((await res.json()) as AuthResponse<T>);
   if (!body.success || body.data === undefined) {
     throw new McpAuthServiceError(body.error ?? `Auth service error: ${res.status}`, res.status);
   }
   return body.data;
+}
+
+// Consume an NDJSON /mcp/call stream: skip heartbeat `ping` frames and resolve
+// on the terminal `result`/`error` frame. Streaming responses are always HTTP
+// 200 (headers flush before the tool settles), so a credential rejection can
+// never arrive here - those still come back as a plain JSON 401/403 on the
+// non-streamed branches, preserving onConnectorBlocked handling.
+async function readMcpStream<T>(res: Response): Promise<AuthResponse<T>> {
+  const reader = res.body?.getReader();
+  if (!reader) {
+    throw new McpAuthServiceError(`Auth service returned an empty stream: ${res.status}`, res.status);
+  }
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const parseLine = (line: string): AuthResponse<T> | undefined => {
+    const trimmed = line.trim();
+    if (!trimmed) return undefined;
+    let frame: { type?: string; data?: T; error?: string };
+    try {
+      frame = JSON.parse(trimmed) as { type?: string; data?: T; error?: string };
+    } catch {
+      return undefined; // ignore any non-JSON keep-alive noise
+    }
+    if (frame.type === "result")
+      // exactOptionalPropertyTypes: omit `data` rather than set it undefined.
+      return frame.data === undefined ? { success: true } : { success: true, data: frame.data };
+    if (frame.type === "error") return { success: false, error: frame.error ?? "MCP call failed" };
+    return undefined; // ping / unknown -> keep reading
+  };
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (value) {
+      buffer += decoder.decode(value, { stream: true });
+      let idx: number;
+      while ((idx = buffer.indexOf("\n")) >= 0) {
+        const terminal = parseLine(buffer.slice(0, idx));
+        buffer = buffer.slice(idx + 1);
+        if (terminal) {
+          void reader.cancel().catch(() => {});
+          return terminal;
+        }
+      }
+    }
+    if (done) break;
+  }
+  const terminal = parseLine(buffer);
+  if (terminal) return terminal;
+  throw new McpAuthServiceError("MCP stream closed before a terminal frame", res.status);
 }
 
 function injectToolCallIdIntoClawCitations(content: string, toolCallId: string): string {
@@ -381,6 +437,9 @@ export async function loadMcpToolsForUser(
             sessionToken,
             {
               method: "POST",
+              // Opt into NDJSON streaming so claw-auth heartbeats this hop
+              // during long tool calls (see readMcpStream / authDispatcher).
+              headers: { "x-mcp-stream": "1" },
               body: JSON.stringify({
                 serverType: server.serverType,
                 tool: mcpTool.name,

--- a/apps/xyne-claw/src/mcp.ts
+++ b/apps/xyne-claw/src/mcp.ts
@@ -7,6 +7,7 @@ import { writeAttachmentToContext } from "./attachment-write.js";
 import { readFile, realpath } from "node:fs/promises";
 import { resolve as resolvePath, isAbsolute, sep } from "node:path";
 import crypto from "node:crypto";
+import { Agent } from "undici";
 
 import { createLogger } from "./logger.js";
 const log = createLogger("mcp");
@@ -105,17 +106,29 @@ export class McpAuthServiceError extends Error {
   }
 }
 
+// `/mcp/call` returns a single JSON response only when the remote tool
+// FINISHES. For a long-running MCP server (e.g. hypersage, an agent-based
+// debugger that can run 5-15 min) no response byte arrives for minutes, so
+// undici's DEFAULT headersTimeout/bodyTimeout (300s) severs the socket at ~5
+// min with UND_ERR_HEADERS_TIMEOUT. That is a Node-internal timer, so no
+// Envoy/LB/nginx timeout raise can fix it. Disable both idle timers on this
+// dispatcher (same pattern as consume-claw-stream.ts / userMemoryCuratorClient.ts);
+// the real ceiling stays the MCP request timeout enforced in claw-auth.
+const authDispatcher = new Agent({ headersTimeout: 0, bodyTimeout: 0, connectTimeout: 10_000 });
+
 async function authFetch<T>(path: string, sessionToken: string, init?: RequestInit): Promise<T> {
   const url = `${SERVER.authServiceUrl}${path}`;
   const res = await fetch(url, {
     ...init,
+    // `dispatcher` is an undici extension not in the DOM RequestInit type.
+    dispatcher: authDispatcher,
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${sessionToken}`,
       "x-s2s-key": SERVER.s2sKey,
       ...init?.headers,
     },
-  });
+  } as unknown as RequestInit);
   const body = (await res.json()) as AuthResponse<T>;
   if (!body.success || body.data === undefined) {
     throw new McpAuthServiceError(body.error ?? `Auth service error: ${res.status}`, res.status);


### PR DESCRIPTION
## What
The pod → claw-auth hop (`authFetch` → `POST /mcp/call` in `apps/xyne-claw/src/mcp.ts`) used a bare global `fetch`, which inherits undici's default `headersTimeout`/`bodyTimeout` of **300s**. `/mcp/call` returns a single JSON response only when the remote MCP tool *finishes*, so any tool running longer than ~5 min (e.g. **hypersage**, an agent-based debugger) had its socket severed at ~300s with `UND_ERR_HEADERS_TIMEOUT`.

## Why infra fixes didn't help
undici's idle timeout is a Node-internal timer — raising the Envoy / LB / nginx timeouts (even to 10 min) does not affect it. The call kept dying at ~5 min regardless.

## Change
Route `authFetch` through a dedicated undici `Agent({ headersTimeout: 0, bodyTimeout: 0, connectTimeout: 10_000 })`, disabling the idle timers on this hop. Same pattern already used in `apps/xyne-claw-auth/backend/src/lib/consume-claw-stream.ts:27` and `apps/xyne-claw-auth/backend/src/services/userMemoryCuratorClient.ts:63`. The effective ceiling is now the MCP request timeout enforced in claw-auth (`MCP_REQUEST_TIMEOUT_MS = 600_000`), not undici's default.

## Scope / risk
- One file changed (`apps/xyne-claw/src/mcp.ts`): +14 / −1.
- `dispatcher` is an undici extension not in the DOM `RequestInit` type, so the options object is cast `as unknown as RequestInit` (matching the existing two call sites).
- No behavior change for fast calls; only removes the premature 300s cut on long ones.

## Follow-up (not in this PR)
To replace the remaining fixed 10-min wall with keep-alive-driven closing, a separate change in `apps/xyne-claw-auth/backend/src/mcp/runner.ts` `callTool` would add `resetTimeoutOnProgress: true` + `maxTotalTimeout` and drop the fixed `AbortSignal.timeout`. That depends on hypersage emitting MCP `notifications/progress` (not just transport keep-alive) and is intentionally held out of this PR.