### PR TITLE
fix: XYNE-62238 show board stages whenever a single board is in scope

### DIFF
--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -1297,11 +1297,22 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
   // Fetch stages for filtered single board (when exactly one board is in filter)
   // In board view, the path param boardId IS the single board context
-  const filteredSingleBoardId = useMemo(() => {
+  const explicitBoardId = useMemo(() => {
     if (viewMode === 'board' && boardId) return boardId;
     if (filters.boards && filters.boards.length === 1) return filters.boards[0];
     return null;
   }, [viewMode, boardId, filters.boards]);
+
+  // A project/channel scope holding exactly one board is that board, even under "All Boards".
+  const [scopeBoards] = useCachedQuery(
+    queries.boardsListByProject({ projectId: effectiveProjectId || '' }),
+    { enabled: !!effectiveProjectId && !explicitBoardId && !filters.boards?.length },
+  );
+
+  const soleScopeBoardId =
+    !filters.boards?.length && scopeBoards?.length === 1 ? scopeBoards[0]?.id : undefined;
+
+  const filteredSingleBoardId = explicitBoardId ?? soleScopeBoardId ?? null;
 
   // Get all boards for the project (needed for channel stage view and create ticket modal)
   // In my-tickets/user-tickets/group-tickets, fetch ALL boards (no project filter) since tickets can span projects
@@ -1560,7 +1571,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     const isAllBoardsSelected = !filters.boards || filters.boards.length === 0;
 
     // If "All Boards" is selected, always use status columns
-    if (isAllBoardsSelected && channelId && viewMode === 'project') {
+    if (isAllBoardsSelected && !filteredSingleBoardId && channelId && viewMode === 'project') {
       return getStatusColumns();
     }
 
@@ -1570,10 +1581,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     }
 
     // If single board selected in filter, use its stages.
-    // Workspace-views always group by status (shouldUseStatusColumns), so never
-    // return board stage UUIDs here or columns/counts/drag mode would mismatch.
     if (
-      !isWorkspaceView &&
       filteredSingleBoardId &&
       stagesDataForFilteredBoard &&
       stagesDataForFilteredBoard.length > 0
@@ -1700,7 +1708,6 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     ];
   }, [
     viewMode,
-    isWorkspaceView,
     shouldShowBoardWiseView,
     filteredSingleBoardId,
     stagesDataForFilteredBoard,
@@ -3079,10 +3086,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     });
   }, [flowTicketNodes]);
 
-  const shouldUseStatusColumns =
-    isWorkspaceView ||
-    (!filteredSingleBoardId && ['project', 'my-tickets'].includes(viewMode)) ||
-    (channelId && viewMode === 'project' && channelViewType !== 'stage');
+  const shouldUseStatusColumns = !filteredSingleBoardId || !stagesDataForFilteredBoard?.length;
 
   const navBaseArgs = useMemo<KanbanTicketsPageBaseArgs>(
     () => ({
@@ -3298,14 +3302,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   );
 
   // Use drag and drop hook
-  const dragDropMode = useMemo(() => {
-    // For channel tickets: use view type to determine mode
-    if (channelId && viewMode === 'project') {
-      return channelViewType === 'stage' ? 'stage' : 'status';
-    }
-    // For other views
-    return viewMode === 'board' || filteredSingleBoardId ? 'stage' : 'status';
-  }, [channelId, viewMode, channelViewType, filteredSingleBoardId]);
+  const dragDropMode = shouldUseStatusColumns ? 'status' : 'stage';
 
   const canReorder = !!filteredSingleBoardId;
   const setDragLocalTickets = useCallback<React.Dispatch<React.SetStateAction<Ticket[]>>>(value => {


### PR DESCRIPTION
POT - https://drive.google.com/file/d/1XwfvpIULJwLj3bSiw8gYXIZsu0VB7tkH/view?usp=sharing
### Problem

The tickets kanban showed **status categories** instead of the board's **stages** in two cases where only one board was actually in scope:

1. a **saved view** scoped to a single board — `shouldUseStatusColumns` short-circuited on `isWorkspaceView`, and the stages memo had a matching `!isWorkspaceView` guard;
2. a **project or channel whose only board** is the one board — nothing seeds `filters.boards`, so "All Boards" stays empty and the single-board branch never fires.

### Change (`KanbanBoardScreen.tsx` only, +15 / −18)

- a project/channel scope that holds exactly one board now resolves to that board (`queries.boardsListByProject`, already used by `TicketFiltersDropdown`; the query is only enabled when no board filter is set, so the common paths fetch nothing extra);
- the `isWorkspaceView` short-circuit is gone from both `shouldUseStatusColumns` and the stages memo;
- `shouldUseStatusColumns` collapses to one condition — `!filteredSingleBoardId || !stagesDataForFilteredBoard?.length` — and `dragDropMode` is now derived from it, so the rendered columns, the counts/pagination `columnType` and the drop handler cannot disagree.

Everything downstream already supported this: `columnType` is plumbed through the counts service (`getCountField`), the Zero page query (`applyKanbanTicketPageConditions`) and the live socket deltas (`getStageKeys`). No backend change.

### Also fixes a silent data corruption

A saved view with one board rendered **status** columns while `dragDropMode` evaluated to **`'stage'`** (it never checked `isWorkspaceView`). In `useDragAndDrop`, `currentStage = stages.find(s => s.name === activeTicket.stageName)` can't match a status label, so the entire gating block — transitions, approvers, forms, sequence — was skipped, and the write at the end still ran: `ticket.update({ stageName: 'Todo', statusV2: 'TODO' })`. `mutators.ticket.update` validates stage moves only for FLOW and NON_LINEAR boards, so on a DEFAULT/RELEASE board the status label was persisted into `Ticket.stageName`, after which `groupTicketsByStage` pins that ticket to column 0 permanently. The same mismatch existed for the channel tickets tab under "All Boards".

It also fixes empty columns in `user-tickets` / `group-tickets` with no board selected, where the old allowlist (`['project','my-tickets']`) left `columnType='stage'` while status columns rendered, so counts were queried as `stageName='Todo'`.

### Behaviour to be aware of

A project whose **only** board is a **FLOW** board will now open in the flow layout on the project screen, because `isFlowBoard` follows the resolved single board. That is already what happens today when you select that board in the filter. Say the word if you'd rather keep the project screen on kanban there — it's a one-line guard.

### Scope

Single board only. Multi-board selections keep status categories; the "multiple boards sharing an identical stage-name set" half of this ticket (PR #1571) is **not** included here. #1571 can be closed in favour of this PR.

### Verification

`pnpm typecheck` clean, `eslint` 0 errors on the file (13 pre-existing warnings), `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01US5UEP3ha5U6NoUhjVFwMn
