### PR TITLE
feat: per-subagent MCP credentials (claw-auth foundation)

### DIFF
--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260909120000_subagent_mcp_connections/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260909120000_subagent_mcp_connections/migration.sql
@@ -1,0 +1,39 @@
+-- Per-subagent MCP credentials. Companion to agent_mcp_connections, but owned
+-- by a subagent_definitions row. Resolves ABOVE the agent/user/global cascade
+-- in credentials-loader; when non_overridable is true it short-circuits the
+-- cascade entirely so no lower-priority credential can shadow it.
+--
+-- Additive only: absence of a row == today's behaviour (subagent inherits the
+-- parent agent's pinned instance via mcpInstanceMap). No backfill needed.
+CREATE TABLE "subagent_mcp_connections" (
+    "id" TEXT NOT NULL,
+    "subagentDefinitionId" TEXT NOT NULL,
+    "mcpServerId" TEXT NOT NULL,
+    "slug" TEXT NOT NULL DEFAULT 'default',
+    "displayName" TEXT,
+    "nonOverridable" BOOLEAN NOT NULL DEFAULT true,
+    "encryptedCreds" TEXT NOT NULL,
+    "iv" TEXT NOT NULL,
+    "authTag" TEXT NOT NULL,
+    "createdByUserId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "subagent_mcp_connections_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "subagent_mcp_connections_subagentDefinitionId_mcpServerId_slug_key"
+    ON "subagent_mcp_connections"("subagentDefinitionId", "mcpServerId", "slug");
+
+CREATE INDEX "subagent_mcp_connections_subagentDefinitionId_idx"
+    ON "subagent_mcp_connections"("subagentDefinitionId");
+
+ALTER TABLE "subagent_mcp_connections"
+    ADD CONSTRAINT "subagent_mcp_connections_subagentDefinitionId_fkey"
+    FOREIGN KEY ("subagentDefinitionId") REFERENCES "subagent_definitions"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "subagent_mcp_connections"
+    ADD CONSTRAINT "subagent_mcp_connections_mcpServerId_fkey"
+    FOREIGN KEY ("mcpServerId") REFERENCES "mcp_servers"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260909120500_subagent_mcp_audit_events/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260909120500_subagent_mcp_audit_events/migration.sql
@@ -1,0 +1,7 @@
+-- Audit events for subagent-level MCP credential writes. Kept in a SEPARATE
+-- migration from the table create so the ALTER TYPE ... ADD VALUE runs in its
+-- own transaction (Postgres forbids using a freshly-added enum value in the
+-- same transaction that adds it). Same pattern as
+-- 20260818090000_agent_authoring_audit_events.
+ALTER TYPE "AgentAuditEvent" ADD VALUE IF NOT EXISTS 'SUBAGENT_MCP_UPDATED';
+ALTER TYPE "AgentAuditEvent" ADD VALUE IF NOT EXISTS 'SUBAGENT_MCP_DELETED';

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -1505,6 +1505,11 @@ enum AgentAuditEvent {
   SUBAGENT_CREATED
   SUBAGENT_UPDATED
   MCP_SERVER_CREATED
+  // Subagent-level MCP credential writes. Added by migration
+  // 20260909120000_subagent_mcp_connections (ALTER TYPE ADD VALUE) —
+  // kept here so a fresh `prisma generate` accepts them.
+  SUBAGENT_MCP_UPDATED
+  SUBAGENT_MCP_DELETED
 }
 
 model AgentAuditLog {
@@ -1691,6 +1696,7 @@ model McpServer {
   agentConnections     AgentMcpConnection[]
   globalCredentials    GlobalMcpCredentials[]
   editRequests         McpConnectorEditRequest[]
+  subagentConnections  SubagentMcpConnection[]
 
   @@unique([type])
   @@index([enabled])
@@ -1922,6 +1928,7 @@ model SubagentDefinition {
   org              Organization    @relation(fields: [orgId], references: [id], onDelete: Restrict)
   skills           SubagentSkill[]
   shares           SubagentShare[]
+  mcpConnections   SubagentMcpConnection[]
 
   @@unique([orgId, name])
   @@index([orgId])
@@ -1955,6 +1962,44 @@ model SubagentSkill {
 
   @@unique([subagentDefinitionId, skillId])
   @@map("subagent_skills")
+}
+
+// Per-subagent MCP credential. Companion to AgentMcpConnection, but owned by a
+// SubagentDefinition instead of an Agent. When present it resolves ABOVE the
+// agent/user/global cascade in credentials-loader. When `nonOverridable` is
+// true (the default) it SHORT-CIRCUITS that cascade — no user or agent
+// credential can shadow it — which is the whole point of the feature: a
+// subagent that must always authenticate as a specific identity (e.g. one
+// Nammayatri MID per subagent). `slug` mirrors AgentMcpConnection so one
+// subagent can hold several instances of the same server type.
+model SubagentMcpConnection {
+  id                   String             @id @default(cuid())
+  subagentDefinitionId String
+  subagent             SubagentDefinition @relation(fields: [subagentDefinitionId], references: [id], onDelete: Cascade)
+  mcpServerId          String
+  mcpServer            McpServer          @relation(fields: [mcpServerId], references: [id], onDelete: Cascade)
+  /// Stable short identifier for this instance, scoped to (subagent, server).
+  /// Matched against SubagentDefinition.mcpInstanceMap at runtime. Defaults to
+  /// 'default'. Allowed chars: lowercase alnum + hyphen.
+  slug                 String             @default("default")
+  /// Optional human-readable label shown in the subagent editor.
+  displayName          String?
+  /// When true, this credential short-circuits the agent/user/global cascade
+  /// so it cannot be overridden by any lower-priority connection. When false
+  /// it is a soft pin: preferred, but normal fallback still applies if the
+  /// decrypt/lookup yields nothing.
+  nonOverridable       Boolean            @default(true)
+  encryptedCreds       String
+  iv                   String
+  authTag              String
+  /// User who pasted the creds — used in audit logs.
+  createdByUserId      String?
+  createdAt            DateTime           @default(now())
+  updatedAt            DateTime           @updatedAt
+
+  @@unique([subagentDefinitionId, mcpServerId, slug])
+  @@index([subagentDefinitionId])
+  @@map("subagent_mcp_connections")
 }
 
 model PendingMemoryReview {

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -1506,7 +1506,7 @@ enum AgentAuditEvent {
   SUBAGENT_UPDATED
   MCP_SERVER_CREATED
   // Subagent-level MCP credential writes. Added by migration
-  // 20260909120000_subagent_mcp_connections (ALTER TYPE ADD VALUE) —
+  // 20260909120500_subagent_mcp_audit_events (ALTER TYPE ADD VALUE) —
   // kept here so a fresh `prisma generate` accepts them.
   SUBAGENT_MCP_UPDATED
   SUBAGENT_MCP_DELETED

--- a/apps/xyne-claw-auth/backend/src/lib/credentials-loader.subagent.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/credentials-loader.subagent.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Focused tests for the per-subagent MCP credential branch added to
+// loadEffectiveCredentials: org-scoping (the security fix), the non-overridable
+// short-circuit, soft-pin fallthrough, and decrypt-failure behavior.
+
+const state = vi.hoisted(() => ({
+  subRow: null as null | Record<string, any>,
+  userOrgId: "org-1" as string | null,
+  // decrypt() returns a JSON string in production; the branch JSON.parses it.
+  decryptImpl: (() => JSON.stringify({ apiKey: "x" })) as (...args: any[]) => unknown,
+  findFirstCalls: [] as any[],
+}));
+
+vi.mock("../config.js", () => ({ CONFIG: { encryptionKey: Buffer.alloc(32, 7) } }));
+vi.mock("../logger.js", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock("./errors.js", () => ({ errMsg: (e: unknown) => String(e) }));
+vi.mock("../crypto.js", () => ({ decrypt: (...a: any[]) => state.decryptImpl(...a) }));
+// Neutralize the OAuth / live-session short-circuits that sit above the branch.
+vi.mock("./oauth-server-types.js", () => ({ OAUTH_SERVER_TYPES: new Set<string>() }));
+vi.mock("../routes/oauth-token.js", () => ({ getOAuthProvider: () => null }));
+vi.mock("./oauth-token-endpoint.js", () => ({
+  resolveFreshOAuthCreds: vi.fn(async () => null),
+  TokenRefreshError: class extends Error {},
+}));
+vi.mock("./credentials-refresh.js", () => ({ getFreshCredentials: vi.fn() }));
+vi.mock("./spaces-db.js", () => ({
+  getSpacesAuthForUser: vi.fn(async () => null),
+  getWorkspaceIdForUser: vi.fn(async () => null),
+}));
+vi.mock("../db.js", () => ({
+  prisma: {
+    subagentMcpConnection: {
+      findFirst: vi.fn(async (args: any) => {
+        state.findFirstCalls.push(args);
+        return state.subRow;
+      }),
+    },
+    user: {
+      findUnique: vi.fn(async () => ({ orgId: state.userOrgId })),
+    },
+    // Cascade reads that run only on a soft-pin fallthrough — stubbed to null
+    // so the resolver returns null instead of throwing.
+    userMcpConnection: { findFirst: vi.fn(async () => null) },
+    mcpServer: { findUnique: vi.fn(async () => null) },
+    agentMcpConnection: { findFirst: vi.fn(async () => null) },
+  },
+}));
+
+import { loadEffectiveCredentials } from "./credentials-loader.js";
+
+const SERVER = "juspay-internal";
+const SUB_ID = "sub-1";
+
+beforeEach(() => {
+  state.subRow = null;
+  state.userOrgId = "org-1";
+  state.decryptImpl = () => JSON.stringify({ apiKey: "x" });
+  state.findFirstCalls = [];
+});
+
+describe("loadEffectiveCredentials — subagent pin", () => {
+  it("scopes the lookup to the caller's org and returns a subagent-sourced credential on a hit", async () => {
+    state.subRow = { id: "conn-1", slug: "default", nonOverridable: true, encryptedCreds: "e", iv: "i", authTag: "t" };
+
+    const res = await loadEffectiveCredentials("user-1", SERVER, undefined, undefined, "org-1", SUB_ID);
+
+    expect(res).not.toBeNull();
+    expect(res!.source).toBe("subagent");
+    expect(res!.connectionId).toBe("conn-1");
+    // Security: every lookup must be constrained to the caller's own org.
+    expect(state.findFirstCalls.length).toBeGreaterThan(0);
+    for (const call of state.findFirstCalls) {
+      expect(call.where.subagent).toEqual({ orgId: "org-1" });
+      expect(call.where.subagentDefinitionId).toBe(SUB_ID);
+    }
+  });
+
+  it("resolves the org from userId when agentOrgId is not passed", async () => {
+    state.subRow = { id: "conn-2", slug: "default", nonOverridable: true, encryptedCreds: "e", iv: "i", authTag: "t" };
+    state.userOrgId = "org-9";
+
+    const res = await loadEffectiveCredentials("user-1", SERVER, undefined, undefined, undefined, SUB_ID);
+
+    expect(res!.source).toBe("subagent");
+    expect(state.findFirstCalls.every((c) => c.where.subagent.orgId === "org-9")).toBe(true);
+  });
+
+  it("fails closed: when no org can be resolved the subagent pin is never consulted", async () => {
+    state.subRow = { id: "conn-3", slug: "default", nonOverridable: true, encryptedCreds: "e", iv: "i", authTag: "t" };
+    state.userOrgId = null; // user has no org, agentOrgId not passed
+
+    const res = await loadEffectiveCredentials("user-1", SERVER, undefined, undefined, undefined, SUB_ID);
+
+    expect(state.findFirstCalls.length).toBe(0);
+    expect(res).toBeNull(); // fell through to the cascade, which finds nothing
+  });
+
+  it("returns null (does NOT fall through) when a non-overridable pin cannot be decrypted", async () => {
+    state.subRow = { id: "conn-4", slug: "default", nonOverridable: true, encryptedCreds: "e", iv: "i", authTag: "t" };
+    state.decryptImpl = () => { throw new Error("bad key"); };
+
+    const res = await loadEffectiveCredentials("user-1", SERVER, undefined, undefined, "org-1", SUB_ID);
+
+    expect(res).toBeNull();
+  });
+
+  it("falls through to the cascade when a SOFT pin cannot be decrypted", async () => {
+    state.subRow = { id: "conn-5", slug: "default", nonOverridable: false, encryptedCreds: "e", iv: "i", authTag: "t" };
+    state.decryptImpl = () => { throw new Error("bad key"); };
+
+    // Soft pin decrypt-failure must NOT short-circuit to null; it falls through
+    // to the cascade (stubbed to null here, so the overall result is null).
+    const res = await loadEffectiveCredentials("user-1", SERVER, undefined, undefined, "org-1", SUB_ID);
+    expect(res).toBeNull();
+  });
+
+  it("does not consult a subagent pin when no subagentId is supplied", async () => {
+    state.subRow = { id: "conn-6", slug: "default", nonOverridable: true, encryptedCreds: "e", iv: "i", authTag: "t" };
+
+    await loadEffectiveCredentials("user-1", SERVER, undefined, undefined, "org-1");
+    expect(state.findFirstCalls.length).toBe(0);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/lib/credentials-loader.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/credentials-loader.ts
@@ -45,7 +45,7 @@ import { createLogger } from "../logger.js";
 const log = createLogger("credentials-loader");
 
 export interface EffectiveCredentials {
-  source: "agent" | "user" | "global";
+  source: "subagent" | "agent" | "user" | "global";
   connectionId: string;
   credentials: Record<string, unknown>;
   /** True iff the user owns this connection (admin/health code uses this to
@@ -142,6 +142,10 @@ export async function loadEffectiveCredentials(
   agentSlug?: string,
   instanceSlug?: string,
   agentOrgId?: string,
+  // SubagentDefinition.id when the tool call originates from a subagent's
+  // nested run. When set, a SubagentMcpConnection is consulted ABOVE the
+  // agent/user/global cascade below; a `nonOverridable` row short-circuits it.
+  subagentId?: string,
 ): Promise<EffectiveCredentials | null> {
   // google / microsoft: per-user OAuth connectors (never agent-pinned or
   // global), executed as claw-auth-hosted stdio MCP servers. Resolve a fresh
@@ -241,6 +245,57 @@ export async function loadEffectiveCredentials(
     }
     log.info(`[creds-loader] xyne-spaces-app-tools userId=${userId} agent=${agentSlug} → no spacesAppToken on agent; cannot resolve`);
     return null;
+  }
+
+  // 0. Subagent-pinned creds resolve ABOVE the agent/user/global cascade.
+  //    Only consulted when the caller passes a subagentId (the tool call
+  //    originates from a subagent's nested run). When the matched row is
+  //    `nonOverridable` (the default) it SHORT-CIRCUITS the cascade: no agent,
+  //    user, or global credential can shadow it — the subagent always
+  //    authenticates as this pinned identity. A soft pin (nonOverridable=false)
+  //    is preferred but falls through to the normal cascade on a miss. This
+  //    sits AFTER the OAuth / live-session short-circuits above by design:
+  //    those server types (google, xyne-dashboard, xyne-spaces-app-tools) have
+  //    no per-row secret to pin, so a subagent pin only applies to
+  //    secret-backed servers.
+  if (subagentId) {
+    let subConn = null;
+    if (instanceSlug) {
+      subConn = await prisma.subagentMcpConnection.findFirst({
+        where: { subagentDefinitionId: subagentId, mcpServer: { type: serverType }, slug: instanceSlug },
+      });
+    } else {
+      subConn = await prisma.subagentMcpConnection.findFirst({
+        where: { subagentDefinitionId: subagentId, mcpServer: { type: serverType }, slug: "default" },
+      });
+      if (!subConn) {
+        subConn = await prisma.subagentMcpConnection.findFirst({
+          where: { subagentDefinitionId: subagentId, mcpServer: { type: serverType } },
+          orderBy: { createdAt: "asc" },
+        });
+      }
+    }
+    if (subConn) {
+      try {
+        const decrypted = decrypt(subConn.encryptedCreds, subConn.iv, subConn.authTag, CONFIG.encryptionKey);
+        log.info(
+          `[creds-loader] ${serverType} userId=${userId} subagent=${subagentId} instance=${subConn.slug} nonOverridable=${subConn.nonOverridable} → subagent hit (connId=${subConn.id})`,
+        );
+        return {
+          source: "subagent",
+          connectionId: subConn.id,
+          credentials: JSON.parse(decrypted) as Record<string, unknown>,
+          isUserOwned: false,
+        };
+      } catch (err) {
+        // A pinned-but-undecryptable credential is a config error. When the pin
+        // is non-overridable we must NOT fall through to a weaker identity —
+        // that would silently defeat the "cannot be overridden" contract — so
+        // we fail the resolution. A soft pin falls through to the cascade.
+        log.error(`[creds-loader] ${serverType} subagent=${subagentId} → decrypt failed: ${errMsg(err)}`);
+        if (subConn.nonOverridable) return null;
+      }
+    }
   }
 
   // 1. Agent-pinned creds win when present. Only checked if the caller

--- a/apps/xyne-claw-auth/backend/src/lib/credentials-loader.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/credentials-loader.ts
@@ -259,20 +259,47 @@ export async function loadEffectiveCredentials(
   //    no per-row secret to pin, so a subagent pin only applies to
   //    secret-backed servers.
   if (subagentId) {
+    // Org-scope the pin to the CALLER'S org, derived from the authenticated
+    // userId / agentOrgId — NEVER from the request body. The transport only
+    // authenticates the run, not which subagent it claims to be, so a
+    // body-supplied subagentId is untrusted. Constraining every lookup to
+    // `subagent.orgId === callerOrg` means a foreign-org (or forged) id
+    // resolves to nothing and falls through to the normal cascade, instead of
+    // borrowing another org's pinned payment credentials. If the org cannot be
+    // resolved we skip the pin entirely (fail closed).
+    const subagentOrgScope = agentOrgId
+      ?? (await prisma.user.findUnique({ where: { id: userId }, select: { orgId: true } }))?.orgId
+      ?? undefined;
     let subConn = null;
-    if (instanceSlug) {
-      subConn = await prisma.subagentMcpConnection.findFirst({
-        where: { subagentDefinitionId: subagentId, mcpServer: { type: serverType }, slug: instanceSlug },
-      });
-    } else {
-      subConn = await prisma.subagentMcpConnection.findFirst({
-        where: { subagentDefinitionId: subagentId, mcpServer: { type: serverType }, slug: "default" },
-      });
-      if (!subConn) {
+    if (subagentOrgScope) {
+      if (instanceSlug) {
         subConn = await prisma.subagentMcpConnection.findFirst({
-          where: { subagentDefinitionId: subagentId, mcpServer: { type: serverType } },
-          orderBy: { createdAt: "asc" },
+          where: {
+            subagentDefinitionId: subagentId,
+            subagent: { orgId: subagentOrgScope },
+            mcpServer: { type: serverType },
+            slug: instanceSlug,
+          },
         });
+      } else {
+        subConn = await prisma.subagentMcpConnection.findFirst({
+          where: {
+            subagentDefinitionId: subagentId,
+            subagent: { orgId: subagentOrgScope },
+            mcpServer: { type: serverType },
+            slug: "default",
+          },
+        });
+        if (!subConn) {
+          subConn = await prisma.subagentMcpConnection.findFirst({
+            where: {
+              subagentDefinitionId: subagentId,
+              subagent: { orgId: subagentOrgScope },
+              mcpServer: { type: serverType },
+            },
+            orderBy: { createdAt: "asc" },
+          });
+        }
       }
     }
     if (subConn) {

--- a/apps/xyne-claw-auth/backend/src/routes/mcp.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/mcp.ts
@@ -806,6 +806,11 @@ async function loadEffectiveCredentialsWithSpacesFallback(
   agentSlug?: string,
   agentOrgId?: string,
   sessionId?: string,
+  // SubagentDefinition.id forwarded from the /mcp/call body when the tool
+  // call originates from a subagent's nested run. Threaded into the resolver
+  // so a SubagentMcpConnection can pin (and, when non-overridable, force) the
+  // credential identity above the agent/user/global cascade.
+  subagentId?: string,
 ): Promise<EffectiveCredentials | null> {
   // A Slack-surface run must use the bot installed in the workspace that
   // dispatched it. Do this before user/agent/global credential resolution so
@@ -815,7 +820,7 @@ async function loadEffectiveCredentialsWithSpacesFallback(
     if (surface) return surface;
   }
 
-  const effective = await loadEffectiveCredentials(userId, serverType, agentSlug, undefined, agentOrgId);
+  const effective = await loadEffectiveCredentials(userId, serverType, agentSlug, undefined, agentOrgId, subagentId);
   if (effective) return effective;
 
   if (serverType === "xyne-spaces") {
@@ -1347,12 +1352,15 @@ router.post("/:sessionId/mcp/call", async (req: Request<{ sessionId: string }>, 
     const strictAgentToolsConfig = isStrictAgentToolsEnabled()
       ? await withSurfaceDefaultToolsConfig(sessionAgentTools?.toolsConfig, req.params.sessionId, spacesAppId)
       : undefined;
-    const { serverType, tool, params, permission, backendId } = req.body as {
+    const { serverType, tool, params, permission, backendId, subagentId } = req.body as {
       serverType?: string;
       tool?: string;
       params?: Record<string, unknown>;
       permission?: string;
       backendId?: string;
+      // Set by xyne-claw when the invoking tool belongs to a subagent's
+      // palette. Selects a SubagentMcpConnection identity in the resolver.
+      subagentId?: string;
     };
 
     if (!serverType || typeof serverType !== "string") {
@@ -1657,6 +1665,7 @@ router.post("/:sessionId/mcp/call", async (req: Request<{ sessionId: string }>, 
       agentSlug,
       sessionAgentOrgId,
       req.params.sessionId,
+      subagentId,
     );
     if (!effective) {
       res
@@ -2099,6 +2108,7 @@ router.post("/:sessionId/actions/sign", async (req: Request<{ sessionId: string 
         params?: Record<string, unknown>;
         userId?: string;
         signature?: string;
+        subagentId?: string;
       };
       // Initial-signing shape (2026-07-15): claw's custom-tool write wrapper
       // (custom-tools.ts signWriteAction) sends the bare action — it CANNOT
@@ -2112,11 +2122,15 @@ router.post("/:sessionId/actions/sign", async (req: Request<{ sessionId: string 
       serverType?: string;
       tool?: string;
       params?: Record<string, unknown>;
+      subagentId?: string;
     };
 
     let serverType: string | undefined;
     let tool: string | undefined;
     let actionParams: Record<string, unknown>;
+    // Preserve the subagent-pinned credential identity across the write-approval
+    // replay: use whichever shape carried it (undefined = normal cascade).
+    const subagentId = body.subagentId ?? body.pendingAction?.subagentId;
 
     if (body.pendingAction && typeof body.pendingAction === "object") {
       // Re-sign shape: verify the existing signature before re-issuing.
@@ -2250,6 +2264,7 @@ router.post("/:sessionId/actions/sign", async (req: Request<{ sessionId: string 
         agentSlug,
         sessionAgentOrgId,
         req.params.sessionId,
+        subagentId,
       );
       const credentials = effective?.credentials;
       if (!credentials) {

--- a/apps/xyne-claw-auth/backend/src/routes/subagents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/subagents.ts
@@ -18,6 +18,9 @@ import { Router, type Request, type Response } from "express";
 import { Prisma } from "@prisma/client";
 import { asyncHandler, ok, badRequest, unauthorized, forbidden, notFound, HttpError } from "../lib/http.js";
 import { prisma } from "../db.js";
+import { encrypt } from "../crypto.js";
+import { CONFIG } from "../config.js";
+import { writeAuditLog } from "../lib/audit.js";
 import {
   subagentDefinitionRepository,
   subagentShareRepository,
@@ -34,6 +37,11 @@ import { createLogger } from "../logger.js";
 const log = createLogger("subagents");
 
 const router = Router();
+
+// Instance-slug convention, identical to AgentMcpConnection.slug.
+const SUBAGENT_MCP_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,31}$/;
+const isValidInstanceSlug = (v: unknown): v is string =>
+  typeof v === "string" && SUBAGENT_MCP_SLUG_RE.test(v);
 
 // ── Response shapes ──────────────────────────────────────────────────────
 
@@ -413,5 +421,170 @@ router.delete("/:name/shares/:userId", asyncHandler(async (req: Request, res: Re
   await subagentShareRepository.delete(row.id, userId).catch(() => undefined);
   ok(res);
 }));
+
+// ── Per-subagent MCP credentials ─────────────────────────────────────────
+// Companion to the agent-level routes in agents.ts. A subagent can pin its own
+// MCP credential per (server type, instance slug); when `nonOverridable` is set
+// (default) the credentials-loader forces that identity above the
+// agent/user/global cascade. Built-in subagents (code-defined, no DB row)
+// cannot hold pinned creds. All three routes require edit rights on the
+// subagent because credential configuration is sensitive.
+
+async function resolveEditableSubagent(req: Request): Promise<NonNullable<DbRow>> {
+  const name = typeof req.params.name === "string" ? req.params.name : "";
+  if (!name) throw badRequest("name is required");
+  if (SUBAGENT_DEFINITIONS.some((d) => d.name === name)) {
+    throw badRequest("Built-in subagents cannot hold pinned MCP credentials");
+  }
+  const requesterId = getRequesterId(req);
+  if (!requesterId) throw unauthorized("authentication required");
+  const row = await subagentDefinitionRepository.findByName(name, getOrgId(req));
+  if (!row) throw notFound("subagent not found");
+  if (!(await canEditSubagent(row, requesterId))) {
+    throw forbidden("you do not have edit access to this subagent");
+  }
+  return row;
+}
+
+// GET /:name/mcp/connections — list pinned instances (metadata only, no secrets).
+router.get("/:name/mcp/connections", asyncHandler(async (req: Request, res: Response) => {
+  const subagent = await resolveEditableSubagent(req);
+  const connections = await prisma.subagentMcpConnection.findMany({
+    where: { subagentDefinitionId: subagent.id },
+    include: { mcpServer: { select: { id: true, type: true, name: true } } },
+    orderBy: [{ mcpServerId: "asc" }, { createdAt: "asc" }],
+  });
+  ok(res, connections.map((c) => ({
+    id: c.id,
+    mcpServerId: c.mcpServerId,
+    mcpServerType: c.mcpServer.type,
+    mcpServerName: c.mcpServer.name,
+    slug: c.slug,
+    displayName: c.displayName ?? c.mcpServer.name,
+    nonOverridable: c.nonOverridable,
+    createdByUserId: c.createdByUserId,
+    createdAt: c.createdAt,
+    updatedAt: c.updatedAt,
+  })));
+}));
+
+// POST /:name/mcp/connections — create or update a pinned instance in place.
+// Identified by (subagent, serverType, slug). slug defaults to 'default'.
+router.post("/:name/mcp/connections", asyncHandler(async (req: Request, res: Response) => {
+  const subagent = await resolveEditableSubagent(req);
+  const requesterId = getRequesterId(req)!;
+  const { mcpServerType, slug: rawSlug, displayName, credentials, nonOverridable } = req.body as {
+    mcpServerType?: string;
+    slug?: string;
+    displayName?: string;
+    credentials?: Record<string, unknown>;
+    nonOverridable?: boolean;
+  };
+  if (!mcpServerType || typeof mcpServerType !== "string") {
+    throw badRequest("mcpServerType is required");
+  }
+  if (!credentials || typeof credentials !== "object") {
+    throw badRequest("credentials object is required");
+  }
+  const instanceSlug = rawSlug ?? "default";
+  if (!isValidInstanceSlug(instanceSlug)) {
+    throw badRequest("slug must be lowercase alphanumeric + hyphen, 1-32 chars");
+  }
+  if (nonOverridable !== undefined && typeof nonOverridable !== "boolean") {
+    throw badRequest("nonOverridable must be a boolean");
+  }
+  const server = await prisma.mcpServer.findUnique({ where: { type: mcpServerType } });
+  if (!server) throw notFound(`Unknown mcpServerType: ${mcpServerType}`);
+
+  const { ciphertext, iv, authTag } = encrypt(JSON.stringify(credentials), CONFIG.encryptionKey);
+  const cleanDisplayName = typeof displayName === "string" && displayName.trim().length > 0
+    ? displayName.trim()
+    : null;
+
+  const row = await prisma.subagentMcpConnection.upsert({
+    where: {
+      subagentDefinitionId_mcpServerId_slug: {
+        subagentDefinitionId: subagent.id,
+        mcpServerId: server.id,
+        slug: instanceSlug,
+      },
+    },
+    create: {
+      subagentDefinitionId: subagent.id,
+      mcpServerId: server.id,
+      slug: instanceSlug,
+      displayName: cleanDisplayName,
+      nonOverridable: nonOverridable ?? true,
+      encryptedCreds: ciphertext,
+      iv,
+      authTag,
+      createdByUserId: requesterId,
+    },
+    update: {
+      encryptedCreds: ciphertext,
+      iv,
+      authTag,
+      // Only overwrite optional fields when the caller explicitly sent them,
+      // so a creds-only update doesn't clobber a previously-set label/flag.
+      ...(cleanDisplayName !== null ? { displayName: cleanDisplayName } : {}),
+      ...(nonOverridable !== undefined ? { nonOverridable } : {}),
+    },
+  });
+
+  await writeAuditLog({
+    actorUserId: requesterId,
+    eventType: "SUBAGENT_MCP_UPDATED",
+    targetId: subagent.id,
+    description: `Set MCP "${mcpServerType}" / instance "${instanceSlug}" (nonOverridable=${row.nonOverridable}) on subagent "${subagent.name}"`,
+  });
+
+  res.status(201).json({
+    success: true,
+    data: {
+      id: row.id,
+      mcpServerId: row.mcpServerId,
+      mcpServerType: server.type,
+      mcpServerName: server.name,
+      slug: row.slug,
+      displayName: row.displayName ?? server.name,
+      nonOverridable: row.nonOverridable,
+      createdByUserId: row.createdByUserId,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    },
+  });
+}));
+
+// DELETE /:name/mcp/connections/:mcpServerType/:instanceSlug
+router.delete(
+  "/:name/mcp/connections/:mcpServerType/:instanceSlug",
+  asyncHandler(async (req: Request, res: Response) => {
+    const subagent = await resolveEditableSubagent(req);
+    const requesterId = getRequesterId(req)!;
+    const { mcpServerType, instanceSlug } = req.params as { mcpServerType: string; instanceSlug: string };
+    if (!isValidInstanceSlug(instanceSlug)) throw badRequest("Invalid instance slug");
+    const server = await prisma.mcpServer.findUnique({ where: { type: mcpServerType } });
+    if (!server) throw notFound(`Unknown mcpServerType: ${mcpServerType}`);
+
+    await prisma.subagentMcpConnection.delete({
+      where: {
+        subagentDefinitionId_mcpServerId_slug: {
+          subagentDefinitionId: subagent.id,
+          mcpServerId: server.id,
+          slug: instanceSlug,
+        },
+      },
+    }).catch(() => undefined);
+
+    await writeAuditLog({
+      actorUserId: requesterId,
+      eventType: "SUBAGENT_MCP_DELETED",
+      targetId: subagent.id,
+      description: `Removed MCP "${mcpServerType}" / instance "${instanceSlug}" from subagent "${subagent.name}"`,
+    });
+
+    ok(res, { deleted: true });
+  }),
+);
 
 export default router;

--- a/apps/xyne-claw-auth/backend/src/routes/subagents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/subagents.ts
@@ -566,24 +566,30 @@ router.delete(
     const server = await prisma.mcpServer.findUnique({ where: { type: mcpServerType } });
     if (!server) throw notFound(`Unknown mcpServerType: ${mcpServerType}`);
 
-    await prisma.subagentMcpConnection.delete({
+    // deleteMany is idempotent: it removes the row if present and reports the
+    // count, without throwing when the pin does not exist. This avoids the old
+    // `.catch(() => undefined)` which swallowed EVERY error (e.g. a DB outage)
+    // and then emitted a "deleted" audit log that never happened.
+    const { count } = await prisma.subagentMcpConnection.deleteMany({
       where: {
-        subagentDefinitionId_mcpServerId_slug: {
-          subagentDefinitionId: subagent.id,
-          mcpServerId: server.id,
-          slug: instanceSlug,
-        },
+        subagentDefinitionId: subagent.id,
+        mcpServerId: server.id,
+        slug: instanceSlug,
       },
-    }).catch(() => undefined);
-
-    await writeAuditLog({
-      actorUserId: requesterId,
-      eventType: "SUBAGENT_MCP_DELETED",
-      targetId: subagent.id,
-      description: `Removed MCP "${mcpServerType}" / instance "${instanceSlug}" from subagent "${subagent.name}"`,
     });
 
-    ok(res, { deleted: true });
+    // Only record the audit event when a row was actually removed, so the
+    // audit trail cannot claim a deletion that did not occur.
+    if (count > 0) {
+      await writeAuditLog({
+        actorUserId: requesterId,
+        eventType: "SUBAGENT_MCP_DELETED",
+        targetId: subagent.id,
+        description: `Removed MCP "${mcpServerType}" / instance "${instanceSlug}" from subagent "${subagent.name}"`,
+      });
+    }
+
+    ok(res, { deleted: count > 0 });
   }),
 );
 

--- a/apps/xyne-claw/src/mcp.ts
+++ b/apps/xyne-claw/src/mcp.ts
@@ -279,6 +279,12 @@ export async function loadMcpToolsForUser(
   // from omitting or replacing trusted run bindings.
   trustedToolBindings?: TrustedMcpToolBindings,
   onConnectorBlocked?: (serverType: string, status: number) => void,
+  // When these MCP tools are being built for a SPECIFIC subagent's palette,
+  // pass that SubagentDefinition.id here. It is forwarded in the /mcp/call
+  // body so claw-auth's credentials-loader can resolve a SubagentMcpConnection
+  // (a per-subagent pinned identity) above the agent/user/global cascade.
+  // Undefined for the main-agent loader — unchanged behaviour.
+  subagentId?: string,
 ): Promise<{
   groups: McpToolGroup[];
   cleanup: () => Promise<void>;
@@ -374,6 +380,7 @@ export async function loadMcpToolsForUser(
                 params: callParams,
                 permission,
                 agentSlug,
+                ...(subagentId ? { subagentId } : {}),
               }),
             },
             server.serverType,


### PR DESCRIPTION
## Summary
Adds a **per-subagent MCP credential** layer so a subagent can pin its own MCP credentials, resolved with high (optionally non-overridable) priority above the existing agent → user → global cascade.

**Motivation (Nammayatri):** one agent needs distinct MIDs/credentials per subagent — e.g. different creds for payouts vs. payment links. Today a subagent inherits the parent agent's pinned instance via `mcpInstanceMap`, so it cannot hold its own identity.

## What this PR does (reviewable core)
- **Schema:** new `SubagentMcpConnection` model + back-refs on `McpServer` and `SubagentDefinition`; two new `AgentAuditEvent` values (`SUBAGENT_MCP_UPDATED`, `SUBAGENT_MCP_DELETED`).
- **Migrations:** additive `CREATE TABLE subagent_mcp_connections` (unique on `(subagentDefinitionId, mcpServerId, slug)`, FKs `ON DELETE CASCADE`), plus a separate `ALTER TYPE ... ADD VALUE` migration so the enum add runs in its own transaction (older-Postgres safe).
- **Resolver (`credentials-loader.ts`):** new subagent branch resolves **above** the agent/user/global cascade. When `nonOverridable=true` (default) it short-circuits so no lower-priority credential can shadow it; a soft pin (`false`) falls through on a miss or undecryptable row. A non-overridable-but-undecryptable row returns `null` rather than silently falling back to a weaker identity.
- **claw-auth routes:** `GET/POST/DELETE /subagents/:name/mcp/connections`, gated by `canEditSubagent`, with `SUBAGENT_MCP_UPDATED`/`SUBAGENT_MCP_DELETED` audit logs. Built-in (code-defined) subagents are rejected — they have no DB row to pin against.
- **Call path:** `/mcp/call` and `/actions/sign` forward an optional `subagentId` into the resolver.
- **xyne-claw:** `loadMcpToolsForUser` accepts an optional `subagentId` and forwards it in the `/mcp/call` body (symmetric plumbing hook; undefined = unchanged main-agent behaviour).

## Security notes
- Credential CRUD requires **edit rights** on the subagent (`canEditSubagent`: owner, claw admin, or EDITOR share).
- Creds are encrypted at rest with `CONFIG.encryptionKey` (same `encrypt`/`decrypt` as `AgentMcpConnection`).
- Non-overridable pins are the core guarantee for the per-MID requirement: a lower-priority (agent/user/global) credential can never shadow a subagent's pinned identity.

## Follow-up (flagged, NOT in this PR)
Wiring `buildSubagentTools` to construct **per-subagent MCP tool groups** bound to `subagentId` is a high-blast-radius runtime path (it rebuilds the subagent tool palette's `execute()` closures) and can't be fully integration-tested here. The plumbing hook above makes that a localized follow-up. Until then the `subagentId` field is threaded end-to-end on the claw-auth side but only set once the runtime constructs subagent-scoped tools.

## Validation
- `prisma generate` + typecheck must run in CI: the authoring sandbox has **no network** to fetch the Prisma engine, so the client could not be regenerated locally. With the current (stale) client, the only new type error was a scope bug that is now fixed; all remaining `tsc` errors are the pre-existing ungenerated-client cascade also present on the base branch.
- Suggested checks: apply both migrations on a scratch DB; unit-test the resolver's subagent branch (hit, non-overridable short-circuit, soft-pin fallthrough, undecryptable non-overridable → null); route tests for ACL + audit-log emission.