### PR TITLE
feat: XYNE-61398 allow ticket creation from the Tickets Views tab

### DIFF
--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -3828,131 +3828,136 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
         {/* Create Ticket / Save View Button - Right Side */}
         <div className='flex flex-wrap lg:flex-col md:items-end gap-3 ml-auto md:ml-0'>
-          {isWorkspaceView && (
-            <div className='flex items-center gap-2'>
-              {isViewDirty && (
-                <>
-                  <span className='text-[13px] text-muted-foreground whitespace-nowrap'>
-                    Unsaved changes
-                  </span>
-                  <Button
-                    variant='ghost'
-                    size='sm'
-                    onClick={handleResetWorkspaceView}
-                    className='rounded-[10px]'
-                    aria-label='Discard unsaved changes'
-                    data-track-category='Projects'
-                    data-track-name='ResetView'
-                  >
-                    Reset
-                  </Button>
-                </>
-              )}
-              <Button
-                variant='outline'
-                size='sm'
-                onClick={handleShareWorkspaceView}
-                disabled={!workspaceViewReady}
-                className='rounded-[10px] border-border hover:bg-muted'
-                aria-label='Share view'
-                data-track-category='Projects'
-                data-track-name='ShareView'
-              >
-                <Share2 className='w-3 h-3 text-muted-foreground' />
-                <span>Share</span>
-              </Button>
-              {canSaveInPlace ? (
-                <Button
-                  size='sm'
-                  onClick={handleSaveExistingView}
-                  disabled={!workspaceViewReady || isSavingWorkspaceView || !isViewDirty}
-                  className='rounded-[10px]'
-                  data-track-category='Projects'
-                  data-track-name='SaveView'
-                >
-                  <Bookmark className='w-3 h-3' />
-                  <span>Save</span>
-                </Button>
-              ) : (
-                <Popover
-                  open={isSavePopoverOpen}
-                  onOpenChange={handleSavePopoverOpenChange}
-                  align='end'
-                  className='w-64 p-3'
-                  trigger={
+          <div className='flex flex-wrap items-center justify-end gap-2'>
+            {isWorkspaceView && (
+              <div className='flex items-center gap-2'>
+                {isViewDirty && (
+                  <>
+                    <span className='text-[13px] text-muted-foreground whitespace-nowrap'>
+                      Unsaved changes
+                    </span>
                     <Button
+                      variant='ghost'
                       size='sm'
-                      disabled={!workspaceViewReady || isSavingWorkspaceView}
+                      onClick={handleResetWorkspaceView}
                       className='rounded-[10px]'
+                      aria-label='Discard unsaved changes'
                       data-track-category='Projects'
-                      data-track-name='SaveView'
+                      data-track-name='ResetView'
                     >
-                      <Bookmark className='w-3 h-3' />
-                      <span>{viewId ? 'Save' : 'Save view'}</span>
+                      Reset
                     </Button>
-                  }
+                  </>
+                )}
+                <Button
+                  variant='outline'
+                  size='sm'
+                  onClick={handleShareWorkspaceView}
+                  disabled={!workspaceViewReady}
+                  className='rounded-[10px] border-border hover:bg-muted'
+                  aria-label='Share view'
+                  data-track-category='Projects'
+                  data-track-name='ShareView'
                 >
-                  <div className='flex flex-col gap-2'>
-                    <span className='text-[13px] font-medium text-foreground'>Name this view</span>
-                    <input
-                      autoFocus
-                      value={workspaceViewNameDraft}
-                      onChange={e => setWorkspaceViewNameDraft(e.target.value)}
-                      onKeyDown={e => {
-                        if (e.key === 'Enter') handleConfirmSaveWorkspaceView();
-                      }}
-                      placeholder='e.g. My open PRs'
-                      data-track-category='Projects'
-                      data-track-name='SaveViewNameInput'
-                      className={cn(
-                        'h-8 px-2 rounded-md border border-input bg-background text-[13px]',
-                        'text-foreground outline-none placeholder:text-muted-foreground',
-                        'focus-visible:ring-[3px] focus-visible:ring-ring/50',
-                      )}
-                    />
-                    <div className='flex justify-end gap-2 pt-1'>
-                      <Button
-                        variant='ghost'
-                        size='sm'
-                        onClick={() => setIsSavePopoverOpen(false)}
-                        data-track-category='Tickets'
-                        data-track-name='CANCEL_SAVE_WORKSPACE_VIEW'
-                      >
-                        Cancel
-                      </Button>
+                  <Share2 className='w-3 h-3 text-muted-foreground' />
+                  <span>Share</span>
+                </Button>
+                {canSaveInPlace ? (
+                  <Button
+                    size='sm'
+                    onClick={handleSaveExistingView}
+                    disabled={!workspaceViewReady || isSavingWorkspaceView || !isViewDirty}
+                    className='rounded-[10px]'
+                    data-track-category='Projects'
+                    data-track-name='SaveView'
+                  >
+                    <Bookmark className='w-3 h-3' />
+                    <span>Save</span>
+                  </Button>
+                ) : (
+                  <Popover
+                    open={isSavePopoverOpen}
+                    onOpenChange={handleSavePopoverOpenChange}
+                    align='end'
+                    className='w-64 p-3'
+                    trigger={
                       <Button
                         size='sm'
-                        onClick={handleConfirmSaveWorkspaceView}
-                        data-track-category='Tickets'
-                        data-track-name='CONFIRM_SAVE_WORKSPACE_VIEW'
-                        disabled={!workspaceViewNameDraft.trim() || isSavingWorkspaceView}
+                        disabled={!workspaceViewReady || isSavingWorkspaceView}
+                        className='rounded-[10px]'
+                        data-track-category='Projects'
+                        data-track-name='SaveView'
                       >
-                        Save
+                        <Bookmark className='w-3 h-3' />
+                        <span>{viewId ? 'Save' : 'Save view'}</span>
                       </Button>
+                    }
+                  >
+                    <div className='flex flex-col gap-2'>
+                      <span className='text-[13px] font-medium text-foreground'>
+                        Name this view
+                      </span>
+                      <input
+                        autoFocus
+                        value={workspaceViewNameDraft}
+                        onChange={e => setWorkspaceViewNameDraft(e.target.value)}
+                        onKeyDown={e => {
+                          if (e.key === 'Enter') handleConfirmSaveWorkspaceView();
+                        }}
+                        placeholder='e.g. My open PRs'
+                        data-track-category='Projects'
+                        data-track-name='SaveViewNameInput'
+                        className={cn(
+                          'h-8 px-2 rounded-md border border-input bg-background text-[13px]',
+                          'text-foreground outline-none placeholder:text-muted-foreground',
+                          'focus-visible:ring-[3px] focus-visible:ring-ring/50',
+                        )}
+                      />
+                      <div className='flex justify-end gap-2 pt-1'>
+                        <Button
+                          variant='ghost'
+                          size='sm'
+                          onClick={() => setIsSavePopoverOpen(false)}
+                          data-track-category='Tickets'
+                          data-track-name='CANCEL_SAVE_WORKSPACE_VIEW'
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          size='sm'
+                          onClick={handleConfirmSaveWorkspaceView}
+                          data-track-category='Tickets'
+                          data-track-name='CONFIRM_SAVE_WORKSPACE_VIEW'
+                          disabled={!workspaceViewNameDraft.trim() || isSavingWorkspaceView}
+                        >
+                          Save
+                        </Button>
+                      </div>
                     </div>
-                  </div>
-                </Popover>
+                  </Popover>
+                )}
+              </div>
+            )}
+            {canCreateTicket &&
+              ((channel && !channel.isArchived) || isMyTicketsView || isWorkspaceView) && (
+                <button
+                  data-testid='kanban-create-ticket-button'
+                  data-track-event='BUTTON_CLICK'
+                  data-track-category='Tickets'
+                  data-track-name='CREATE_TICKET_KANBAN'
+                  data-track-metadata={JSON.stringify({ boardId, channelId })}
+                  onClick={() => {
+                    setCreateTicketSeed(null);
+                    setIsCreateModalOpen(true);
+                  }}
+                  className='flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-primary-foreground bg-primary rounded-lg transition-colors flex-shrink-0'
+                >
+                  <Plus className='w-4 h-4' />
+                  <span className='hidden sm:inline font-semibold text-sm'>Create Ticket</span>
+                  <span className='sm:hidden'>Create</span>
+                </button>
               )}
-            </div>
-          )}
-          {canCreateTicket && ((channel && !channel.isArchived) || isMyTicketsView) && (
-            <button
-              data-testid='kanban-create-ticket-button'
-              data-track-event='BUTTON_CLICK'
-              data-track-category='Tickets'
-              data-track-name='CREATE_TICKET_KANBAN'
-              data-track-metadata={JSON.stringify({ boardId, channelId })}
-              onClick={() => {
-                setCreateTicketSeed(null);
-                setIsCreateModalOpen(true);
-              }}
-              className='flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-primary-foreground bg-primary rounded-lg transition-colors flex-shrink-0'
-            >
-              <Plus className='w-4 h-4' />
-              <span className='hidden sm:inline font-semibold text-sm'>Create Ticket</span>
-              <span className='sm:hidden'>Create</span>
-            </button>
-          )}
+          </div>
           {/* Layout View Toggle (flow boards only have the flow view) */}
           <div className='flex items-center gap-2'>
             {!isFlowBoard && (
@@ -5394,8 +5399,8 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         />
       )}
 
-      {/* Create Ticket Modal — my-tickets view (no channel context, user picks channel + board) */}
-      {isMyTicketsView && !channel && isCreateModalOpen && (
+      {/* Create Ticket Modal — my-tickets and saved views (no channel context, user picks channel + board) */}
+      {(isMyTicketsView || isWorkspaceView) && !channel && isCreateModalOpen && (
         <CreateTicketModal
           isOpen={isCreateModalOpen}
           onClose={() => {


### PR DESCRIPTION
POT - https://drive.google.com/file/d/1uG63QtMpK607Rl0qbgtwMHAYufeVwTDB/view?usp=sharing

### Problem

You cannot create a ticket from the Tickets **Views** tab. A saved view is rendered by `ProjectViewBuilder` with no `channelId` prop and no `:projectId` route param (`AppRoot.tsx:1596-1602`), so the fallback channel lookup at `KanbanBoardScreen.tsx:505-513` resolves to `''`, `channel` is permanently `undefined`, and `effectiveProjectId` is undefined with it. All three create affordances are gated on those two values:

- header "Create Ticket" — `KanbanBoardScreen.tsx:3938`
- per-column `+` — `:5327` (so `KanbanColumns` never receives `onAddTicketInColumn`, and its own button at `KanbanColumns.tsx:258` never renders)
- the modal block itself — `:5376`

This was never deliberately disabled — the guards predate `workspace-view`. `73d18f78a`'s own message notes "a saved view has neither a channel nor a project to key on", which was solved for *reading* tickets and never for creating them.

### Change

`CreateTicketModal` takes one new optional prop, `candidateBoardIds`. When it's non-empty, `boards` resolves from the existing `queries.boardsByIds` instead of the channel-mapping → project cascade, so a view's boards work even when they span projects (`ViewBoardPicker` lets a view select boards across projects, so they can).

`POST /tickets` hard-requires a channel (`ticketController.ts:605-608`) and a board doesn't determine one (`ChannelBoardMapping` is many-to-many). So the channel is **inferred** from the chosen board's project — the first non-archived channel with a matching `projectId`, taken from the already-loaded `useAllVisibleChannels()` list. **No new query.** The modal falls back to asking the user only when a board is chosen whose project has no such channel; `canSelectChannel` gains `isViewScoped && !!formValues.boardId && !inferredChannelId`, and the `formValues.boardId` half is what stops the channel dropdown appearing on open and then vanishing once a board is picked. The existing "Channel is required" validation at `:1249` covers that fallback path.

In `KanbanBoardScreen.tsx`: the two button guards now also allow `isWorkspaceView`, and a third modal block passes `channelId=''`, the view's boards, and `selectedBoardId` **only** when the view holds exactly one board — `filters.boards` order is not meaningful (value rows have random uuid PKs and are re-inserted with one shared timestamp, and no query orders them), so nothing is preselected for a multi-board view.

### What needed no change

- **`projectId`** — the modal already sends `selectedBoard.projectId` (`CreateTicketModal.tsx:1513`), and the server re-derives it from `boardId` (`ticketController.ts:781-784`), so cross-project candidate boards flow through safely.
- **Stage** — `ticketRepository.createTicket` falls back to the board's first stage by `sequenceNumber` when `stageName` doesn't match the chosen board (`:145-153`), so a status/stage preset coming from a column `+` is always safe.
- **Custom fields** — `getFormMappingByContextId` is already keyed on `formValues.boardId`, and `dynamicFields` already resets on board change.
- **Deleted boards** — `boardsByIds` silently drops ids it can't resolve, which is what we want: `board.delete` never cleans up `saved_user_configuration_values`, so dead board ids linger in a view forever.
- **RELEASE boards** — already excluded by `boardOptions`' existing `isReleaseBoard` filter. FLOW/NON_LINEAR stay selectable; the server already special-cases FLOW.

### Note

In a multi-board view the columns are status categories, so a ticket created from the "Completed" column `+` gets `statusV2: COMPLETED` and the board's first stage. That matches what the project view does today; say the word if the per-column `+` should be header-only in views.

### Verification

`pnpm typecheck`, `eslint --quiet` and `prettier --check` clean on both files.
