### PR TITLE
feat: add KataSandboxAdapter for workflowsV2

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -92,6 +92,7 @@
     "@types/unzipper": "^0.10.11",
     "@types/yauzl": "^2.10.3",
     "@xyne/shared": "workspace:*",
+    "@xyne/kata-sdk": "workspace:*",
     "@xyne/storage": "workspace:*",
     "@xyne/vespa-ts": "1.6.0",
     "@xyne/workflow-sdk": "3.2.36",

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -463,6 +463,10 @@ const envSchema = Joi.object({
   XYNE_CLAW_URL: Joi.string().uri().default('http://localhost:3002'),
   XYNE_CLAW_S2S_KEY: Joi.string().allow('').default(''),
   XYNE_CLAW_AUTH_URL: Joi.string().uri().default('http://localhost:3003'),
+  // Kata sandbox fleet (workflowsV2 SandboxAdapter → in-cluster sandbox-router)
+  KATA_ROUTER_URL: Joi.string().allow('').default(''),
+  KATA_NAMESPACE: Joi.string().default('xyne-apps'),
+  KATA_TEMPLATE: Joi.string().default('kata-workspace-template'),
   XYNE_CLAW_WEBHOOK_URL: Joi.string().uri().default('http://localhost:3003/claw/api/v1/webhook'),
   XYNE_CLAW_AUTH_CALLBACK_URL_AUTOMATION: Joi.string()
     .uri()
@@ -1139,6 +1143,11 @@ export const config = {
     webhookUrl: envVars.XYNE_CLAW_WEBHOOK_URL as string,
     clawAuthCallbackUrlAutomation: envVars.XYNE_CLAW_AUTH_CALLBACK_URL_AUTOMATION as string,
     callbackUrl: (envVars.XYNE_CLAW_CALLBACK_URL || envVars.BACKEND_URL) as string,
+  },
+  kata: {
+    routerUrl: envVars.KATA_ROUTER_URL as string,
+    namespace: envVars.KATA_NAMESPACE as string,
+    template: envVars.KATA_TEMPLATE as string,
   },
   internalS2sKey: envVars.INTERNAL_S2S_KEY as string,
   apps: {

--- a/apps/backend/src/workflowsV2/adapters/sandbox.ts
+++ b/apps/backend/src/workflowsV2/adapters/sandbox.ts
@@ -1,0 +1,174 @@
+/**
+ * `SandboxAdapter` for `@xyne/workflow-sdk`, over the Kata/QEMU microVM sandbox
+ * fleet (`@xyne/kata-sdk` → the in-cluster `sandbox-router`, backed by
+ * `SandboxClaim`/`Sandbox` CRDs in the `xyne-apps` namespace).
+ *
+ * This is the sibling of {@link WorkflowStorageAdapter}: the SDK defines the
+ * seam, the host implements it, and the framework imports no execution backend.
+ * The runtime threads it into every step's execution context, where the
+ * built-in `run_code` agent tool (and, later, a deterministic `CODE` step)
+ * reach for it via a handle-bound `SandboxSession`.
+ *
+ * ── Impedance notes (kata ↔ the SDK contract) ────────────────────────────────
+ *  - The contract is stateless and handle-based (one adapter → many concurrent
+ *    sandboxes, each addressed by an opaque `{ id }`). `KataClient.createSession`
+ *    hands back a stateful `Session`, so this adapter keeps the live objects in a
+ *    registry keyed by the handle id — the same pattern xyne-claw's session store
+ *    uses.
+ *  - kata only runs shell (`/execute`). `bash` maps 1:1; `exec` (Python by
+ *    default in the SDK's reference image) has no native equivalent, so it writes
+ *    the code to a temp file and runs the interpreter, reporting a raise through
+ *    the structured `error` field rather than an exit code.
+ *  - kata has no artifact/output-dir concept, so `artifacts` is always `[]`.
+ *    `run_code` still works; it just won't auto-collect produced files. Closing
+ *    that means listing a conventional output dir via the filesystem module after
+ *    each call and reading the bytes back.
+ *
+ * ── Operational reality ──────────────────────────────────────────────────────
+ * Cold start is slow (repo templates prebake minutes) and `createSession`
+ * self-throttles to one `SandboxClaim` per ~10s (a GCP per-source-snapshot
+ * CreateVolume rate limit). The SDK's `SandboxSession` lifecycle is
+ * create → … → destroy per step, so a hot `CODE`/`run_code` path pays full
+ * cold-start each run and can serialize under burst. Add session reuse here if
+ * that becomes a problem.
+ */
+import { randomUUID } from 'crypto';
+import type {
+  SandboxAdapter,
+  SandboxExecOptions,
+  SandboxExecResult,
+  SandboxFileUpload,
+  SandboxHandle,
+  StorageScope,
+} from '@xyne/workflow-sdk';
+import { KataClient, type Session } from '@xyne/kata-sdk';
+import { config } from '@/config/env';
+import { logger } from '@/utils/logger';
+
+/** Default per-call wall-clock timeout when a caller doesn't set one. */
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+export class KataSandboxAdapter implements SandboxAdapter {
+  private readonly client: KataClient;
+
+  /**
+   * Live `Session` objects, keyed by the opaque handle id we hand back to the
+   * SDK. The contract is handle-based; kata's `Session` is stateful, so the
+   * adapter owns the mapping between the two.
+   */
+  private readonly sessions = new Map<string, Session>();
+
+  constructor() {
+    this.client = new KataClient({
+      routerUrl: config.kata.routerUrl,
+      namespace: config.kata.namespace,
+      template: config.kata.template,
+    });
+  }
+
+  /**
+   * Boot a fresh, isolated sandbox and wait until it is serving.
+   *
+   * `scope` is accepted for parity with {@link StorageScope} routing; today the
+   * whole fleet shares one namespace/template, so it is only logged. Route per
+   * tenant here (namespace/template off `scope`) when that becomes a
+   * requirement.
+   */
+  async create(opts?: { scope?: StorageScope; signal?: AbortSignal }): Promise<SandboxHandle> {
+    opts?.signal?.throwIfAborted();
+    const session = await this.client.createSession();
+    await session.waitUntilReady();
+    this.sessions.set(session.id, session);
+    logger.info(`[WORKFLOWS-SANDBOX] created sandbox ${session.id}`);
+    return { id: session.id };
+  }
+
+  /**
+   * Run code. kata has no code executor, so write it to a temp file and run the
+   * interpreter — this sidesteps all shell-quoting hazards of inlining code.
+   * A non-zero exit is reported through `error` (the contract's channel for a
+   * raised exception), not `exitCode`.
+   */
+  async exec(
+    handle: SandboxHandle,
+    code: string,
+    opts?: SandboxExecOptions,
+  ): Promise<SandboxExecResult> {
+    const session = this.require(handle);
+    const started = Date.now();
+    const scriptPath = `/tmp/wf-exec-${randomUUID()}.py`;
+    await session.files.write(scriptPath, Buffer.from(code, 'utf8'));
+    try {
+      const r = await session.commands.run(
+        `python3 ${scriptPath}`,
+        opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      );
+      const result: SandboxExecResult = {
+        stdout: r.stdout,
+        stderr: r.stderr,
+        artifacts: [],
+        durationMs: Date.now() - started,
+      };
+      if (r.exitCode !== 0) {
+        result.error = { name: 'ExecError', value: r.stderr.trim(), traceback: r.stderr };
+      }
+      return result;
+    } finally {
+      // Best-effort cleanup; the sandbox is ephemeral and destroyed per step,
+      // so a failed rm must never surface as the step's error.
+      await session.commands.run(`rm -f ${scriptPath}`).catch(() => undefined);
+    }
+  }
+
+  /** Run a shell command. Maps 1:1 onto the kata commands module. */
+  async bash(
+    handle: SandboxHandle,
+    command: string,
+    opts?: SandboxExecOptions,
+  ): Promise<SandboxExecResult> {
+    const session = this.require(handle);
+    const started = Date.now();
+    const r = await session.commands.run(command, opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    return {
+      stdout: r.stdout,
+      stderr: r.stderr,
+      exitCode: r.exitCode,
+      artifacts: [],
+      durationMs: Date.now() - started,
+    };
+  }
+
+  /** Upload files into the sandbox filesystem. */
+  async writeFiles(handle: SandboxHandle, files: SandboxFileUpload[]): Promise<void> {
+    const session = this.require(handle);
+    for (const file of files) {
+      await session.files.write(file.path, Buffer.from(file.bytes));
+    }
+  }
+
+  /** Read a file's bytes back out of the sandbox. */
+  async readFile(handle: SandboxHandle, path: string): Promise<Uint8Array> {
+    const buffer = await this.require(handle).files.read(path);
+    return new Uint8Array(buffer);
+  }
+
+  /**
+   * Tear the sandbox down. Idempotent: an unknown handle is a no-op, so a
+   * caller's `finally` never throws over a double-destroy or a lost session.
+   */
+  async destroy(handle: SandboxHandle): Promise<void> {
+    const session = this.sessions.get(handle.id);
+    if (!session) return;
+    this.sessions.delete(handle.id);
+    await session.destroy();
+    logger.info(`[WORKFLOWS-SANDBOX] destroyed sandbox ${handle.id}`);
+  }
+
+  private require(handle: SandboxHandle): Session {
+    const session = this.sessions.get(handle.id);
+    if (!session) {
+      throw new Error(`workflows sandbox: unknown handle ${JSON.stringify(handle.id)}`);
+    }
+    return session;
+  }
+}

--- a/apps/backend/src/workflowsV2/runtime.ts
+++ b/apps/backend/src/workflowsV2/runtime.ts
@@ -29,6 +29,7 @@ import { PrismaPersistenceAdapter } from './adapters/persistence';
 import { BullQueueAdapter } from './adapters/queue';
 import { BullSchedulerAdapter } from './adapters/scheduler';
 import { WorkflowStorageAdapter } from './adapters/storage';
+import { KataSandboxAdapter } from './adapters/sandbox';
 import { XyneWorkflowAuthorizer } from './authorizer';
 import { DEFAULT_CRON_TIMEZONE } from './constants';
 import type { XyneCtx, XyneFilter } from './types';
@@ -46,6 +47,20 @@ export const persistence = new PrismaPersistenceAdapter();
 export const eventBus = new ExecutionEventBus();
 
 const storage = new WorkflowStorageAdapter();
+
+/**
+ * Sandbox adapter — code execution over the Kata microVM fleet. Capability-gated the
+ * same way RUN_AGENT is: with no KATA_ROUTER_URL the adapter is simply absent, so the
+ * built-in `run_code` tool (and a future CODE step) is unavailable rather than present
+ * and failing mid-run. Requires the host process's ServiceAccount to hold RBAC for
+ * sandboxclaims/sandboxes in the kata namespace — see the workflows deploy notes.
+ */
+const sandbox = config.kata.routerUrl ? new KataSandboxAdapter() : undefined;
+if (sandbox) {
+  logger.info('[workflows] sandbox adapter registered (kata microVM fleet)');
+} else {
+  logger.warn('[workflows] kata not configured — run_code / CODE sandbox will not be available');
+}
 const services = new ServiceRegistry();
 const steps = new StepRegistry();
 const triggers = new TriggerRegistry();
@@ -86,6 +101,7 @@ const executor = new WorkflowExecutor(persistence, steps, triggers, services, {
   eventBus,
   baseUrl: BASE_URL,
   storage,
+  sandbox,
   logger: sdkLogger,
 });
 
@@ -98,6 +114,7 @@ export const workflowRuntime = new WorkflowRuntime<Record<string, unknown>, Xyne
   triggers,
   executor,
   storage,
+  sandbox,
   eventBus,
   authorizer: new XyneWorkflowAuthorizer(),
   logger: sdkLogger,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
       '@types/yauzl':
         specifier: ^2.10.3
         version: 2.10.3
+      '@xyne/kata-sdk':
+        specifier: workspace:*
+        version: link:../../packages/kata-sdk
       '@xyne/shared':
         specifier: workspace:*
         version: link:../../packages/shared


### PR DESCRIPTION
## What
Implements `SandboxAdapter` — the `@xyne/workflow-sdk` code-execution seam — over the Kata microVM fleet via `@xyne/kata-sdk`, as the sibling of the existing `WorkflowStorageAdapter`. This lets the workflowsV2 built-in `run_code` agent tool (and a future deterministic `CODE` step) execute code in isolated sandboxes.

## Changes
- **`apps/backend/src/workflowsV2/adapters/sandbox.ts`** (new): `KataSandboxAdapter` maps the SDK's stateless, handle-based contract onto stateful kata `Session`s via an `id -> Session` registry.
  - `bash` → `session.commands.run` 1:1
  - `exec` writes code to a temp file and runs `python3` (kata has no code executor); a raise is surfaced through the structured `error` field
  - `writeFiles`/`readFile` → the kata filesystem module
  - `destroy` is idempotent
  - `artifacts` is always `[]` (kata has no output-dir concept)
- **`apps/backend/src/workflowsV2/runtime.ts`**: instantiates the adapter and threads it into `WorkflowExecutor` and `WorkflowRuntime`, capability-gated on `KATA_ROUTER_URL` (same pattern as `RUN_AGENT`) — absent config means the sandbox is simply unavailable, not present-and-failing.
- **`apps/backend/src/config/env.ts`**: adds `KATA_ROUTER_URL` / `KATA_NAMESPACE` (default `xyne-apps`) / `KATA_TEMPLATE` (default `kata-workspace-template`) and a `config.kata` block.
- **`apps/backend/package.json`**: adds `@xyne/kata-sdk` workspace dependency.

## Validation
- `pnpm typecheck` (backend) passes clean.

## Deploy note (not in this PR)
Enabling this in a deployed environment requires the host process's ServiceAccount to hold RBAC for `sandboxclaims`/`sandboxes` in the kata namespace, plus the `KATA_*` env vars. Without `KATA_ROUTER_URL` the adapter stays absent, so this change is inert until deploy config is added.

## Operational caveat
Cold start is slow and `createSession` self-throttles to ~1 SandboxClaim/10s (GCP snapshot rate limit). The SDK's per-step create→destroy lifecycle pays full cold-start each run; add session reuse if a hot path needs it.