### PR TITLE
fix: XYNE-63093 render DM add/remove system message names as plain text [release-20260904]

### DIFF
--- a/apps/backend/src/controllers/channelController.ts
+++ b/apps/backend/src/controllers/channelController.ts
@@ -141,19 +141,17 @@ export class ChannelController {
       // Names are user-supplied, so everything interpolated into the markup is escaped.
       const esc = (value: string): string =>
         value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-      const userPill = (userId: string, userName: string): string =>
-        `<span data-mention data-mention-type="user" data-user-id="${esc(userId)}" data-username="${esc(userName)}">${esc(userName)}</span>`;
       const channelPill = (id: string, label: string): string =>
         `<span data-channel-mention data-channel-id="${esc(id)}" data-channel-name="${esc(label)}" data-is-private="true">${esc(label)}</span>`;
 
-      const pills = newParticipants.map(p => userPill(p.userId, p.userName));
+      const names = newParticipants.map(p => esc(p.userName));
       let formattedUsers = '';
-      if (pills.length === 1) {
-        formattedUsers = pills[0];
-      } else if (pills.length > 1) {
-        formattedUsers = `${pills.slice(0, -1).join(', ')} and ${pills[pills.length - 1]}`;
+      if (names.length === 1) {
+        formattedUsers = names[0];
+      } else if (names.length > 1) {
+        formattedUsers = `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
       }
-      const actor = userPill(authData.id, authData.name);
+      const actor = esc(authData.name);
 
       const addedOrRemovedText = operationType === 'participants_added' ? 'added' : 'removed';
       let systemContent: string;
@@ -169,7 +167,7 @@ export class ChannelController {
       } else if (operationType === 'conversation_moved_target') {
         systemContent = `${actor} moved messages from a previous conversation into this one`;
       } else {
-        systemContent = `${formattedUsers} ${pills.length === 1 ? 'was' : 'were'} ${addedOrRemovedText} by ${actor}`;
+        systemContent = `${formattedUsers} ${names.length === 1 ? 'was' : 'were'} ${addedOrRemovedText} by ${actor}`;
       }
 
       // Create metadata


### PR DESCRIPTION
## Type of Change
Main: https://github.com/juspay/xyne-spaces/pull/1705
- [x] Bugfix

## Description

XYNE-63093. Backport of #1705 (main) — same commit, cherry-picked cleanly, no conflicts.

The "X was added by Y" system message in a DM/group DM renders the names as full-strength blue
mention pills inside an otherwise muted system line — reported in-app as "neither faded nor bold
fully".

Cause: #690 changed `ChannelController` to wrap the participant and actor names in
`<span data-mention …>` (`channelController.ts:144`). The dashboard renders any such span with
`className='mention-text'` (`RenderMessageWithHTML.tsx:321`), and `.mention-text` hard-codes
`--mention-bg` / `--mention-color` plus a `::before { content: "@" }` prefix
(`global.css:2100-2109`). None of that inherits the system line's muted colour, so the pills stay
blue and the names pick up a stray `@`. The channel-add path was never changed and still emits
plain names (`zero/utils/systemMessagesUtils.ts:39`), so the two paths disagree.

Fix: drop `userPill` and interpolate escaped plain names instead. The `esc()` helper #690 added is
kept, so the XSS hardening from that PR is unaffected. `channelPill` is left in place, so "moved
messages to #channel" keeps its channel link.

Not included: messages already written to the DB keep their pill markup and will still render as
blue pills. A backfill would be a separate change.

## Areas Touched

- [x] `apps/backend` (API / worker)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Static only — backend `typecheck` and `build` pass on the main-branch commit this was picked from
(run by the pre-commit hook there). Not manually exercised in a running app; the change is a
one-expression swap inside the system-message string builder with no behavioural branch. A
reviewer running it locally should confirm the rendered line reads "Name was added by Name" with
no pill styling and no `@`.

### Automated

- [x] Not covered by tests <!-- no existing test asserts on this string; none added -->

### Manual

- [ ] Not manually verified yet — see above.

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Backend `typecheck` + `build` pass
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] No debug logging or commented-out code left behind
- [ ] Dashboard checks — not applicable, no dashboard files changed
