### PR TITLE
feat: XYNE-63168 compact grid layout for multiple file attachments

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatList/ChatListV2.utils.ts
+++ b/apps/dashboard/src/components/Chat/ChatList/ChatListV2.utils.ts
@@ -6,6 +6,7 @@ import { CombinedMessageItem, shouldShowAvatar } from './ChatListUtils';
 import { MessageMetadata } from '../../ui/MessageBubble/MessageBubble.utils';
 import { MessageType, parseReactionsMd } from '@xyne/shared';
 import { getInitialMessageFromConversation } from '../../../utils/conversationMessageHelpers';
+import { isPreviewableDocument } from '../../../services/documentThumbnailService';
 
 type CombinedMesseges = {
   combinedMessages: CombinedMessageItem[];
@@ -39,6 +40,7 @@ const WITHOUT_AVATAR_PADDING = 16;
 const ATTACHMENT_CHROME = 16; // py-2 wrapper (8px top + 8px bottom)
 const MEDIA_CAP = 256; // Preview fixedHeight (desktop)
 const FILE_CARD_HEIGHT = 256; // h-64 container for non-image file attachments (estimator)
+const FILE_PILL_HEIGHT = 62;
 const ATTACHMENT_HEADER = 16; // single text-xs flex row, line-height ~16px
 
 // Video constraints (must match InlineVideoPlayer)
@@ -416,10 +418,18 @@ export function estimateMessageHeight(
         height += rowCount * (MEDIA_CAP + ATTACHMENT_CHROME);
       }
 
-      // Files (includes text/plain, PDFs, etc.): each on its own row.
-      // FilePills are in flex-col gap-2 (8px gap between each pill).
       if (files.length > 0) {
-        height += files.length * FILE_CARD_HEIGHT + (files.length - 1) * 8;
+        const singleFile = files.length === 1 ? files[0] : undefined;
+        const showsPreviewCard =
+          !!singleFile && isPreviewableDocument(singleFile.mimetype) && !!singleFile.thumbnailUrl;
+
+        if (showsPreviewCard) {
+          height += FILE_CARD_HEIGHT;
+        } else {
+          const pillsPerRow = isMobile ? 1 : 2;
+          const rows = Math.ceil(files.length / pillsPerRow);
+          height += rows * FILE_PILL_HEIGHT + (rows - 1) * 8;
+        }
       }
     }
   }

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -193,7 +193,10 @@ const AttachmentsBlock: React.FC<AttachmentsBlockProps> = ({
   const nonPreviewableFiles = fileAttachments.filter(a => !hasDocumentThumbnail(a));
 
   // Check if we need to use FilePill for all files (mixed types)
-  const useFilePillForAllFiles = nonPreviewableFiles.length > 0;
+  // Collapse to compact pills whenever there is more than one document file,
+  // so multiple Office/Excel/PDF files render as a clean grid instead of a row
+  // of large preview cards. A single file keeps its rich preview.
+  const useFilePillForAllFiles = nonPreviewableFiles.length > 0 || fileAttachments.length > 1;
 
   const handleFileClick = (attachment: AttachmentType) => {
     // Build attachment refs for the viewer (same order as rendered)
@@ -359,7 +362,7 @@ const AttachmentsBlock: React.FC<AttachmentsBlockProps> = ({
           {/* Non-previewable files - use FilePill component */}
           {/* If useFilePillForAllFiles is true, show ALL files in FilePill format */}
           {(useFilePillForAllFiles ? fileAttachments : nonPreviewableFiles).length > 0 && (
-            <div className='flex flex-col gap-2'>
+            <div className='grid grid-cols-1 sm:grid-cols-2 gap-2'>
               {(useFilePillForAllFiles ? fileAttachments : nonPreviewableFiles).map(attachment => (
                 <FilePill
                   key={attachment.id}

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -119,6 +119,8 @@ interface AttachmentsBlockProps {
   parentMessage?: AttachmentRef['parentMessage'];
 }
 
+const FILE_PILL_GRID_COLUMNS = 'repeat(auto-fill, minmax(min(240px, 100%), 1fr))';
+
 /**
  * Check if attachment has a document thumbnail (PDF with preview)
  */
@@ -193,9 +195,6 @@ const AttachmentsBlock: React.FC<AttachmentsBlockProps> = ({
   const nonPreviewableFiles = fileAttachments.filter(a => !hasDocumentThumbnail(a));
 
   // Check if we need to use FilePill for all files (mixed types)
-  // Collapse to compact pills whenever there is more than one document file,
-  // so multiple Office/Excel/PDF files render as a clean grid instead of a row
-  // of large preview cards. A single file keeps its rich preview.
   const useFilePillForAllFiles = nonPreviewableFiles.length > 0 || fileAttachments.length > 1;
 
   const handleFileClick = (attachment: AttachmentType) => {
@@ -362,13 +361,13 @@ const AttachmentsBlock: React.FC<AttachmentsBlockProps> = ({
           {/* Non-previewable files - use FilePill component */}
           {/* If useFilePillForAllFiles is true, show ALL files in FilePill format */}
           {(useFilePillForAllFiles ? fileAttachments : nonPreviewableFiles).length > 0 && (
-            <div className='grid grid-cols-1 sm:grid-cols-2 gap-2'>
+            <div className='grid gap-2' style={{ gridTemplateColumns: FILE_PILL_GRID_COLUMNS }}>
               {(useFilePillForAllFiles ? fileAttachments : nonPreviewableFiles).map(attachment => (
                 <FilePill
                   key={attachment.id}
+                  className='max-w-none'
                   fileName={attachment.originalFilename}
                   mimeType={attachment.mimetype}
-                  fileSize={attachment.size}
                   fileId={attachment.id}
                   uploadedByUserId={attachment.uploadedByUserId}
                   onClick={() => handleFileClick(attachment)}

--- a/apps/dashboard/src/components/ui/files/FilePill.tsx
+++ b/apps/dashboard/src/components/ui/files/FilePill.tsx
@@ -5,20 +5,18 @@
 // ============================================================================
 
 import React from 'react';
+import { X, Download, Trash2 } from 'lucide-react';
 import {
-  X,
-  Download,
-  FileText,
-  Image,
-  Video,
-  Music,
-  Archive,
+  Cube,
+  FileBarGraph,
   FileCode,
-  Trash2,
-} from 'lucide-react';
-// Lucide has no PDF-specific glyph, so PDFs used to fall back to the same
-// generic document sheet as Word/Excel/text. The design system ships one.
-import { FilePdfFormat } from '@xyne/icons';
+  FilePdfFormat,
+  FileText,
+  MusicQuaverNote,
+  PhotoImageDefault,
+  PresentationBargraph,
+  VideoRecording,
+} from '@xyne/icons';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { cn } from '../../../utils/classNames';
 import { useAuth } from '../../../hooks/useAuth';
@@ -77,7 +75,7 @@ const getFileTypeConfig = (mimeType: string, fileName: string): FileTypeConfig =
   // Images
   if (mimeType.startsWith('image/')) {
     return {
-      icon: Image,
+      icon: PhotoImageDefault,
       color: 'bg-blue-500',
       textColor: 'text-blue-500',
       label: 'Image',
@@ -87,7 +85,7 @@ const getFileTypeConfig = (mimeType: string, fileName: string): FileTypeConfig =
   // Videos
   if (mimeType.startsWith('video/')) {
     return {
-      icon: Video,
+      icon: VideoRecording,
       color: 'bg-purple-500',
       textColor: 'text-purple-500',
       label: 'Video',
@@ -97,7 +95,7 @@ const getFileTypeConfig = (mimeType: string, fileName: string): FileTypeConfig =
   // Audio
   if (mimeType.startsWith('audio/')) {
     return {
-      icon: Music,
+      icon: MusicQuaverNote,
       color: 'bg-green-500',
       textColor: 'text-green-500',
       label: 'Audio',
@@ -123,7 +121,7 @@ const getFileTypeConfig = (mimeType: string, fileName: string): FileTypeConfig =
       icon: FileText,
       color: 'bg-blue-600',
       textColor: 'text-blue-600',
-      label: 'Word',
+      label: 'Word Document',
     };
   }
 
@@ -134,10 +132,10 @@ const getFileTypeConfig = (mimeType: string, fileName: string): FileTypeConfig =
     mimeType === 'text/csv'
   ) {
     return {
-      icon: FileText,
+      icon: FileBarGraph,
       color: 'bg-green-600',
       textColor: 'text-green-600',
-      label: 'Excel',
+      label: 'Excel Spreadsheet',
     };
   }
 
@@ -147,10 +145,10 @@ const getFileTypeConfig = (mimeType: string, fileName: string): FileTypeConfig =
     mimeType === 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
   ) {
     return {
-      icon: FileText,
+      icon: PresentationBargraph,
       color: 'bg-orange-500',
       textColor: 'text-orange-500',
-      label: 'PowerPoint',
+      label: 'PowerPoint Presentation',
     };
   }
 
@@ -165,7 +163,7 @@ const getFileTypeConfig = (mimeType: string, fileName: string): FileTypeConfig =
     mimeType.includes('compressed')
   ) {
     return {
-      icon: Archive,
+      icon: Cube,
       color: 'bg-yellow-500',
       textColor: 'text-yellow-500',
       label: 'Archive',
@@ -251,9 +249,6 @@ export const FilePill: React.FC<FilePillProps> = ({
   // Check if current user can delete (owner or admin)
   const canDelete = uploadedByUserId && user?.id === uploadedByUserId;
 
-  // Truncate filename if too long
-  const displayName = fileName.length > 40 ? `${fileName.substring(0, 37)}...` : fileName;
-
   // Format size for display
   const sizeDisplay = formatFileSize(fileSize);
 
@@ -296,7 +291,7 @@ export const FilePill: React.FC<FilePillProps> = ({
       {/* File Info */}
       <div className='flex-1 min-w-0 flex flex-col gap-0.5'>
         <div className='text-sm font-medium text-foreground truncate' title={fileName}>
-          {displayName}
+          {fileName}
         </div>
         <div className='text-xs text-muted-foreground flex items-center gap-1'>
           <span>{typeLabel || config.label}</span>


### PR DESCRIPTION
Services-Requiring-Redeployment:

- dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-63168. Attaching several Excel/Office/PDF files produced a tall, cluttered attachment block — each document rendered as a large preview card, one per row. Messages with more than one document file now render as a compact, responsive grid of `FilePill` cards, matching the Slack layout that was requested.

<img width="1728" height="1117" alt="Screenshot 2026-09-10 at 1 11 24 PM" src="https://github.com/user-attachments/assets/83e0bff8-2355-44ed-949f-43ecdfea252f" />

**`MessageBubble.tsx` (`AttachmentsBlock`)**

- Widen the pill trigger: `useFilePillForAllFiles = nonPreviewableFiles.length > 0 || fileAttachments.length > 1` — collapse to pills whenever there is more than one document file.
- Pill container is an auto-fill grid (`repeat(auto-fill, minmax(min(240px, 100%), 1fr))`) so the column count follows the container width. Fixed breakpoint columns track the viewport, not the message pane, which changes width when the thread panel opens.
- Pills get `max-w-none` so they fill their grid track instead of stopping at the component's `max-w-[320px]`, which previously left a wide gap down the middle of the row.
- File size is no longer passed on message pills, so the subtitle is just the file type.

**`FilePill.tsx`**

- File-type icons now come from `@xyne/icons` rather than `lucide-react`. Word, Excel and PowerPoint previously shared one `FileText` glyph and differed only by background colour, so a wall of Office files was hard to scan.
- Fuller type labels: "Excel Spreadsheet", "Word Document", "PowerPoint Presentation".
- Dropped the 40-character JS filename truncation. The container already had `truncate` + `title`, so names were being cut twice; CSS alone lets a name use the card's real width.

**`ChatListV2.utils.ts`**

- Height estimate updated to match: pills are ~62px laid out in a grid, not 256px preview cards stacked one per row. A single document with a thumbnail still estimates as a tall preview card. Without this the virtualiser over-counts message height, which the file's own comments note causes scrollbar jumps and flicker.

**Unchanged:** single-file rich preview, images, videos, HTML preview cards, attachment ordering (`position`), the "Download all" header, and click-to-open in the shared attachment viewer. Mobile keeps its existing `MobileAttachmentsGrid` path.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Ran locally against the dev stack. Sent messages with 8 JSON files, and with a mixed set of 4 PDFs + an archive + 2 code files: both render as a packed grid that reflows with the pane width, and the same messages render correctly in the thread panel, which is narrower and so fits fewer columns. Confirmed the single-attachment path is unchanged.

Not yet verified: a message of several real `.xlsx` files, and scroll behaviour in a channel containing a many-file message (the height-estimate path).

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- no component-test harness exists in apps/dashboard: no *.test.tsx and no test script; dashboard coverage runs through Gauge -->

### Manual

**Users**
- [x] Single user

**Run mode**
- [x] Local dev (`pnpm run dev:all`)

**Surface & data**
- [x] Web browser
- [x] Large / realistic data volume <!-- 7- and 8-attachment messages -->

Dark theme only; light theme and narrow/mobile viewport not exercised.

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [x] Backend `typecheck` + `build` pass <!-- via CI -->
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind

## Known gaps

- **Mobile parity** — `MobileAttachmentsGrid.tsx` has no `FilePill` branch and still renders full-size cards. Unchanged by this PR (0 lines touched) and not a regression, but the two renderers now differ. Follow-up ticket to be raised.
- **Tests** — see the Automated note above; there is no dashboard component-test harness to add unit tests to.
