### PR TITLE
feat: XYNE-57690 rebuild radar Others as requested-by × teams and people

### DIFF
--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -3021,18 +3021,6 @@ export const executionRunLogTable = table("execution_run_logs")
   })
   .primaryKey("id");
 
-export const radarTeamTable = table("radar_teams")
-  .columns({
-    workspaceId: string(),
-    id: string(),
-    ownerId: string(),
-    name: string(),
-    memberIds: json<string[]>(),
-    createdAt: number(),
-    updatedAt: number(),
-  })
-  .primaryKey("id");
-
 
 // Define relationships
 
@@ -5228,7 +5216,6 @@ export const schema = createSchema(
       executionThreadStateTable,
       executionItemMutationTable,
       executionRunLogTable,
-      radarTeamTable,
     ],
     relationships: [
       agentTableRelationships,
@@ -5532,4 +5519,3 @@ export type ExecutionItem = Row<typeof schema.tables.execution_items>;
 export type ExecutionThreadState = Row<typeof schema.tables.execution_thread_states>;
 export type ExecutionItemMutation = Row<typeof schema.tables.execution_item_mutations>;
 export type ExecutionRunLog = Row<typeof schema.tables.execution_run_logs>;
-export type RadarTeam = Row<typeof schema.tables.radar_teams>;

--- a/apps/backend/prisma/migrations/20260909130000_drop_radar_teams/migration.sql
+++ b/apps/backend/prisma/migrations/20260909130000_drop_radar_teams/migration.sql
@@ -1,0 +1,5 @@
+-- Radar teams move to the browser. A team is one viewer's private shorthand
+-- for a set of people used to filter their own feed; it never needed a row
+-- everyone's queries had to carry. The server-side lens that justified the
+-- table was removed in #1570 and nothing has written here since.
+DROP TABLE IF EXISTS "non_zero"."radar_teams";

--- a/apps/backend/prisma/migrations/20260910120000_execution_items_workspace_open_updated_idx/migration.sql
+++ b/apps/backend/prisma/migrations/20260910120000_execution_items_workspace_open_updated_idx/migration.sql
@@ -1,0 +1,11 @@
+-- CreateIndex
+-- The Pending Others feed is the first execution_items read with no positive
+-- GIN predicate to drive off: its array conditions are a negation and an
+-- emptiness test, which GIN cannot serve, and its channel scope is a relation
+-- filter probed per row rather than a leading predicate. Without this the
+-- planner sequentially scans the table and top-N sorts by updatedAt on every
+-- Radar mount and tab refocus; with it the ORDER BY updatedAt DESC LIMIT walks
+-- the index in order and stops.
+-- CONCURRENTLY: the table is read on the message write path via the parse queue.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "execution_items_workspaceId_status_updatedAt_idx"
+  ON "non_zero"."execution_items" ("workspaceId", "status", "updatedAt" DESC);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -4787,7 +4787,10 @@ model ExecutionItem {
   workspaceId     String // denormalized tenant key (stamped on insert)
   id              String    @id @default(cuid())
   conversationId  String // thread this item lives in (no FK constraint)
-  channelId       String // denormalized for ACL joins (no FK constraint)
+  // Denormalized for ACL joins (no FK constraint). Kept in step with the
+  // conversation: reparenting rewrites it in the same transaction that moves
+  // the thread, so a feed may scope on it directly.
+  channelId       String
   sourceMessageId String // message that created the ask; >1 item per source = split
   title           String
   contextSummary  String?
@@ -4798,14 +4801,18 @@ model ExecutionItem {
   updatedAt       DateTime  @updatedAt
   resolvedAt      DateTime?
 
-  // Only indexes an actual query drives off. workspaceId is never the selective
-  // predicate here — every read pairs it with a GIN array match, a
-  // conversationId, or an id, so the planner drives off that and applies
-  // workspaceId as a filter. Leading with it produced write cost for nothing.
+  // Only indexes an actual query drives off. Most reads pair workspaceId with
+  // a GIN array match, a conversationId, or an id, so the planner drives off
+  // that and applies workspaceId as a filter. The one exception is the Pending
+  // Others feed: its array predicates are a negation and an emptiness test
+  // that GIN cannot serve, so nothing narrows it before the ORDER BY. The last
+  // index below lets that walk updatedAt in order and stop at the limit rather
+  // than sorting everything the channel scope leaves standing.
   @@index([conversationId, status]) // gate: tracked-thread check + resolve-all
   @@index([channelId, status]) // DM scope: open items, debug, bulk actions
   @@index([pendingOn], type: Gin) // feed: Pending Me membership
   @@index([requestedBy], type: Gin) // feed: Waiting On membership
+  @@index([workspaceId, status, updatedAt(sort: Desc)]) // feed: Pending Others ordering
   @@map("execution_items")
   @@schema("non_zero")
 }
@@ -4888,20 +4895,3 @@ model ExecutionRunLog {
   @@schema("non_zero")
 }
 
-// Radar execution engine: viewer-defined team lenses. A team is a personal,
-// named set of users; the team feed shows open items involving those members,
-// filtered by the VIEWER's channel access (DMs / private channels the viewer
-// is not in stay invisible — the lens never widens ACL).
-model RadarTeam {
-  workspaceId String // denormalized tenant key (stamped on insert)
-  id          String   @id @default(cuid())
-  ownerId     String // creator — teams are private to the viewer who made them
-  name        String
-  memberIds   String[] @default([])
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-
-  @@index([workspaceId, ownerId])
-  @@map("radar_teams")
-  @@schema("non_zero")
-}

--- a/apps/backend/src/database/acl/acl-factory.ts
+++ b/apps/backend/src/database/acl/acl-factory.ts
@@ -186,8 +186,6 @@ export class ACLFactory {
       return new BaseQueryACL(ctx, prisma)
     case 'executionRunLog':
       return new BaseQueryACL(ctx, prisma)
-    case 'radarTeam':
-      return new BaseQueryACL(ctx, prisma)
     case 'channel':
       return new ChannelsACL(ctx, prisma)
     case 'channelBoardMapping':

--- a/apps/backend/src/routes/radarExecution.ts
+++ b/apps/backend/src/routes/radarExecution.ts
@@ -5,11 +5,16 @@ import { radarFeedService } from '@/services/radar/radarFeedService';
 
 const router = Router();
 
-function getAuthContext(req: Request): { userId: string; workspaceId: string } | null {
+function getAuthContext(
+  req: Request
+): { userId: string; workspaceId: string; role: string } | null {
   const userId = req.user?.id;
   const workspaceId = req.user?.workspaceId;
-  if (!userId || !workspaceId) return null;
-  return { userId, workspaceId };
+  const role = req.user?.role;
+  // Guests are limited to explicit grants, so a request with no role resolved
+  // is refused rather than evaluated under the member rule.
+  if (!userId || !workspaceId || !role) return null;
+  return { userId, workspaceId, role };
 }
 
 function sendUnauthorized(res: Response): void {
@@ -80,7 +85,7 @@ router.post(
       logger.error('[radar-execution] dismiss-all failed:', err);
       res.status(500).json({ success: false, error: 'Failed to dismiss thread items' });
     }
-  },
+  }
 );
 
 // The param is a SCOPE key, not always a conversation id: a DM card covers its
@@ -104,7 +109,7 @@ router.post(
       logger.error('[radar-execution] resolve-all failed:', err);
       res.status(500).json({ success: false, error: 'Failed to resolve thread items' });
     }
-  },
+  }
 );
 
 router.get('/feed/pending-me', async (req: Request, res: Response) => {
@@ -178,6 +183,21 @@ router.get('/feed/waiting-on', async (req: Request, res: Response) => {
     res.json({ success: true, data: { threads } });
   } catch (err) {
     logger.error('[radar-execution] waiting-on feed failed:', err);
+    res.status(500).json({ success: false, error: 'Failed to load feed' });
+  }
+});
+
+router.get('/feed/pending-others', async (req: Request, res: Response) => {
+  try {
+    const auth = getAuthContext(req);
+    if (!auth) {
+      sendUnauthorized(res);
+      return;
+    }
+    const threads = await radarFeedService.pendingOthers(auth);
+    res.json({ success: true, data: { threads } });
+  } catch (err) {
+    logger.error('[radar-execution] pending-others feed failed:', err);
     res.status(500).json({ success: false, error: 'Failed to load feed' });
   }
 });

--- a/apps/backend/src/services/radar/radarAcl.ts
+++ b/apps/backend/src/services/radar/radarAcl.ts
@@ -1,11 +1,21 @@
 import { DatabaseClient } from '@/database/client';
 import { repositories } from '@/database/repositories';
+import { ChannelsACL } from '@/database/acl/tables/channels-acl';
+import {
+  getGuestAccessibleChannelIds,
+  isGuestContext,
+} from '@/database/acl/tables/channel-access-helper';
 
 const prisma = DatabaseClient.getInstance();
 
-interface AclAuth {
+/** Structurally an ACLContext, so radar can hand it straight to ChannelsACL. */
+export interface AclAuth {
   userId: string;
   workspaceId: string;
+  /** Workspace role. A GUEST sees only channels explicitly granted to them, so
+   *  this is required: a caller that omits it would silently evaluate a guest
+   *  under the member rule. */
+  role: string;
 }
 
 export interface ChannelAccess {
@@ -14,9 +24,9 @@ export interface ChannelAccess {
 }
 
 /**
- * Radar is gated by the app's own conversation-access rule (see
- * websocketService.canAccessConversation): workspace match fail-closed, then
- * the parent channel's ACL. Being named on an item never widens access.
+ * Radar is gated by the app's own channel rule (ChannelsACL): workspace match
+ * fail-closed, then PUBLIC or participant for a member, explicit grants for a
+ * guest. Being named on an item never widens access.
  *
  * Stricter in one respect: visibility is an ALLOW-list. `Channel.visibility`
  * is an unconstrained String, so a future value must fail CLOSED — Radar puts
@@ -25,9 +35,25 @@ export interface ChannelAccess {
  */
 const PUBLIC_VISIBILITY = 'PUBLIC';
 
+/**
+ * The channel read rule as a list of ids, for scoping a feed query up front —
+ * a leading, indexable predicate where a relation filter through each item's
+ * conversation would be probed per row.
+ *
+ * The rule itself is ChannelsACL's, not a second copy: radar must not drift
+ * from what the sync layer says a viewer may open.
+ */
+export async function viewerAccessibleChannelIds(auth: AclAuth): Promise<string[]> {
+  const channels = await prisma.channel.findMany({
+    where: await new ChannelsACL(auth, prisma).getWhereClause(),
+    select: { id: true },
+  });
+  return channels.map((c) => c.id);
+}
+
 export async function canAccessConversation(
   auth: AclAuth,
-  conversationId: string,
+  conversationId: string
 ): Promise<boolean> {
   if (!conversationId) return false;
   const conversation = await repositories.conversations.findById(conversationId);
@@ -44,7 +70,11 @@ export async function canAccessChannel(auth: AclAuth, channelId: string): Promis
   if (!channelId) return false;
   const channel = await repositories.channels.findById(channelId);
   if (!channel) return false;
-  if (channel.workspaceId && channel.workspaceId !== auth.workspaceId) return false;
+  if (channel.workspaceId !== auth.workspaceId) return false;
+  if (isGuestContext(auth)) {
+    const ids = await getGuestAccessibleChannelIds(prisma, auth.workspaceId, auth.userId);
+    return ids.includes(channelId);
+  }
   if (channel.visibility === PUBLIC_VISIBILITY) return true;
   return repositories.channelParticipants.isParticipant(channelId, auth.userId);
 }
@@ -53,6 +83,9 @@ export async function canAccessChannel(auth: AclAuth, channelId: string): Promis
 export async function viewerChannelAccess(
   auth: AclAuth,
   channelIds: string[],
+  /** Guest grants the caller has already resolved. Without this a guest feed
+   *  runs the grant lookup twice per request, in series. */
+  grantedChannelIds?: string[]
 ): Promise<Map<string, ChannelAccess>> {
   const unique = [...new Set(channelIds)];
   if (unique.length === 0) return new Map();
@@ -60,21 +93,36 @@ export async function viewerChannelAccess(
     where: { id: { in: unique } },
     select: { id: true, workspaceId: true, visibility: true },
   });
+  if (isGuestContext(auth)) {
+    const granted = new Set(
+      grantedChannelIds ??
+        (await getGuestAccessibleChannelIds(prisma, auth.workspaceId, auth.userId))
+    );
+    return new Map(
+      channels.map((c) => [
+        c.id,
+        {
+          allowed: c.workspaceId === auth.workspaceId && granted.has(c.id),
+          visibility: c.visibility,
+        },
+      ])
+    );
+  }
   // Membership unlocks everything that is not PUBLIC, not just 'PRIVATE'.
-  const gatedIds = channels.filter(c => c.visibility !== PUBLIC_VISIBILITY).map(c => c.id);
+  const gatedIds = channels.filter((c) => c.visibility !== PUBLIC_VISIBILITY).map((c) => c.id);
   const memberships = gatedIds.length
     ? await prisma.channelParticipant.findMany({
         where: { channelId: { in: gatedIds }, userId: auth.userId },
         select: { channelId: true },
       })
     : [];
-  const memberOf = new Set(memberships.map(m => m.channelId));
+  const memberOf = new Set(memberships.map((m) => m.channelId));
   return new Map(
-    channels.map(c => {
-      const inWorkspace = !c.workspaceId || c.workspaceId === auth.workspaceId;
+    channels.map((c) => {
       const allowed =
-        inWorkspace && (c.visibility === PUBLIC_VISIBILITY || memberOf.has(c.id));
+        c.workspaceId === auth.workspaceId &&
+        (c.visibility === PUBLIC_VISIBILITY || memberOf.has(c.id));
       return [c.id, { allowed, visibility: c.visibility }];
-    }),
+    })
   );
 }

--- a/apps/backend/src/services/radar/radarFeedService.ts
+++ b/apps/backend/src/services/radar/radarFeedService.ts
@@ -1,5 +1,9 @@
 import { DatabaseClient } from '@/database/client';
-import { canAccessConversation, viewerChannelAccess } from '@/services/radar/radarAcl';
+import {
+  canAccessConversation,
+  viewerAccessibleChannelIds,
+  viewerChannelAccess,
+} from '@/services/radar/radarAcl';
 import { radarScopeFor, scopeKeyFor, type RadarScope } from '@/services/radar/radarScope';
 
 const prisma = DatabaseClient.getInstance();
@@ -13,11 +17,17 @@ const THREAD_PREVIEW_CHARS = 200;
 const MAX_DEBUG_RUNS = 50;
 
 const stripHtml = (html: string): string =>
-  html.replace(/<[^>]*>/g, ' ').replace(/&nbsp;/g, ' ').replace(/\s+/g, ' ').trim();
+  html
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
 
 interface AuthContext {
   userId: string;
   workspaceId: string;
+  /** Required: the ACL needs it to tell a guest from a member. */
+  role: string;
 }
 
 export interface FeedItem {
@@ -60,11 +70,13 @@ export interface FeedThreadCard {
 }
 
 /**
- * The two GIN-backed reads the engine exists to serve:
+ * The GIN-backed reads the engine exists to serve:
  *
  * - Pending Me: pendingOn ∋ me.
  * - Waiting On: requestedBy ∋ me, minus items I also hold. An ownerless item
  *   (pendingOn: []) stays here — tracked, nobody on the hook yet.
+ * - Pending Others: held by someone who is not me, whoever asked — plus my
+ *   own ownerless asks, so it is a superset of Waiting On.
  */
 class RadarFeedService {
   async pendingMe(auth: AuthContext): Promise<FeedThreadCard[]> {
@@ -79,6 +91,50 @@ class RadarFeedService {
   }
 
   /**
+   * Where Waiting On answers "what have I chased", this answers "what is this
+   * team holding" — every open item held by someone else, whoever asked, plus
+   * the viewer's own asks that nobody holds yet, since this is the only feed
+   * fetched in All mode and an ownerless ask is still the viewer's.
+   *
+   * It covers Waiting On only while the workspace fits inside the cap. This
+   * scan is workspace-wide and capped at MAX_FEED_ITEMS by recency, where the
+   * other two are GIN-scoped to the viewer and so are effectively unbounded
+   * for one person. Past that, an old ownerless ask of the viewer's is visible
+   * under "requested by me" and missing here, and a team narrows only what
+   * reached the workspace-wide window — silently, with nothing saying the feed
+   * was truncated.
+   *
+   * The other feeds name the viewer in a GIN predicate, so their scan window
+   * is about the viewer by construction. This one is not, so the viewer's
+   * channel rule goes into the WHERE as a channel id list — a leading
+   * predicate the (channelId, status) index can drive off, which a relation
+   * filter through each item's conversation could not. The bound has to be
+   * there at all because the scan is capped: a row dropped by the cap can
+   * never be put back by the check that runs after it.
+   *
+   * item.channelId is safe to scope on: reparenting a thread rewrites it in
+   * the same transaction that moves the conversation. The Jira migration is
+   * the one path that moves a conversation without it, so an item it touched
+   * could be missed here — never wrongly shown, since viewerChannelAccess
+   * still resolves through the conversation afterwards.
+   *
+   * An item the viewer stepped away from that a colleague still holds belongs
+   * here: Dismiss changes who is on the hook, not what the viewer may see.
+   */
+  async pendingOthers(auth: AuthContext): Promise<FeedThreadCard[]> {
+    const scoped = await viewerAccessibleChannelIds(auth);
+    return this.buildFeed(
+      auth,
+      {
+        channelId: { in: scoped },
+        NOT: { pendingOn: { has: auth.userId } },
+        OR: [{ pendingOn: { isEmpty: false } }, { requestedBy: { has: auth.userId } }],
+      },
+      scoped
+    );
+  }
+
+  /**
    * Read items, narrow to what the viewer may open, group into thread cards.
    *
    * The conversation rows are fetched ONCE and threaded through both halves:
@@ -89,11 +145,17 @@ class RadarFeedService {
   private async buildFeed(
     auth: AuthContext,
     filter: Record<string, unknown>,
+    /** Channel ids the caller already resolved for the scan bound, so the
+     *  post-query check does not repeat the lookup. */
+    scopedChannelIds?: string[]
   ): Promise<FeedThreadCard[]> {
     const items = await this.openItems(auth, filter);
     if (items.length === 0) return [];
-    const conversations = await this.conversationsFor(items.map(i => i.conversationId));
-    return this.groupByThread(await this.aclFilter(auth, items, conversations), conversations);
+    const conversations = await this.conversationsFor(items.map((i) => i.conversationId));
+    return this.groupByThread(
+      await this.aclFilter(auth, items, conversations, scopedChannelIds),
+      conversations
+    );
   }
 
   /**
@@ -105,6 +167,7 @@ class RadarFeedService {
     auth: AuthContext,
     items: FeedItem[],
     conversations: Map<string, FeedConversation>,
+    scopedChannelIds?: string[]
   ): Promise<FeedItem[]> {
     if (items.length === 0) return items;
     // Resolve each item's channel from its conversation rather than trusting
@@ -112,10 +175,11 @@ class RadarFeedService {
     // item whose conversation has since vanished is denied.
     const access = await viewerChannelAccess(
       auth,
-      [...conversations.values()].map(c => c.channelId),
+      [...conversations.values()].map((c) => c.channelId),
+      scopedChannelIds
     );
     return items
-      .filter(i => {
+      .filter((i) => {
         const channelId = conversations.get(i.conversationId)?.channelId;
         return channelId ? access.get(channelId)?.allowed : false;
       })
@@ -128,7 +192,7 @@ class RadarFeedService {
    * stamp the cards render.
    */
   private async conversationsFor(
-    conversationIds: string[],
+    conversationIds: string[]
   ): Promise<Map<string, FeedConversation>> {
     const unique = [...new Set(conversationIds)];
     if (unique.length === 0) return new Map();
@@ -143,10 +207,10 @@ class RadarFeedService {
       },
     });
     return new Map(
-      conversations.map(c => [
+      conversations.map((c) => [
         c.conversationId,
         { ...c, scopeType: c.channel?.scopeType ?? null },
-      ]),
+      ])
     );
   }
 
@@ -164,7 +228,7 @@ class RadarFeedService {
     return radarScopeFor(
       conversation.channel?.scopeType ?? null,
       conversation.channelId,
-      conversationId,
+      conversationId
     );
   }
 
@@ -187,9 +251,9 @@ class RadarFeedService {
 
     const messageIds = [
       ...new Set(
-        [item.sourceMessageId, ...mutations.map(m => m.sourceMessageId)].filter(
-          (id): id is string => !!id,
-        ),
+        [item.sourceMessageId, ...mutations.map((m) => m.sourceMessageId)].filter(
+          (id): id is string => !!id
+        )
       ),
     ];
     const messages = messageIds.length
@@ -205,7 +269,7 @@ class RadarFeedService {
         })
       : [];
     const sourceMessages = Object.fromEntries(
-      messages.map(m => [
+      messages.map((m) => [
         m.messageId,
         {
           senderId: m.senderId,
@@ -213,7 +277,7 @@ class RadarFeedService {
           text: stripHtml(m.content).slice(0, 300),
           createdAt: m.createdAt,
         },
-      ]),
+      ])
     );
 
     const itemScope = await this.scopeOf(item.conversationId);
@@ -286,9 +350,7 @@ class RadarFeedService {
       // lookup by thread id can render the full trail set.
       prisma.executionItem.findMany({
         where: {
-          ...(scope?.isDmChannel
-            ? { channelId: scope.channelId }
-            : { conversationId }),
+          ...(scope?.isDmChannel ? { channelId: scope.channelId } : { conversationId }),
           workspaceId: auth.workspaceId,
         },
         orderBy: { createdAt: 'asc' },
@@ -307,7 +369,7 @@ class RadarFeedService {
       : null;
 
     const asPreview = (
-      m: { messageId: string; createdAt: Date; senderId: string | null; content: string } | null,
+      m: { messageId: string; createdAt: Date; senderId: string | null; content: string } | null
     ) =>
       m && {
         messageId: m.messageId,
@@ -351,7 +413,7 @@ class RadarFeedService {
 
   private groupByThread(
     items: FeedItem[],
-    conversations: Map<string, FeedConversation>,
+    conversations: Map<string, FeedConversation>
   ): FeedThreadCard[] {
     if (items.length === 0) return [];
 
@@ -394,7 +456,7 @@ class RadarFeedService {
     // Newest thread activity first; items inside a card are already
     // updatedAt-desc from the query.
     return [...cards.values()].sort(
-      (a, b) => (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0),
+      (a, b) => (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0)
     );
   }
 }

--- a/apps/backend/src/services/radar/radarManualActions.ts
+++ b/apps/backend/src/services/radar/radarManualActions.ts
@@ -17,7 +17,7 @@ const MAX_RESOLVE_ALL_ITEMS = 200;
 export class RadarActionError extends Error {
   constructor(
     public code: 'not-found' | 'bad-request' | 'forbidden',
-    message: string,
+    message: string
   ) {
     super(message);
     this.name = 'RadarActionError';
@@ -27,6 +27,8 @@ export class RadarActionError extends Error {
 interface AuthContext {
   userId: string;
   workspaceId: string;
+  /** Required: the ACL needs it to tell a guest from a member. */
+  role: string;
 }
 
 /**
@@ -45,10 +47,7 @@ class RadarManualActionsService {
     // Either side may close it — the assignee finished it, or the requester
     // withdrew it. A bystander may not.
     if (!item.requestedBy.includes(auth.userId) && !item.pendingOn.includes(auth.userId)) {
-      throw new RadarActionError(
-        'forbidden',
-        'Only someone involved in this item can resolve it',
-      );
+      throw new RadarActionError('forbidden', 'Only someone involved in this item can resolve it');
     }
     const { scope } = await this.resolveScope(auth, item.conversationId);
     return this.applyManual(auth, item.conversationId, scope, [
@@ -86,7 +85,7 @@ class RadarManualActionsService {
       auth,
       conversationId,
       scope,
-      items.map(i => ({ op: 'dismiss' as const, itemId: i.id, conversationId: i.conversationId })),
+      items.map((i) => ({ op: 'dismiss' as const, itemId: i.id, conversationId: i.conversationId }))
     );
   }
 
@@ -113,7 +112,7 @@ class RadarManualActionsService {
       auth,
       conversationId,
       scope,
-      items.map(i => ({ op: 'resolve' as const, itemId: i.id, conversationId: i.conversationId })),
+      items.map((i) => ({ op: 'resolve' as const, itemId: i.id, conversationId: i.conversationId }))
     );
   }
 
@@ -172,7 +171,7 @@ class RadarManualActionsService {
       scope: radarScopeFor(
         conversation?.channel?.scopeType ?? null,
         conversation?.channelId ?? '',
-        scopeKey,
+        scopeKey
       ),
     };
   }
@@ -208,7 +207,7 @@ class RadarManualActionsService {
     auth: AuthContext,
     conversationId: string,
     scope: RadarScope,
-    operations: Array<Omit<ApplyOperation, 'sourceMessageId'>>,
+    operations: Array<Omit<ApplyOperation, 'sourceMessageId'>>
   ) {
     // Under thread scope the watermark is slammed to the thread's latest
     // message, so the parser cannot re-litigate from a stale window.
@@ -238,7 +237,7 @@ class RadarManualActionsService {
       conversationId,
       scope,
       // A CTA acts "as of" the latest message — recorded as its source in audit.
-      operations: operations.map(op => ({
+      operations: operations.map((op) => ({
         ...op,
         sourceMessageId: watermark?.messageId ?? '',
       })) as ApplyOperation[],

--- a/apps/dashboard/src/api/radarApi.ts
+++ b/apps/dashboard/src/api/radarApi.ts
@@ -71,6 +71,15 @@ export function fetchRadarWaitingOn(): Promise<RadarThreadCard[]> {
   ).then(d => d.threads);
 }
 
+/** Open items held by anyone but the viewer, whoever asked — the "All" half of
+ *  the Others filter. Waiting On is the same feed narrowed to the viewer's own
+ *  asks, so the two are never fetched together. */
+export function fetchRadarPendingOthers(): Promise<RadarThreadCard[]> {
+  return unwrap(
+    apiInstance.get<SuccessEnvelope<{ threads: RadarThreadCard[] }>>('/radar/feed/pending-others'),
+  ).then(d => d.threads);
+}
+
 export interface RadarItemMutation {
   id: string;
   itemId: string;

--- a/apps/dashboard/src/components/RadarPanel/RadarPanel.tsx
+++ b/apps/dashboard/src/components/RadarPanel/RadarPanel.tsx
@@ -29,6 +29,7 @@ import {
   fetchRadarDebugRuns,
   fetchRadarItemTrail,
   fetchRadarPendingMe,
+  fetchRadarPendingOthers,
   fetchRadarWaitingOn,
   dismissAllRadarItems,
   dismissRadarItem,
@@ -44,38 +45,23 @@ import { ChannelScopeType } from '@xyne/shared';
 import { useAuth } from '../../hooks/useAuth';
 import { useRadarEnabled } from '../../hooks/radarCacConfig';
 import { usePersistedRadarFilters } from '../../hooks/usePersistedRadarFilters';
-import { useUsersById } from '../../hooks/useUsers';
+import {
+  MAX_TEAM_MEMBERS,
+  usePersistedRadarTeams,
+  type RadarTeam,
+} from '../../hooks/usePersistedRadarTeams';
+import { useActiveUsers, useUsersById } from '../../hooks/useUsers';
 import { useAllChannels } from '../../hooks/useChannels';
 import { cn } from '../../utils/classNames';
+import { getUserDisplayName, matchesUserQuery } from '../../utils/userDisplayName';
+import { Dialog } from '../ui/Dialog/Dialog';
+import Avatar from '../ui/Avatar/Avatar';
 import { Tooltip } from '../ui/Tooltip';
 
 type RadarTab = 'all' | 'pending' | 'waiting';
 
-const AVATAR_COLORS = [
-  'bg-sky-600',
-  'bg-violet-600',
-  'bg-amber-600',
-  'bg-emerald-600',
-  'bg-rose-500',
-  'bg-indigo-600',
-] as const;
-
 /** Avatars rendered before the stack collapses into a +N chip. */
 const AVATARS_SHOWN = 3;
-
-const colorFor = (id: string): string => {
-  let h = 0;
-  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
-  return AVATAR_COLORS[h % AVATAR_COLORS.length] ?? AVATAR_COLORS[0];
-};
-
-const initialsOf = (name: string): string =>
-  name
-    .split(/\s+/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map(w => w[0]?.toUpperCase() ?? '')
-    .join('');
 
 /**
  * Radar — the execution feed. Card-based views over the open-item ledger:
@@ -92,6 +78,7 @@ const RadarPanel = (): ReactElement => {
   const radarEnabled = useRadarEnabled(user?.email);
   const params = useParams<{ channelId?: string; conversationId?: string }>();
   const usersById = useUsersById();
+  const activeUsers = useActiveUsers();
   const channels = useAllChannels();
   const [pending, setPending] = useState<RadarThreadCard[]>([]);
   const [waiting, setWaiting] = useState<RadarThreadCard[]>([]);
@@ -123,8 +110,12 @@ const RadarPanel = (): ReactElement => {
     setPendingOthers,
     pendingUsers,
     setPendingUsers,
-    requestedByUsers,
-    setRequestedByUsers,
+    teamIds,
+    setTeamIds,
+    othersMode,
+    setOthersMode,
+    excludedRequesters,
+    setExcludedRequesters,
     filterChannels,
     setFilterChannels,
     timeRange,
@@ -135,6 +126,23 @@ const RadarPanel = (): ReactElement => {
     setCustomTo,
     clearAllFilters,
   } = usePersistedRadarFilters(user?.id);
+  const { teams, createTeam, updateTeam, deleteTeam } = usePersistedRadarTeams(user?.id);
+  // The manage-teams dialog is transient: which team is being edited and the
+  // half-typed draft describe the dialog, not the feed, so none of it persists.
+  const [manageTeams, setManageTeams] = useState(false);
+  const [teamDraft, setTeamDraft] = useState<{
+    id: string | null;
+    name: string;
+    memberIds: Set<string>;
+  } | null>(null);
+  const [memberSearch, setMemberSearch] = useState('');
+  // Radix restores focus to its own trigger on close; this dialog has none,
+  // so the opener is remembered here and given focus back by hand.
+  const manageTeamsOpenerRef = useRef<HTMLButtonElement>(null);
+  // Requested by defaults to the reading almost everyone wants, so it opens
+  // shut: the header carries the current choice, and only someone who wants
+  // the other one has to open it.
+  const [requestedByOpen, setRequestedByOpen] = useState(false);
   const [requesterSearch, setRequesterSearch] = useState('');
   const [holderSearch, setHolderSearch] = useState('');
   const [channelSearch, setChannelSearch] = useState('');
@@ -199,28 +207,40 @@ const RadarPanel = (): ReactElement => {
   // — which can be team A's. Only the newest request may touch state.
   const requestSeq = useRef(0);
 
-  const load = useCallback(async (background = false) => {
-    const seq = ++requestSeq.current;
-    const isCurrent = (): boolean => seq === requestSeq.current;
-    if (!background) setLoading(true);
-    try {
-      const [p, w] = await Promise.all([fetchRadarPendingMe(), fetchRadarWaitingOn()]);
-      if (!isCurrent()) return;
-      setPending(p);
-      setWaiting(w);
-    } catch {
-      if (!background && isCurrent()) {
-        setPending([]);
-        setWaiting([]);
+  const load = useCallback(
+    async (background = false) => {
+      const seq = ++requestSeq.current;
+      const isCurrent = (): boolean => seq === requestSeq.current;
+      if (!background) setLoading(true);
+      try {
+        // Others is two different reads, not one filtered two ways: "requested
+        // by me" is the viewer's own asks, "all" is everything anyone else is
+        // holding. Fetching the wrong one and narrowing it client-side would
+        // silently cap the feed at whatever the other query returned.
+        // Both halves, always. Skipping the unticked one saves a scan but
+        // makes Me and Others fetch-scoped: ticking either would blank the
+        // list to a spinner and re-download what was already in memory, when
+        // it used to be a client-side view switch over feeds already held.
+        const [p, w] = await Promise.all([
+          fetchRadarPendingMe(),
+          othersMode === 'all' ? fetchRadarPendingOthers() : fetchRadarWaitingOn(),
+        ]);
+        if (!isCurrent()) return;
+        setPending(p);
+        setWaiting(w);
+      } catch {
+        if (!background && isCurrent()) {
+          setPending([]);
+          setWaiting([]);
+        }
+      } finally {
+        if (!background && isCurrent()) setLoading(false);
       }
-    } finally {
-      if (!background && isCurrent()) setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!radarEnabled) return;
-  }, [radarEnabled]);
+    },
+    // othersMode alone: it picks which endpoint Others reads. The tick states
+    // only choose what is rendered from what is already here.
+    [othersMode],
+  );
 
   useEffect(() => {
     if (!radarEnabled) return;
@@ -487,15 +507,12 @@ const RadarPanel = (): ReactElement => {
             aria-label={`Involved: ${involvedNames}`}
           >
             {involved.slice(0, AVATARS_SHOWN).map(id => (
-              <span
+              <Avatar
                 key={id}
-                className={cn(
-                  'size-6 rounded-full text-white text-[10px] font-bold flex items-center justify-center ring-2 ring-card',
-                  colorFor(id),
-                )}
-              >
-                {initialsOf(nameOf(id))}
-              </span>
+                userId={id}
+                size='sm'
+                className='shrink-0 rounded-lg ring-2 ring-card'
+              />
             ))}
             {involved.length > AVATARS_SHOWN && (
               <span className='size-6 rounded-full bg-muted text-muted-foreground text-[10px] font-bold flex items-center justify-center ring-2 ring-card'>
@@ -631,6 +648,55 @@ const RadarPanel = (): ReactElement => {
   // Neither box ticked reads the same as both: no narrowing.
   const tab: RadarTab = pendingMe === pendingOthers ? 'all' : pendingMe ? 'pending' : 'waiting';
 
+  // Each half is narrowed on its own feed before the two are merged. The
+  // requester picker describes who has asked ME, the holder picker describes
+  // who is holding THEIR items, and neither has anything to say about the
+  // other half's cards — filtering after the merge needed a guard on every
+  // predicate to keep it from eating the other feed. The facets are drawn from
+  // the raw feeds for the same reason, plus anything already ticked, so a name
+  // that drops out of a refetched feed stays on screen to untick.
+  // Anything excluded stays listed even when the user store has no row for it
+  // — a deleted account, or an id from another workspace. It renders as
+  // "Someone", which is worth more than an exclusion that hides cards with
+  // nothing on screen to switch it back off.
+  const requesterOptions = [
+    ...new Set([
+      ...pending.flatMap(c => c.items.flatMap(i => i.requestedBy)).filter(id => usersById.has(id)),
+      ...excludedRequesters,
+    ]),
+  ];
+  const otherHolders = [
+    ...new Set([...waiting.flatMap(c => c.items.flatMap(i => i.pendingOn)), ...pendingUsers]),
+  ].filter(id => id !== selfId && usersById.has(id));
+
+  // Requesters are excluded, never included: "everyone but Bob" has to keep
+  // meaning everyone as new people ask, which a stored list of who is in can
+  // never do. An item with no requester on record is nobody's to exclude.
+  const pendingCards =
+    pendingMe && excludedRequesters.size
+      ? pending.filter(card =>
+          card.items.some(
+            i =>
+              i.requestedBy.length === 0 || i.requestedBy.some(id => !excludedRequesters.has(id)),
+          ),
+        )
+      : pending;
+
+  // A ticked team is shorthand for its members, so team and person selections
+  // union rather than intersect: picking Platform Pod and then one more name
+  // widens the list by that name, it does not narrow the pod to them.
+  const effectivePendingUsers = new Set(pendingUsers);
+  for (const team of teams) {
+    if (!teamIds.has(team.id)) continue;
+    for (const memberId of team.memberIds) effectivePendingUsers.add(memberId);
+  }
+  const waitingCards =
+    pendingOthers && effectivePendingUsers.size
+      ? waiting.filter(card =>
+          card.items.some(i => i.pendingOn.some(id => effectivePendingUsers.has(id))),
+        )
+      : waiting;
+
   // Merged on activity, not concatenated. Each feed arrives sorted, but
   // stacking them puts every card of mine above every card of theirs — a
   // minute-old ask sat below an eight-day-old one purely for being someone
@@ -642,32 +708,10 @@ const RadarPanel = (): ReactElement => {
     );
 
   let cards: Array<{ card: RadarThreadCard; kind: 'pending' | 'waiting' }> = [
-    ...(tab !== 'waiting' ? pending.map(card => ({ card, kind: 'pending' as const })) : []),
-    ...(tab !== 'pending' ? waiting.map(card => ({ card, kind: 'waiting' as const })) : []),
+    ...(tab !== 'waiting' ? pendingCards.map(card => ({ card, kind: 'pending' as const })) : []),
+    ...(tab !== 'pending' ? waitingCards.map(card => ({ card, kind: 'waiting' as const })) : []),
   ].sort((a, b) => cardActivity(b.card) - cardActivity(a.card));
 
-  const otherHolders = [
-    ...new Set(cards.flatMap(c => c.card.items.flatMap(i => i.pendingOn))),
-  ].filter(id => id !== selfId && usersById.has(id));
-
-  // Everyone involved anywhere, so a requester with nothing pending on me right
-  // now still appears — at zero — rather than silently vanishing from the list.
-  const requesterOptions = [
-    ...new Set(cards.flatMap(c => c.card.items.flatMap(i => i.requestedBy))),
-  ].filter(id => usersById.has(id));
-
-  if (pendingMe && requestedByUsers.size) {
-    cards = cards.filter(
-      ({ card, kind }) =>
-        kind !== 'pending' ||
-        card.items.some(i => i.requestedBy.some(id => requestedByUsers.has(id))),
-    );
-  }
-  if (pendingOthers && pendingUsers.size) {
-    cards = cards.filter(({ card }) =>
-      card.items.some(i => i.pendingOn.some(id => pendingUsers.has(id))),
-    );
-  }
   // Time is left out on purpose: a channel holding nothing in the current
   // range is still worth offering. Channel too, or the list would shrink to
   // the one option already ticked.
@@ -913,47 +957,16 @@ const RadarPanel = (): ReactElement => {
       a.dm !== b.dm ? (a.dm ? 1 : -1) : a.label.localeCompare(b.label),
     );
   })();
-  // Chips mirror what is actually narrowing the feed, so removing one is the
-  // same gesture as unticking it inside the panel.
-  const chips: Array<{ key: string; label: string; clear: () => void }> = [
-    ...(pendingMe ? [{ key: 'p-me', label: 'Pending: Me', clear: () => setPendingMe(false) }] : []),
-    ...(pendingOthers
-      ? [
-          {
-            key: 'p-others',
-            label: 'Pending: Others',
-            clear: () => {
-              setPendingOthers(false);
-              setPendingUsers(new Set());
-            },
-          },
-        ]
-      : []),
-    // One chip per label, matching the rows: selecting a grouped channel adds
-    // several ids, and a chip each would repeat the same name.
-    ...channelGroups
-      .filter(g => g.ids.some(id => filterChannels.has(id)))
-      .map(g => ({
-        key: `ch-${g.label}`,
-        label: g.label,
-        clear: () =>
-          setFilterChannels(prev => {
-            const next = new Set(prev);
-            for (const id of g.ids) next.delete(id);
-            return next;
-          }),
-      })),
-    ...(timeRange !== 'any'
-      ? [
-          {
-            key: 'time',
-            label:
-              timeRange === 'custom' && customRangeLabel ? customRangeLabel : timeLabel[timeRange],
-            clear: () => setTimeRange('any'),
-          },
-        ]
-      : []),
-  ];
+  // How many things are narrowing the feed. The panel itself says which — the
+  // Me and Others rows read back their own selection — so this is a count on
+  // the button, not a row of chips repeating what is one click away.
+  const activeFilterCount =
+    (pendingMe ? 1 : 0) +
+    (pendingMe ? excludedRequesters.size : 0) +
+    (pendingOthers ? 1 : 0) +
+    (pendingOthers ? teams.filter(t => teamIds.has(t.id)).length + pendingUsers.size : 0) +
+    channelGroups.filter(g => g.ids.some(id => filterChannels.has(id))).length +
+    (timeRange !== 'any' ? 1 : 0);
 
   // DMs belong here — they are channels, and most Radar threads live in one.
   // What is dropped is the unnamed fallback: a DM whose participants cannot be
@@ -990,13 +1003,19 @@ const RadarPanel = (): ReactElement => {
   const checkbox = (checked: boolean): ReactElement => (
     <span
       className={cn(
-        'size-5 shrink-0 rounded-md border flex items-center justify-center transition-colors',
+        'size-4 shrink-0 rounded-full border flex items-center justify-center transition-colors',
         checked ? 'bg-[#e8604c] border-[#e8604c] text-white' : 'border-border',
       )}
     >
-      {checked && <Check className='size-3.5' strokeWidth={3} />}
+      {checked && <Check className='size-2.5' strokeWidth={3} />}
     </span>
   );
+
+  // Requested-by is a choice between two readings of Others, not two
+  // independent toggles — so it reads as a radio, not another checkbox.
+  // Requested by picks one of two readings, so it is a radio in behaviour —
+  // but a row that is "on" should look on, the same as every other row here.
+  const radio = (checked: boolean): ReactElement => checkbox(checked);
 
   // One grid, two clicks: the first sets the start and clears any end, the
   // second closes the range. A click before the start restarts rather than
@@ -1094,16 +1113,25 @@ const RadarPanel = (): ReactElement => {
     setSelected: (next: Set<string>) => void,
     search: string,
     setSearch: (next: string) => void,
+    // Two ways to mean "everyone" over one Set. Include: the set is who is
+    // picked, drawn ticked; nobody picked means everyone, drawn empty with the
+    // rule stated underneath. Exclude: the set is who is taken away, so
+    // everyone else is drawn ticked and an empty set is everyone — no roster
+    // is ever stored, so whoever asks next is in by default.
+    mode: 'include' | 'exclude',
   ): ReactElement => {
     const visible = ids.filter(id =>
       nameOf(id).toLowerCase().includes(search.trim().toLowerCase()),
     );
+    const isOn = (id: string): boolean =>
+      mode === 'exclude' ? !selected.has(id) : selected.has(id);
     // Select all follows the search: with a query typed, it means the names on
-    // screen, not the ones hidden behind it.
-    const allVisibleSelected = visible.length > 0 && visible.every(id => selected.has(id));
+    // screen, not the ones hidden behind it. In exclude mode it only ever puts
+    // people back.
+    const allVisibleOn = visible.length > 0 && visible.every(isOn);
     return (
-      <div className='mt-2 ml-8 rounded-xl border border-border overflow-hidden'>
-        <div className='px-3 py-1.5 bg-muted/40 text-[10px] font-bold uppercase tracking-wide text-muted-foreground'>
+      <div className='mt-3 ml-8 rounded-xl border border-border overflow-hidden'>
+        <div className='px-3 py-2 bg-muted/40 text-[10px] font-bold uppercase tracking-wide text-muted-foreground'>
           {heading}
         </div>
         <div className='relative px-3 pt-2'>
@@ -1117,23 +1145,42 @@ const RadarPanel = (): ReactElement => {
             onChange={e => setSearch(e.target.value)}
           />
         </div>
-        <button
-          className='w-full flex items-center gap-3 px-3 py-2 text-sm font-semibold hover:bg-accent focus:outline-none focus-visible:bg-accent'
-          data-track-category='RADAR'
-          data-track-name='FILTER_PENDING_SELECT_ALL'
-          onClick={() => {
-            const next = new Set(selected);
-            for (const id of visible) {
-              if (allVisibleSelected) next.delete(id);
-              else next.add(id);
-            }
-            setSelected(next);
-          }}
-        >
-          <span className='flex-1 text-left'>Select all</span>
-          {checkbox(allVisibleSelected)}
-        </button>
-        <div className='max-h-44 overflow-y-auto'>
+        {/* With everyone already in, there is nothing to select. */}
+        {(mode === 'include' || selected.size > 0) && (
+          <button
+            className='w-full flex items-center gap-3 px-3 py-2 text-sm font-semibold hover:bg-accent focus:outline-none focus-visible:bg-accent'
+            data-track-category='RADAR'
+            data-track-name='FILTER_PENDING_SELECT_ALL'
+            onClick={() => {
+              // Exclude mode: the row means "everyone in", so it clears the
+              // whole exclusion set. Acting only on the names the search left
+              // on screen looks like a dead control when the excluded one is
+              // hidden behind the query.
+              if (mode === 'exclude') {
+                setSelected(new Set());
+                return;
+              }
+              const next = new Set(selected);
+              for (const id of visible) {
+                if (allVisibleOn) next.delete(id);
+                else next.add(id);
+              }
+              setSelected(next);
+            }}
+          >
+            <span className='flex-1 text-left'>Select all</span>
+            {/* Exclusions exist, so not everyone is in — the row must not draw
+                as though it already is, whatever the search happens to show. */}
+            {checkbox(mode === 'exclude' ? selected.size === 0 : allVisibleOn)}
+          </button>
+        )}
+        {/* Three rows, then scroll: the list is for finding a name, not reading
+            the roster. */}
+        {/* A visible scrollbar takes its width out of the rows, which pushes
+            the tick column left of the unscrolled rows above it. Hiding it
+            keeps one control column; the clipped fourth row is the affordance
+            that there is more. */}
+        <div className='max-h-32 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'>
           {visible.length === 0 && (
             <div className='px-3 py-2 text-xs text-muted-foreground'>
               {ids.length === 0 ? 'Nobody here yet.' : 'No one matches.'}
@@ -1142,7 +1189,7 @@ const RadarPanel = (): ReactElement => {
           {visible.map(id => (
             <button
               key={id}
-              className='w-full flex items-center gap-2.5 px-3 py-1.5 text-sm hover:bg-accent focus:outline-none focus-visible:bg-accent'
+              className='w-full flex items-center gap-2.5 px-3 py-2 text-sm hover:bg-accent focus:outline-none focus-visible:bg-accent'
               data-track-category='RADAR'
               data-track-name='FILTER_PENDING_USER'
               onClick={() => {
@@ -1152,16 +1199,9 @@ const RadarPanel = (): ReactElement => {
                 setSelected(next);
               }}
             >
-              <span
-                className={cn(
-                  'size-6 shrink-0 rounded-full text-white text-[10px] font-bold flex items-center justify-center',
-                  colorFor(id),
-                )}
-              >
-                {initialsOf(nameOf(id))}
-              </span>
+              <Avatar userId={id} size='rg' showActiveStatus className='shrink-0 rounded-lg' />
               <span className='flex-1 text-left truncate'>{nameOf(id)}</span>
-              {checkbox(selected.has(id))}
+              {checkbox(isOn(id))}
             </button>
           ))}
         </div>
@@ -1169,10 +1209,396 @@ const RadarPanel = (): ReactElement => {
     );
   };
 
+  // Every active member bar the viewer. A team narrows Others, which is
+  // "pending on someone else", so the viewer's own name would be a member that
+  // can never match — and so would someone who has left.
+  // Sorted once per roster change rather than on every keystroke anywhere in
+  // the panel, and searched with the predicate the rest of the app uses, so an
+  // email or an out-of-order two-token query finds the same person here as in
+  // cmd+K. The label is the same field that predicate reads, so a row can
+  // never match on a name it does not show.
+  const sortedTeamCandidates = useMemo(
+    () =>
+      activeUsers
+        .filter(u => u.id !== selfId)
+        .map(u => ({ id: u.id, label: getUserDisplayName(u), user: u }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    [activeUsers, selfId],
+  );
+  const teamCandidates = sortedTeamCandidates.filter(c => matchesUserQuery(c.user, memberSearch));
+
+  const selectedTeamNames = teams.filter(t => teamIds.has(t.id)).map(t => t.name);
+
+  // Reads back the sentence the two halves make: who asked, then whose queue.
+  // Teams are named because the name is the point of having made one; loose
+  // people are counted, since a list of them is the thing a team replaces.
+  // The Me half reads the same way: who is excluded, if anyone.
+  const meSummary = ((): string => {
+    const excluded = [...excludedRequesters];
+    if (excluded.length === 0) return 'from anyone';
+    // Same shape as the Others half: name the first, count the rest.
+    const rest = excluded.length - 1;
+    return `all but ${nameOf(excluded[0] ?? '')}${rest ? ` +${rest}` : ''}`;
+  })();
+
+  const othersSummary = ((): string => {
+    const requester = othersMode === 'me' ? 'requested by me' : 'requested by anyone';
+    const peopleCount = pendingUsers.size;
+    if (selectedTeamNames.length === 0 && peopleCount === 0) return `${requester} · everyone`;
+    if (selectedTeamNames.length === 0) {
+      return `${requester} · ${peopleCount} ${peopleCount === 1 ? 'person' : 'people'}`;
+    }
+    const shown = selectedTeamNames.slice(0, 2);
+    const extra = selectedTeamNames.length - shown.length + peopleCount;
+    return `${requester} · ${shown.join(', ')}${extra ? ` +${extra}` : ''}`;
+  })();
+
+  const othersModePicker = (
+    <div className='mt-3 ml-8 rounded-xl border border-border overflow-hidden'>
+      <button
+        className='w-full flex items-center gap-2 px-3 py-2 bg-muted/40 text-left hover:bg-muted/60'
+        aria-expanded={requestedByOpen}
+        data-track-category='RADAR'
+        data-track-name='TOGGLE_REQUESTED_BY'
+        onClick={() => setRequestedByOpen(open => !open)}
+      >
+        <span className='flex-1 text-[10px] font-bold uppercase tracking-wide text-muted-foreground'>
+          Requested by
+        </span>
+        <span className='text-xs text-muted-foreground'>
+          {othersMode === 'me' ? 'Me' : 'Anyone'}
+        </span>
+        <ChevronRight
+          className={cn(
+            'size-3.5 text-muted-foreground transition-transform',
+            requestedByOpen && 'rotate-90',
+          )}
+        />
+      </button>
+      {requestedByOpen &&
+        [
+          { id: 'me' as const, label: 'Me', hint: 'What you are chasing' },
+          { id: 'all' as const, label: 'Anyone', hint: 'Everything on them, whoever asked' },
+        ].map(mode => (
+          <button
+            key={mode.id}
+            className='w-full flex items-center gap-3 px-3 py-2 text-sm hover:bg-accent focus:outline-none focus-visible:bg-accent'
+            data-track-category='RADAR'
+            data-track-name='FILTER_OTHERS_MODE'
+            onClick={() => setOthersMode(mode.id)}
+          >
+            <span className='flex-1 text-left'>
+              <span className='block font-bold'>{mode.label}</span>
+              <span className='block text-xs text-muted-foreground'>{mode.hint}</span>
+            </span>
+            {radio(othersMode === mode.id)}
+          </button>
+        ))}
+    </div>
+  );
+
+  const teamsPicker = (
+    <div className='mt-3 ml-8 rounded-xl border border-border overflow-hidden'>
+      <div className='flex items-center gap-2 px-3 py-2 bg-muted/40'>
+        <span className='flex-1 text-[10px] font-bold uppercase tracking-wide text-muted-foreground'>
+          Pending on · teams
+        </span>
+        {/* With no teams there is nothing to manage, so the one link in this
+            slot is the one action available — making the first team. */}
+        <button
+          ref={manageTeamsOpenerRef}
+          className='text-[11px] font-bold text-[#e8604c] hover:underline'
+          data-track-category='RADAR'
+          data-track-name={teams.length === 0 ? 'CREATE_TEAM_FROM_EMPTY' : 'OPEN_MANAGE_TEAMS'}
+          onClick={() => {
+            setTeamDraft(teams.length === 0 ? { id: null, name: '', memberIds: new Set() } : null);
+            setManageTeams(true);
+          }}
+        >
+          {teams.length === 0 ? '+ Create team' : 'Manage teams ›'}
+        </button>
+      </div>
+      {teams.length === 0 ? (
+        <div className='px-3 py-2.5 text-xs text-muted-foreground'>
+          No teams yet. Create a team to easily filter and see what’s pending.
+        </div>
+      ) : (
+        teams.map(team => (
+          <button
+            key={team.id}
+            className='w-full flex items-center gap-3 px-3 py-2 text-sm hover:bg-accent focus:outline-none focus-visible:bg-accent'
+            data-track-category='RADAR'
+            data-track-name='FILTER_BY_TEAM'
+            onClick={() =>
+              setTeamIds(prev => {
+                const next = new Set(prev);
+                if (next.has(team.id)) next.delete(team.id);
+                else next.add(team.id);
+                return next;
+              })
+            }
+          >
+            <span className='flex-1 text-left font-semibold'>{team.name}</span>
+            <span className='text-xs text-muted-foreground'>
+              {team.memberIds.length === 1 ? '1 person' : `${team.memberIds.length} people`}
+            </span>
+            {checkbox(teamIds.has(team.id))}
+          </button>
+        ))
+      )}
+    </div>
+  );
+
+  const draftValid = Boolean(teamDraft?.name.trim() && teamDraft?.memberIds.size);
+
+  const saveTeamDraft = (): void => {
+    if (!teamDraft || !draftValid) return;
+    const members = [...teamDraft.memberIds];
+    if (teamDraft.id) {
+      updateTeam(teamDraft.id, teamDraft.name, members);
+    } else {
+      const id = createTeam(teamDraft.name, members);
+      // A team is made in order to watch it, so ticking it is the point of
+      // having made it.
+      if (id) {
+        setPendingOthers(true);
+        setTeamIds(prev => new Set(prev).add(id));
+      }
+    }
+    // Straight back to the filters: the team was made in order to use it, and
+    // the list behind this form is not a step anyone asked for.
+    setTeamDraft(null);
+    setManageTeams(false);
+  };
+
+  const removeTeam = (team: RadarTeam): void => {
+    deleteTeam(team.id);
+    // Otherwise a deleted team keeps narrowing the feed from a chip that no
+    // longer has a row to untick.
+    setTeamIds(prev => {
+      const next = new Set(prev);
+      next.delete(team.id);
+      return next;
+    });
+  };
+
+  const closeManageTeams = (): void => {
+    setManageTeams(false);
+    setTeamDraft(null);
+    setMemberSearch('');
+    // After Radix's own unmount focus handling, which runs on a zero timeout.
+    setTimeout(() => manageTeamsOpenerRef.current?.focus(), 50);
+  };
+
+  // The app's Dialog, so Escape, the focus trap, focus restore and the portal
+  // all come for free instead of being rebuilt here one bug at a time.
+  const manageTeamsDialog = (
+    <Dialog
+      open={manageTeams}
+      onOpenChange={open => {
+        if (!open) closeManageTeams();
+      }}
+      title={teamDraft ? (teamDraft.id ? 'Edit team' : 'New team') : 'Teams'}
+      description={
+        teamDraft ? 'Name the team and pick its members.' : 'Saved groups you can filter by.'
+      }
+      className='max-w-[520px] rounded-2xl border border-border overflow-hidden'
+      // The drawer variant drops title, description and className on the
+      // floor; this is a small form, and a dialog on every width keeps it one.
+      mobileVariant='dialog'
+    >
+      <div className='flex flex-col max-h-[80vh]'>
+        <div className='flex items-start gap-3 px-5 pt-4 pb-3 border-b border-border'>
+          <div className='flex-1 min-w-0'>
+            <div className='text-base font-bold'>
+              {teamDraft ? (teamDraft.id ? 'Edit team' : 'New team') : 'Teams'}
+            </div>
+          </div>
+          <button
+            aria-label='Close'
+            className='shrink-0 p-1 rounded-md text-muted-foreground hover:bg-accent'
+            data-track-category='RADAR'
+            data-track-name='CLOSE_MANAGE_TEAMS'
+            onClick={closeManageTeams}
+          >
+            <X className='size-4' />
+          </button>
+        </div>
+
+        <div className='flex-1 overflow-y-auto px-5 py-4'>
+          {!teamDraft && (
+            <div className='flex flex-col gap-2'>
+              {teams.map(team => (
+                <div
+                  key={team.id}
+                  className='flex items-center gap-3 rounded-xl border border-border px-3.5 py-3'
+                >
+                  <div className='flex-1 min-w-0'>
+                    <div className='text-sm font-bold truncate'>{team.name}</div>
+                    <div className='text-xs text-muted-foreground truncate'>
+                      {team.memberIds.length === 1
+                        ? '1 member'
+                        : `${team.memberIds.length} members`}
+                      {' · '}
+                      {team.memberIds.slice(0, 2).map(nameOf).join(', ')}
+                      {team.memberIds.length > 2 && ` +${team.memberIds.length - 2}`}
+                    </div>
+                  </div>
+                  <button
+                    className='shrink-0 rounded-full border border-border px-3 py-1.5 text-xs font-semibold hover:bg-accent'
+                    data-track-category='RADAR'
+                    data-track-name='EDIT_TEAM'
+                    onClick={() =>
+                      setTeamDraft({
+                        id: team.id,
+                        name: team.name,
+                        memberIds: new Set(team.memberIds),
+                      })
+                    }
+                  >
+                    Edit
+                  </button>
+                  <button
+                    className='shrink-0 rounded-full border border-[#e8604c]/40 text-[#e8604c] px-3 py-1.5 text-xs font-semibold hover:bg-[#e8604c]/10'
+                    data-track-category='RADAR'
+                    data-track-name='DELETE_TEAM'
+                    onClick={() => removeTeam(team)}
+                  >
+                    Delete
+                  </button>
+                </div>
+              ))}
+              <button
+                className='rounded-xl border border-dashed border-border px-3.5 py-3 text-sm font-bold text-[#e8604c] hover:bg-accent'
+                data-track-category='RADAR'
+                data-track-name='NEW_TEAM'
+                onClick={() => setTeamDraft({ id: null, name: '', memberIds: new Set() })}
+              >
+                + New team
+              </button>
+            </div>
+          )}
+
+          {teamDraft && (
+            <div>
+              <div className='text-[10px] font-bold uppercase tracking-wide text-muted-foreground mb-1.5'>
+                Team name
+              </div>
+              <input
+                autoFocus
+                className='w-full px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground'
+                placeholder='e.g. Platform Pod'
+                data-track-category='RADAR'
+                data-track-name='TEAM_NAME'
+                value={teamDraft.name}
+                onChange={e => setTeamDraft({ ...teamDraft, name: e.target.value })}
+              />
+              <div className='flex items-center gap-2 mt-4 mb-1.5'>
+                <span className='flex-1 text-[10px] font-bold uppercase tracking-wide text-muted-foreground'>
+                  Members
+                </span>
+                <span className='text-xs text-muted-foreground'>
+                  {teamDraft.memberIds.size
+                    ? `${teamDraft.memberIds.size} selected`
+                    : 'none selected'}
+                </span>
+              </div>
+              <div className='rounded-xl border border-border overflow-hidden'>
+                <div className='relative px-3 pt-2 pb-1'>
+                  <Search className='absolute left-5 top-1/2 mt-0.5 -translate-y-1/2 size-3.5 text-muted-foreground' />
+                  <input
+                    className='w-full pl-7 pr-2 py-1.5 rounded-lg border border-border bg-background text-sm text-foreground'
+                    placeholder='Search people'
+                    data-track-category='RADAR'
+                    data-track-name='SEARCH_TEAM_MEMBERS'
+                    value={memberSearch}
+                    onChange={e => setMemberSearch(e.target.value)}
+                  />
+                </div>
+                {teamCandidates.length === 0 && (
+                  <div className='px-3 py-2 text-xs text-muted-foreground'>
+                    {memberSearch.trim() ? 'No one matches.' : 'Nobody here yet.'}
+                  </div>
+                )}
+                {teamCandidates.map(candidate => {
+                  const picked = teamDraft.memberIds.has(candidate.id);
+                  // The cap is what the picker enforces: past it, only
+                  // unticking stays available.
+                  const full = !picked && teamDraft.memberIds.size >= MAX_TEAM_MEMBERS;
+                  return (
+                    <button
+                      key={candidate.id}
+                      disabled={full}
+                      title={full ? `At most ${MAX_TEAM_MEMBERS} members` : undefined}
+                      className={cn(
+                        'w-full flex items-center gap-2.5 px-3 py-2 text-sm hover:bg-accent focus:outline-none focus-visible:bg-accent',
+                        full && 'opacity-50 cursor-not-allowed',
+                      )}
+                      data-track-category='RADAR'
+                      data-track-name='TEAM_MEMBER'
+                      onClick={() => {
+                        const next = new Set(teamDraft.memberIds);
+                        if (next.has(candidate.id)) next.delete(candidate.id);
+                        else next.add(candidate.id);
+                        setTeamDraft({ ...teamDraft, memberIds: next });
+                      }}
+                    >
+                      <Avatar
+                        userId={candidate.id}
+                        size='rg'
+                        showActiveStatus
+                        className='shrink-0 rounded-lg'
+                      />
+                      <span className='flex-1 text-left truncate'>{candidate.label}</span>
+                      {checkbox(picked)}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className='flex items-center gap-3 px-5 py-3 border-t border-border'>
+          <span className='flex-1 text-xs text-muted-foreground'>
+            {teamDraft ? '' : teams.length === 1 ? '1 team' : `${teams.length} teams`}
+          </span>
+          <button
+            className='rounded-full px-4 py-2 text-sm font-semibold hover:bg-accent'
+            data-track-category='RADAR'
+            data-track-name='MANAGE_TEAMS_BACK'
+            onClick={() => {
+              if (teamDraft) setTeamDraft(null);
+              else setManageTeams(false);
+            }}
+          >
+            {teamDraft ? 'Back' : 'Done'}
+          </button>
+          {teamDraft && (
+            <button
+              disabled={!draftValid}
+              className={cn(
+                'rounded-full px-4 py-2 text-sm font-semibold transition-colors',
+                draftValid
+                  ? 'bg-foreground text-background'
+                  : 'bg-muted text-muted-foreground cursor-not-allowed',
+              )}
+              data-track-category='RADAR'
+              data-track-name='SAVE_TEAM'
+              onClick={saveTeamDraft}
+            >
+              {teamDraft.id ? 'Save team' : 'Create team'}
+            </button>
+          )}
+        </div>
+      </div>
+    </Dialog>
+  );
+
   const filtersPanel = (
-    <div className='absolute left-0 top-full mt-2 z-40 w-[680px] rounded-2xl border border-border bg-popover text-popover-foreground shadow-xl overflow-hidden'>
-      <div className='flex min-h-[360px]'>
-        <div className='w-56 shrink-0 border-r border-border bg-muted/30 p-2'>
+    <div className='absolute left-0 top-full mt-2 z-40 w-[820px] rounded-2xl border border-border bg-popover text-popover-foreground shadow-xl overflow-hidden'>
+      <div className='flex min-h-[440px]'>
+        <div className='w-60 shrink-0 border-r border-border bg-muted/30 p-3'>
           <div className='px-3 pt-1 pb-2 text-[11px] font-bold tracking-wide text-muted-foreground uppercase'>
             All filters
           </div>
@@ -1181,53 +1607,70 @@ const RadarPanel = (): ReactElement => {
           {railItem('time', 'Time', timeRange === 'any' ? 0 : 1)}
         </div>
 
-        <div className='flex-1 min-w-0 p-5 max-h-[32rem] overflow-y-auto'>
+        <div className='flex-1 min-w-0 p-6 max-h-[38rem] overflow-y-auto'>
           {filterCategory === 'pending' && (
             <>
               <div className='text-sm font-semibold text-muted-foreground mb-3'>Pending on</div>
               <button
-                className='w-full flex items-center gap-3 px-2 py-2 rounded-lg text-sm hover:bg-accent'
+                className='w-full flex items-center gap-3 pl-2 pr-[13px] py-2.5 rounded-lg text-sm hover:bg-accent'
                 data-track-category='RADAR'
                 data-track-name='FILTER_PENDING_ME'
                 onClick={() => setPendingMe(v => !v)}
               >
-                <span className='flex-1 text-left'>Me</span>
+                <span className='flex-1 min-w-0 flex items-baseline gap-2 text-left'>
+                  <span className='font-bold'>Me</span>
+                  {pendingMe && (
+                    <span className='truncate text-xs text-muted-foreground'>{meSummary}</span>
+                  )}
+                </span>
                 {checkbox(pendingMe)}
               </button>
               {pendingMe &&
                 userPicker(
                   'Requested by',
                   requesterOptions,
-                  requestedByUsers,
-                  setRequestedByUsers,
+                  excludedRequesters,
+                  setExcludedRequesters,
                   requesterSearch,
                   setRequesterSearch,
+                  'exclude',
                 )}
               <button
                 className={cn(
-                  'w-full flex items-center gap-3 px-2 py-2 rounded-lg text-sm hover:bg-accent',
+                  'w-full flex items-center gap-3 pl-2 pr-[13px] py-2.5 rounded-lg text-sm hover:bg-accent',
                   // Clear of the picker above, so the two halves read as two.
-                  pendingMe && 'mt-4',
+                  pendingMe && 'mt-8',
                 )}
                 data-track-category='RADAR'
                 data-track-name='FILTER_PENDING_OTHERS'
                 onClick={() => {
                   setPendingOthers(v => !v);
-                  if (pendingOthers) setPendingUsers(new Set());
+                  if (pendingOthers) {
+                    setPendingUsers(new Set());
+                    setTeamIds(new Set());
+                  }
                 }}
               >
-                <span className='flex-1 text-left'>Others</span>
+                <span className='flex-1 min-w-0 flex items-baseline gap-2 text-left'>
+                  <span className='font-bold'>Others</span>
+                  {pendingOthers && (
+                    <span className='truncate text-xs text-muted-foreground'>{othersSummary}</span>
+                  )}
+                </span>
                 {checkbox(pendingOthers)}
               </button>
+              {pendingOthers && teamsPicker}
               {pendingOthers &&
                 userPicker(
-                  'Pending on',
+                  'Pending on · people',
                   otherHolders,
                   pendingUsers,
                   setPendingUsers,
                   holderSearch,
                   setHolderSearch,
+                  'include',
                 )}
+              {pendingOthers && othersModePicker}
             </>
           )}
 
@@ -1256,7 +1699,7 @@ const RadarPanel = (): ReactElement => {
                   <button
                     key={group.label}
                     className={cn(
-                      'w-full flex items-center gap-3 px-2 py-2 rounded-lg text-sm hover:bg-accent',
+                      'w-full flex items-center gap-3 pl-2 pr-[13px] py-2.5 rounded-lg text-sm hover:bg-accent',
                       !group.live && 'opacity-50',
                     )}
                     title={group.live ? undefined : 'Nothing pending here right now'}
@@ -1276,15 +1719,12 @@ const RadarPanel = (): ReactElement => {
                     {group.dm ? (
                       <span className='flex -space-x-1.5 shrink-0'>
                         {group.people.slice(0, 2).map(id => (
-                          <span
+                          <Avatar
                             key={id}
-                            className={cn(
-                              'size-6 rounded-lg text-white text-[10px] font-bold flex items-center justify-center ring-2 ring-popover',
-                              colorFor(id),
-                            )}
-                          >
-                            {initialsOf(nameOf(id))}
-                          </span>
+                            userId={id}
+                            size='sm'
+                            className='rounded-lg ring-2 ring-popover'
+                          />
                         ))}
                       </span>
                     ) : (
@@ -1399,7 +1839,7 @@ const RadarPanel = (): ReactElement => {
             <button
               className={cn(
                 'inline-flex items-center gap-2 pl-3.5 pr-3 py-2 rounded-full text-sm font-semibold transition-colors border',
-                filtersOpen || chips.length > 0
+                filtersOpen || activeFilterCount > 0
                   ? 'bg-foreground text-background border-foreground'
                   : 'bg-card text-foreground border-border hover:bg-accent',
               )}
@@ -1411,32 +1851,15 @@ const RadarPanel = (): ReactElement => {
             >
               <ListFilter className='size-4' />
               Filters
-              {chips.length > 0 && (
+              {activeFilterCount > 0 && (
                 <span className='min-w-5 h-5 px-1.5 rounded-full bg-[#e8604c] text-white text-[11px] font-bold flex items-center justify-center'>
-                  {chips.length}
+                  {activeFilterCount}
                 </span>
               )}
             </button>
             {filtersOpen && filtersPanel}
+            {manageTeams && manageTeamsDialog}
           </span>
-
-          {chips.map(chip => (
-            <span
-              key={chip.key}
-              className='inline-flex items-center gap-1.5 pl-3 pr-2 py-1.5 rounded-full bg-[#e8604c]/10 text-[#e8604c] text-sm font-semibold'
-            >
-              {chip.label}
-              <button
-                aria-label={`Remove ${chip.label} filter`}
-                className='rounded-full p-0.5 hover:bg-[#e8604c]/20'
-                data-track-category='RADAR'
-                data-track-name='REMOVE_FILTER_CHIP'
-                onClick={chip.clear}
-              >
-                <X className='size-3.5' />
-              </button>
-            </span>
-          ))}
         </div>
 
         <div className='flex-1 overflow-y-auto px-6 pb-8'>

--- a/apps/dashboard/src/hooks/usePersistedRadarFilters.ts
+++ b/apps/dashboard/src/hooks/usePersistedRadarFilters.ts
@@ -4,6 +4,13 @@ export type RadarTimeRange = 'any' | 'today' | '7d' | '30d' | 'custom';
 
 const TIME_RANGES: RadarTimeRange[] = ['any', 'today', '7d', '30d', 'custom'];
 
+/** Which half of Others the viewer wants: only their own asks, or everything
+ *  the other person is holding. The two are different feeds, not a client-side
+ *  narrowing of one. */
+export type RadarOthersMode = 'me' | 'all';
+
+const OTHERS_MODES: RadarOthersMode[] = ['me', 'all'];
+
 /** What survives a reload. The transient bits of the panel — which rail tab is
  *  open, the picker search boxes, the calendar's visible month — are not here:
  *  they describe the popover, not the feed the user chose to look at. */
@@ -11,7 +18,14 @@ export interface RadarFilters {
   pendingMe: boolean;
   pendingOthers: boolean;
   pendingUsers: Set<string>;
-  requestedByUsers: Set<string>;
+  /** Saved groups ticked under Others. Teams resolve to their members when the
+   *  feed is filtered, so a team and a person tick to the same effect. */
+  teamIds: Set<string>;
+  othersMode: RadarOthersMode;
+  /** Requesters taken OUT of Pending Me. An exclusion list, not a selection:
+   *  "everyone but Bob" has to keep meaning everyone as new people ask, which
+   *  a stored list of who is in can never do. Empty means nobody excluded. */
+  excludedRequesters: Set<string>;
   filterChannels: Set<string>;
   timeRange: RadarTimeRange;
   customFrom: string;
@@ -22,7 +36,13 @@ const DEFAULT_FILTERS: RadarFilters = {
   pendingMe: true,
   pendingOthers: true,
   pendingUsers: new Set(),
-  requestedByUsers: new Set(),
+  teamIds: new Set(),
+  // 'me' is what Others has always meant: the old single checkbox read the
+  // Waiting On feed, which is requestedBy ∋ me. Starting there leaves an
+  // existing user's feed exactly as they left it, and 'all' — the wider read,
+  // and the one the rail explains — stays a deliberate choice.
+  othersMode: 'me',
+  excludedRequesters: new Set(),
   filterChannels: new Set(),
   timeRange: 'any',
   customFrom: '',
@@ -51,7 +71,11 @@ const readStorage = (key: string): RadarFilters => {
           ? p['pendingOthers']
           : DEFAULT_FILTERS.pendingOthers,
       pendingUsers: toSet(p['pendingUsers']),
-      requestedByUsers: toSet(p['requestedByUsers']),
+      teamIds: toSet(p['teamIds']),
+      othersMode: OTHERS_MODES.includes(p['othersMode'] as RadarOthersMode)
+        ? (p['othersMode'] as RadarOthersMode)
+        : DEFAULT_FILTERS.othersMode,
+      excludedRequesters: toSet(p['excludedRequesters']),
       filterChannels: toSet(p['filterChannels']),
       timeRange: TIME_RANGES.includes(p['timeRange'] as RadarTimeRange)
         ? (p['timeRange'] as RadarTimeRange)
@@ -73,7 +97,9 @@ const writeStorage = (key: string, filters: RadarFilters): void => {
         pendingMe: filters.pendingMe,
         pendingOthers: filters.pendingOthers,
         pendingUsers: [...filters.pendingUsers],
-        requestedByUsers: [...filters.requestedByUsers],
+        teamIds: [...filters.teamIds],
+        othersMode: filters.othersMode,
+        excludedRequesters: [...filters.excludedRequesters],
         filterChannels: [...filters.filterChannels],
         timeRange: filters.timeRange,
         customFrom: filters.customFrom,
@@ -89,7 +115,9 @@ export interface PersistedRadarFilters extends RadarFilters {
   setPendingMe: Dispatch<SetStateAction<boolean>>;
   setPendingOthers: Dispatch<SetStateAction<boolean>>;
   setPendingUsers: Dispatch<SetStateAction<Set<string>>>;
-  setRequestedByUsers: Dispatch<SetStateAction<Set<string>>>;
+  setTeamIds: Dispatch<SetStateAction<Set<string>>>;
+  setOthersMode: Dispatch<SetStateAction<RadarOthersMode>>;
+  setExcludedRequesters: Dispatch<SetStateAction<Set<string>>>;
   setFilterChannels: Dispatch<SetStateAction<Set<string>>>;
   setTimeRange: Dispatch<SetStateAction<RadarTimeRange>>;
   setCustomFrom: Dispatch<SetStateAction<string>>;
@@ -140,16 +168,22 @@ export const usePersistedRadarFilters = (userId: string | undefined): PersistedR
 
   const clearAllFilters = useCallback(() => {
     touchedRef.current = true;
-    const next: RadarFilters = {
-      ...DEFAULT_FILTERS,
-      pendingMe: false,
-      pendingOthers: false,
-      pendingUsers: new Set(),
-      requestedByUsers: new Set(),
-      filterChannels: new Set(),
-    };
-    if (storageKey) writeStorage(storageKey, next);
-    setFilters(next);
+    setFilters(prev => {
+      // Requested by is a reading of Others, not a narrowing of it — clearing
+      // the filters must not quietly swap the feed underneath the viewer.
+      const next: RadarFilters = {
+        ...DEFAULT_FILTERS,
+        othersMode: prev.othersMode,
+        pendingMe: false,
+        pendingOthers: false,
+        pendingUsers: new Set(),
+        teamIds: new Set(),
+        excludedRequesters: new Set(),
+        filterChannels: new Set(),
+      };
+      if (storageKey) writeStorage(storageKey, next);
+      return next;
+    });
   }, [storageKey]);
 
   const setters = useMemo(
@@ -157,7 +191,9 @@ export const usePersistedRadarFilters = (userId: string | undefined): PersistedR
       setPendingMe: (v: SetStateAction<boolean>) => setField('pendingMe', v),
       setPendingOthers: (v: SetStateAction<boolean>) => setField('pendingOthers', v),
       setPendingUsers: (v: SetStateAction<Set<string>>) => setField('pendingUsers', v),
-      setRequestedByUsers: (v: SetStateAction<Set<string>>) => setField('requestedByUsers', v),
+      setTeamIds: (v: SetStateAction<Set<string>>) => setField('teamIds', v),
+      setOthersMode: (v: SetStateAction<RadarOthersMode>) => setField('othersMode', v),
+      setExcludedRequesters: (v: SetStateAction<Set<string>>) => setField('excludedRequesters', v),
       setFilterChannels: (v: SetStateAction<Set<string>>) => setField('filterChannels', v),
       setTimeRange: (v: SetStateAction<RadarTimeRange>) => setField('timeRange', v),
       setCustomFrom: (v: SetStateAction<string>) => setField('customFrom', v),

--- a/apps/dashboard/src/hooks/usePersistedRadarTeams.ts
+++ b/apps/dashboard/src/hooks/usePersistedRadarTeams.ts
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+/** A saved group of people, named by whoever watches it. Teams are a filter
+ *  shortcut, not a lens: ticking one is the same gesture as ticking each of its
+ *  members, so nothing here can widen what a viewer may see. */
+export interface RadarTeam {
+  id: string;
+  name: string;
+  memberIds: string[];
+}
+
+/** Matches what the picker can comfortably show, and keeps one team from
+ *  standing in for the whole workspace. */
+export const MAX_TEAM_MEMBERS = 25;
+
+const STORAGE_PREFIX = 'xyne:radar-teams';
+
+const storageKeyFor = (userId: string): string => `${STORAGE_PREFIX}:${userId}`;
+
+const newId = (): string =>
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `t-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+/** Anything stored by an older build — or hand-edited — is read defensively:
+ *  a single malformed row must not cost the viewer every other team. */
+const parseTeams = (raw: unknown): RadarTeam[] => {
+  if (!Array.isArray(raw)) return [];
+  const teams: RadarTeam[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== 'object' || entry === null) continue;
+    const t = entry as Record<string, unknown>;
+    if (typeof t['id'] !== 'string' || typeof t['name'] !== 'string') continue;
+    const memberIds = Array.isArray(t['memberIds'])
+      ? [...new Set(t['memberIds'].filter((m): m is string => typeof m === 'string'))]
+      : [];
+    if (memberIds.length === 0) continue;
+    teams.push({ id: t['id'], name: t['name'], memberIds: memberIds.slice(0, MAX_TEAM_MEMBERS) });
+  }
+  return teams;
+};
+
+const readStorage = (key: string): RadarTeam[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? parseTeams(JSON.parse(raw)) : [];
+  } catch {
+    return [];
+  }
+};
+
+const writeStorage = (key: string, teams: RadarTeam[]): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(teams));
+  } catch {
+    // Quota or private mode — the teams still hold for this session.
+  }
+};
+
+export interface PersistedRadarTeams {
+  teams: RadarTeam[];
+  /** Returns the new team's id so the caller can tick it straight away. */
+  createTeam: (name: string, memberIds: string[]) => string | null;
+  updateTeam: (id: string, name: string, memberIds: string[]) => void;
+  deleteTeam: (id: string) => void;
+}
+
+/**
+ * Radar's saved teams, per user, in localStorage. They live in the browser and
+ * nowhere else: a team is one viewer's private shorthand for a set of people,
+ * so it does not follow them to another device and no one else can see it.
+ */
+export const usePersistedRadarTeams = (userId: string | undefined): PersistedRadarTeams => {
+  const storageKey = userId ? storageKeyFor(userId) : null;
+
+  const [teams, setTeams] = useState<RadarTeam[]>(() =>
+    storageKey ? readStorage(storageKey) : [],
+  );
+
+  // Same late-key problem the filters hook has: the panel mounts before auth
+  // necessarily has a user, and the key is the user id.
+  const hydratedKeyRef = useRef<string | null>(storageKey);
+  const touchedRef = useRef(false);
+
+  useEffect(() => {
+    if (!storageKey || hydratedKeyRef.current === storageKey) return;
+    hydratedKeyRef.current = storageKey;
+    if (touchedRef.current) return;
+    setTeams(readStorage(storageKey));
+  }, [storageKey]);
+
+  const commit = useCallback(
+    (next: (prev: RadarTeam[]) => RadarTeam[]): void => {
+      touchedRef.current = true;
+      setTeams(prev => {
+        const value = next(prev);
+        if (storageKey) writeStorage(storageKey, value);
+        return value;
+      });
+    },
+    [storageKey],
+  );
+
+  const sanitize = (
+    name: string,
+    memberIds: string[],
+  ): { name: string; memberIds: string[] } | null => {
+    const trimmed = name.trim();
+    const unique = [...new Set(memberIds)].slice(0, MAX_TEAM_MEMBERS);
+    if (!trimmed || unique.length === 0) return null;
+    return { name: trimmed, memberIds: unique };
+  };
+
+  const api = useMemo(
+    () => ({
+      createTeam: (name: string, memberIds: string[]): string | null => {
+        const clean = sanitize(name, memberIds);
+        if (!clean) return null;
+        const id = newId();
+        commit(prev => [...prev, { id, ...clean }]);
+        return id;
+      },
+      updateTeam: (id: string, name: string, memberIds: string[]): void => {
+        const clean = sanitize(name, memberIds);
+        if (!clean) return;
+        commit(prev => prev.map(t => (t.id === id ? { id, ...clean } : t)));
+      },
+      deleteTeam: (id: string): void => commit(prev => prev.filter(t => t.id !== id)),
+    }),
+    [commit],
+  );
+
+  return { teams, ...api };
+};


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-57690.

Others was one checkbox over one feed: Waiting On, which is `requestedBy ∋ me`. That answers "what have I chased" and cannot answer "what is this pod holding" — the reading that makes someone else's work visible at all.

Others now asks two questions in order. **Requested by** picks the reading: "Requested by me" keeps today's Waiting On, "All" is a new feed of every open item held by someone who is not the viewer, whoever asked. They are separate reads rather than one filtered two ways, because narrowing the wrong one client-side would silently cap the feed at whatever the other query returned. Nothing widens ACL: the new feed goes through the same viewer channel check as the other two, so an item on a colleague in a private channel the viewer is not in never reaches a card. Ownerless items stay out — with `pendingOn` empty there is no "them" to be pending on.

Then **Pending on** narrows it, by team or by name. A team is a saved group of people, and ticking one is exactly ticking each of its members: teams and names union rather than intersect, so adding a name to a ticked pod widens the list by that name. Teams live in localStorage next to the filter selection they serve — one viewer's private shorthand, never synced, never visible to anyone else — so there is no row, no ACL and no sharing model to reason about. Deleting a team drops its tick with it, or a chip would keep narrowing the feed with no row left to untick.

**Bugfix:** Requested by under Me now comes from the pending feed alone. It was drawn from every card, so the Others query fed it too — switching Requested by added and removed names under Me that had nothing to do with what was on the viewer's plate. Anything already ticked stays listed, so narrowing the source cannot make a live selection disappear.

A first visit opens up rather than empty. Me arrives with every requester ticked and Others on All, instead of an empty picker that only behaves like everyone; a stored selection is left alone, since a returning user's empty set is a deliberate choice. Both people lists show three rows and scroll, and the panel is wider so the two halves are not read through a slot.

`radar_teams` goes with it. The server-side team lens that justified the table was deleted in #1570, which kept the table on the grounds that dropping it discards whatever anyone saved; teams are a browser concern now and the column set has had no reader or writer since.

## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [x] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] ~~Server and client mutators mirror each other~~ — N/A, no mutators
- [ ] ~~No `Date.now()` / `uuid()` inside a mutator~~ — N/A, no mutators
- [ ] ~~Optimistic client result matches the server result~~ — N/A, no mutators
- [ ] ~~New tables exported in `createSchema()` + Query ACL~~ — N/A, table removed not added
- [x] Matching Prisma model + migration, client regenerated

`radarTeamTable` removed from the generated Zero schema, its ACL case removed from `acl-factory.ts`. Nothing added.

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [x] Prisma schema modified (`apps/backend/prisma`)
- [x] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [x] Clients regenerated (`db:generate`)
- [x] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum` passes)
- [x] Backward compatible with deployed code — no deployed code reads or writes this table
- [ ] ~~Backfill is idempotent~~ — N/A, no backfill

<!-- Rollout / rollback notes: -->
`DROP TABLE non_zero.radar_teams` is destructive and irreversible. No reader or writer exists in deployed code, so rollout ordering is unconstrained — but any rows present in staging/prod are lost. Note this reverses a deliberate call in #1570, which kept the table precisely because "dropping it discards whatever anyone saved". Two rows existed in local dev; none anywhere else visible from this branch.

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [ ] No API changes
- [x] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots

`GET /radar/feed/pending-others` — open items held by anyone but the viewer, whoever asked. Same response shape as the existing two feeds, same viewer channel ACL. Nothing existing changed.

---

## How did you test it?

Driven through the running app against the dev DB, which has 11 open items pending on me, 121 requested by me and 122 pending on others — so the two Requested by modes return genuinely different feeds rather than the same rows twice.

- New route returns 401 (not 404) alongside the existing two — registered
- Me's requester list is identical under both Others modes — the reported bug where Xyne Mail appeared under Me only when Others was on All
- Fresh localStorage → `othersMode: all`, all requesters seeded ticked, both toggles on; a stored selection is left untouched
- Summary reads `everyone` → `1 person` → `2 people` → `Platform Pod +2`, and `requested by anyone` in All mode
- Rail guidance renders on the Pending pane only — absent on Channels and Time
- People lists measured at 120px client height / 160px scroll height: three rows, scrolls beyond
- Create team → auto-ticked, chip appears, persisted to `xyne:radar-teams:<userId>`
- Empty state offers only `+ Create team`; the header swaps to `Manage teams ›` once a team exists
- Save disabled with "Add a name and at least one member" until both are given
- Delete team clears its tick and its chip — no orphan narrowing
- Reload restores team, tick, chip, mode and summary

### Automated

- [ ] Backend unit tests
- [ ] Claw tests
- [ ] End-to-end suite
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- no existing test file for RadarPanel or radarFeedService; the filter model is UI state over two endpoints -->

### Manual

**Users**
- [x] Single user
- [ ] Two users at once
- [ ] Different roles or permission levels
- [ ] Different workspaces / spaces

**Login**
- [ ] Google
- [ ] Microsoft
- [x] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [x] Local dev
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience**
- [ ] Multiple tabs stay consistent
- [x] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [x] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [x] Empty state
- [x] Large / realistic data volume
- [ ] Error paths

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes <!-- could not run locally: corepack pnpm 11.21 vs pinned 10.15 gate. This diff touches no packages/ files -->
- [x] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass <!-- lint + typecheck pass; vite build aborted with a Node OOM locally, bundle step unverified -->
- [x] Formatting clean in the packages I touched
- [x] New deps — none added
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind