### PR TITLE
feat: log channelId with counts in Google manual refetch summary

### DIFF
--- a/apps/backend/src/integrations/adapters/google/refetch.ts
+++ b/apps/backend/src/integrations/adapters/google/refetch.ts
@@ -225,7 +225,7 @@ export class GoogleRefetch extends BaseRefetch {
     }
 
     logger.info(
-      `${TAG} ${source.name}: processed=${processed} newTickets=${newTickets} skipped=${skipped} errors=${errors.length}`,
+      `${TAG} ${source.name}: channel=${ingestChannelId} processed=${processed} newTickets=${newTickets} skipped=${skipped} errors=${errors.length}`,
       { dlEmail: options.dlEmail, ingestChannelId },
     );
     return { processed, newTickets, skipped, errors };


### PR DESCRIPTION
## What
Adds `channel=<ingestChannelId>` to the summary log line emitted at the end of `GoogleRefetch.refetch()` in `apps/backend/src/integrations/adapters/google/refetch.ts`, alongside the existing `processed / newTickets / skipped / errors` counts.

## Why
Manual Fetch Mail in production runs asynchronously (the `/external-source-sync/:channelId/refetch` endpoint returns `202 queued`), so per-desk mail counts are not returned in the HTTP response — they are only visible in worker logs. The existing summary log carried the counts and had `ingestChannelId` in structured metadata, but not in the greppable message string. Putting `channel=<id>` directly in the message makes per-channel counts filterable in Grafana/VictoriaLogs, which is needed to build a per-desk manual-fetch status report.

## Change
Single-line change to the `logger.info` message string; no behavior change.