### PR TITLE
fix: XYNE-63184 route call invites through the launch screen

### DIFF
--- a/apps/dashboard-external/src/routes/ExternalLobby/ExternalLobbyPage.tsx
+++ b/apps/dashboard-external/src/routes/ExternalLobby/ExternalLobbyPage.tsx
@@ -66,18 +66,76 @@ type LobbyAction =
 
 const initialState: LobbyState = { stage: 'LOADING' };
 
-function getInternalCallUrl(externalId: string, workspaceId: string): string {
+function getDashboardBaseUrl(): string {
   const configuredBaseUrl = import.meta.env['VITE_INTERNAL_DASHBOARD_BASE_URL'] as
     | string
     | undefined;
-  const dashboardBaseUrl =
+  return (
     configuredBaseUrl?.trim() ||
-    (import.meta.env.DEV ? 'http://localhost:5173' : window.location.origin);
+    (import.meta.env.DEV ? 'http://localhost:5173' : window.location.origin)
+  );
+}
 
-  return new URL(
-    `/${encodeURIComponent(workspaceId)}/call/${encodeURIComponent(externalId)}`,
-    dashboardBaseUrl,
-  ).toString();
+/**
+ * Reached when a call URL is typed into the in-app browser panel, which main's
+ * interception does not cover — /launch there would ask the app to open itself.
+ * Inlined rather than imported: .dependency-cruiser.cjs allows this app only
+ * four direct dashboard imports.
+ */
+function isRunningInDesktopApp(): boolean {
+  if (typeof window === 'undefined') return false;
+  if ((window as { electronAPI?: unknown }).electronAPI) return true;
+  return navigator.userAgent.toLowerCase().includes('electron');
+}
+
+/**
+ * Spaces joins its own call links in-app (dashboard App.tsx) and leaves only
+ * modifier-clicks to the browser, so a referrer from Spaces means the member
+ * asked for a tab, not for the desktop app.
+ */
+function cameFromSpaces(dashboardBaseUrl: string): boolean {
+  if (!document.referrer) return false;
+  try {
+    const referrerOrigin = new URL(document.referrer).origin;
+    return (
+      referrerOrigin === new URL(dashboardBaseUrl, window.location.origin).origin ||
+      referrerOrigin === window.location.origin
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Mirrors the backend's SLACK_FRONTEND_URL: production serves /launch from the
+ * standalone page, not the dashboard route of the same name.
+ */
+function getLaunchBaseUrl(): string {
+  const configured = import.meta.env['VITE_LAUNCH_BASE_URL'] as string | undefined;
+  return configured?.trim() || getDashboardBaseUrl();
+}
+
+/**
+ * A call has one invite URL for teammates and guests alike, so members land in
+ * the guest lobby and are sent back into Spaces from here. Opened from outside
+ * Spaces that goes via /launch, which offers the desktop app and the browser
+ * rather than guessing which one they have: `web` names the browser target,
+ * `autoOpen=0` stops it deep-linking before the choice is shown.
+ */
+function getInternalCallUrl(externalId: string, workspaceId: string): string {
+  const dashboardBaseUrl = getDashboardBaseUrl();
+  const callPath = `/${encodeURIComponent(workspaceId)}/call/${encodeURIComponent(externalId)}`;
+  const directUrl = new URL(callPath, dashboardBaseUrl).toString();
+
+  if (isRunningInDesktopApp() || cameFromSpaces(dashboardBaseUrl)) {
+    return directUrl;
+  }
+
+  const launchUrl = new URL('/launch', getLaunchBaseUrl());
+  launchUrl.searchParams.set('path', callPath);
+  launchUrl.searchParams.set('web', new URL(dashboardBaseUrl, window.location.origin).origin);
+  launchUrl.searchParams.set('autoOpen', '0');
+  return launchUrl.toString();
 }
 
 function lobbyReducer(state: LobbyState, action: LobbyAction): LobbyState {

--- a/apps/public-web/public/index.html
+++ b/apps/public-web/public/index.html
@@ -99,23 +99,80 @@
         .hidden {
             display: none;
         }
+
+        .link-muted {
+            display: inline-block;
+            margin-top: 10px;
+            color: #86868b;
+            font-size: 13px;
+            text-decoration: underline;
+            cursor: pointer;
+        }
+
+        .link-muted:hover {
+            color: #1d1d1f;
+        }
     </style>
     <script>
+        // ?web= names the dashboard "Open in browser" opens. Matched by shape so
+        // no environment is listed here, but still matched: an unchecked origin
+        // from the query string would make this an open redirect.
+        var WEB_HOST_SUFFIX = ".xyne.juspay.net";
+
+        // URLSearchParams decodes once already, so a bare '%' reaching this second
+        // pass throws and takes the whole launch down with it.
+        function safeDecode(value) {
+            try {
+                return decodeURIComponent(value);
+            } catch (e) {
+                return value;
+            }
+        }
+
+        function isLocalHost(hostname) {
+            return hostname === 'localhost' || hostname === '127.0.0.1';
+        }
+
+        // "" when unnamed or not ours, which hides the link rather than guessing —
+        // links predating ?web= keep their old behaviour that way.
+        function resolveWebOrigin(urlParams) {
+            var requested = urlParams.get('web');
+            if (!requested) return "";
+            try {
+                var url = new URL(requested);
+                var host = url.hostname;
+                var isOurs = host === WEB_HOST_SUFFIX.slice(1) || host.endsWith(WEB_HOST_SUFFIX);
+                if (isOurs && url.protocol === 'https:') return url.origin;
+                if (isLocalHost(host)) return url.origin;
+                return "";
+            } catch (e) {
+                return "";
+            }
+        }
+
         window.onload = function () {
-            let deepLink = "xyne-spaces://";
             // Logic to handle both new Path-based and old Query-based links
             const urlParams = new URLSearchParams(window.location.search);
             const legacyPath = urlParams.get('path');
+            let appPath = "";
             if (legacyPath) {
-                deepLink += decodeURIComponent(legacyPath);
+                appPath = safeDecode(legacyPath);
             } else {
                 const path = window.location.pathname;
                 if (path && path !== "/" && path !== "/index.html") {
-                    const cleanPath = path.startsWith('/') ? path.substring(1) : path;
-                    deepLink += cleanPath;
+                    appPath = path;
                 }
             }
-            window.location.href = deepLink;
+            appPath = appPath.replace(/^\/+/, "");
+
+            let deepLink = "xyne-spaces://" + appPath;
+
+            // Launching on load is what a notification wants, but it defeats a page
+            // meant to offer a choice, so call invites pass autoOpen=0.
+            const autoOpen = urlParams.get('autoOpen') !== '0';
+            if (autoOpen) {
+                window.location.href = deepLink;
+            }
             // Platform Detection & UI Update
             const userAgent = navigator.userAgent || navigator.vendor || window.opera;
             const isAndroid = /android/i.test(userAgent);
@@ -124,7 +181,25 @@
             const openBtn = document.getElementById('open-app-btn');
             const downloadBtn = document.getElementById('download-btn');
             const infoBox = document.getElementById('info-box');
+            const openWebBtn = document.getElementById('open-web-btn');
             if (openBtn) openBtn.href = deepLink;
+
+            // A browser cannot be asked whether the desktop app is installed, so
+            // offer both rather than guess.
+            const webOrigin = resolveWebOrigin(urlParams);
+            if (openWebBtn && appPath && webOrigin) {
+                openWebBtn.href = webOrigin + "/" + appPath;
+                openWebBtn.classList.remove('hidden');
+            }
+
+            if (!autoOpen) {
+                const subtitle = document.getElementById('subtitle');
+                if (subtitle) subtitle.textContent = 'Choose how you want to open this.';
+                // Nothing was launched, so the "if nothing happens" nudge would be
+                // describing an attempt that never took place.
+                const autoHint = document.getElementById('auto-hint');
+                if (autoHint) autoHint.classList.add('hidden');
+            }
             if (isMobile) {
                 if (downloadBtn) {
                     downloadBtn.classList.remove('hidden');
@@ -155,7 +230,7 @@
         <img src="xyne.svg" alt="Xyne Spaces" class="logo" />
 
         <h1>Xyne Spaces</h1>
-        <p>Opening content in the app...</p>
+        <p id="subtitle">Opening content in the app...</p>
 
         <!-- Primary Action: Open App -->
         <a href="#" id="open-app-btn" class="button button-primary">Open Application</a>
@@ -168,7 +243,8 @@
     </div>
 
     <div class="footer">
-        If nothing happens, click "Open Application" above.
+        <div id="auto-hint">If nothing happens, click "Open Application" above.</div>
+        <a href="#" id="open-web-btn" class="link-muted hidden">Open in browser</a>
     </div>
 </body>
 


### PR DESCRIPTION
A call has one invite URL for teammates and guests alike, so a member opening it lands in the guest lobby and is redirected back into Spaces. That redirect always went to the web dashboard, even for members who have the desktop app.

Opened from outside Spaces it now goes via the /launch screen that Slack notifications and invitations already use, which offers the desktop app and the browser side by side. A browser cannot be asked whether an app is installed, so the choice is left to the member rather than guessed. Two params extend that page: `web` names the dashboard to offer as the browser option, validated against a host shape so the parameter cannot make it an open redirect, and `autoOpen=0` stops it deep-linking before the choice is shown. Links passing neither keep their behaviour.

Clicks inside Spaces are unaffected: the dashboard joins its own call links in place, and Electron intercepts them before the lobby loads. Guests still reach the lobby.

Also fixes a double decode on the launch page that threw on a bare '%' and took the whole handler down with it.


Claude-Session: https://claude.ai/code/session_01MZy1oTRa1U2HDpqPbJyete

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
