### PR TITLE
feat: XYNE-61401 fix search in filter and group by

### DIFF
--- a/apps/backend/src/validators/vespaSearchValidator.ts
+++ b/apps/backend/src/validators/vespaSearchValidator.ts
@@ -31,11 +31,11 @@ export const vespaSearchQuerySchema = Joi.object({
     'number.max': 'Offset cannot exceed 1000',
   }),
 
-  limit: Joi.number().integer().min(1).max(200).default(20).messages({
+  limit: Joi.number().integer().min(1).max(400).default(20).messages({
     'number.base': 'Limit must be a number',
     'number.integer': 'Limit must be an integer',
     'number.min': 'Limit must be at least 1',
-    'number.max': 'Limit cannot exceed 200'
+    'number.max': 'Limit cannot exceed 400'
   }),
 
   // Rank profile

--- a/apps/dashboard/src/components/Tickets/KanbanColumns/KanbanColumns.tsx
+++ b/apps/dashboard/src/components/Tickets/KanbanColumns/KanbanColumns.tsx
@@ -318,11 +318,29 @@ const PaginatedStageList: React.FC<{
     // When using direct Vespa rows, trust the results - they're already filtered
     // by group-specific Vespa filters (dynamic field tokens, assignee, priority, etc.)
     if (isUsingDirectVespaRows) {
-      // Merge with cached tickets for optimistic updates if available
-      if (allKnownTickets.length > 0) {
-        const knownTicketsById = new Map(allKnownTickets.map(t => [t.id, t]));
-        return tickets.map(ticket => knownTicketsById.get(ticket.id) ?? ticket);
+      // If Vespa returned tickets, merge with cached tickets for optimistic updates
+      if (tickets.length > 0) {
+        if (allKnownTickets.length > 0) {
+          const knownTicketsById = new Map(allKnownTickets.map(t => [t.id, t]));
+          return tickets.map(ticket => knownTicketsById.get(ticket.id) ?? ticket);
+        }
+        return tickets;
       }
+      // Vespa returned 0 tickets. This could be:
+      // 1. A valid empty result (filters matched nothing) - respect it
+      // 2. Vespa segregation filtered out tickets due to stage mismatch - use allKnownTickets
+      //
+      // To distinguish: if allKnownTickets has tickets that belong to this column,
+      // use them (case 2). Otherwise, trust the empty result (case 1).
+      if (allKnownTickets.length > 0) {
+        const columnTickets = allKnownTickets.filter(ticket =>
+          ticketBelongsToColumn(ticket, columnType, columnValue, columnStatus),
+        );
+        if (columnTickets.length > 0) {
+          return columnTickets;
+        }
+      }
+      // No tickets match - return empty (this is a valid filtered result)
       return tickets;
     }
 
@@ -345,7 +363,15 @@ const PaginatedStageList: React.FC<{
     // In group by mode without direct Vespa rows, use allKnownTickets as source of truth.
     // This path is used when Zero query provides the tickets.
     if (allKnownTickets.length === 0) {
-      // Grouping not ready yet - return empty to prevent showing wrong tickets
+      // When allKnownTickets is empty but we have tickets from the hook, use them directly.
+      // This prevents the view from being empty when filtering in group-by mode,
+      // especially for priority grouping where the chicken-and-egg problem can occur:
+      // - allKnownTickets comes from kanbanTicketsForGrouping
+      // - kanbanTicketsForGrouping is built from tickets reported by columns
+      // - But columns can't report tickets if they don't render any
+      if (tickets.length > 0) {
+        return tickets;
+      }
       return [];
     }
 

--- a/apps/dashboard/src/hooks/useVespaTicketSearch.ts
+++ b/apps/dashboard/src/hooks/useVespaTicketSearch.ts
@@ -5,8 +5,9 @@ import type { Ticket } from '@xyne/shared';
 import { TicketPriority, TicketStatusV2 } from '@xyne/shared';
 import { useCmdkDefaultRankProfiles } from './useCmdkSearchConfig';
 
-const MAX_VESPA_TICKET_SEARCH_LIMIT = 200;
+const MAX_VESPA_TICKET_SEARCH_LIMIT = 400;
 const FILTER_ONLY_DYNAMIC_FIELD_CACHE_TTL_MS = 30_000;
+const SEARCH_CACHE_TTL_MS = 10_000;
 const SEARCH_DEBOUNCE_MS = 300;
 
 interface UseVespaTicketSearchParams {
@@ -42,6 +43,10 @@ const filterOnlyDynamicFieldCache = new Map<
   { expiresAt: number; results: DisplaySearchResult[] }
 >();
 const filterOnlyDynamicFieldInflight = new Map<string, Promise<DisplaySearchResult[]>>();
+
+// Shared cache for search results (keyed by searchKey from caller)
+const searchKeyCache = new Map<string, { expiresAt: number; results: Ticket[] }>();
+const searchKeyInflight = new Map<string, Promise<Ticket[]>>();
 
 const getFilterOnlyDynamicFieldCacheKey = (filters: VespaSearchFilters): string =>
   JSON.stringify({
@@ -282,6 +287,57 @@ export const useVespaTicketSearch = ({
           );
           if (!abortController.signal.aborted) {
             setSearchResults(results.map(toTicket));
+            setIsSearching(false);
+          }
+          return;
+        }
+
+        // Use shared cache when searchKey is provided (for deduplicating calls across columns)
+        if (searchKey) {
+          // Include all filters in cache key so different filter combinations don't return stale results
+          const fullCacheKey = `${searchKey}:${JSON.stringify(vespaFilters)}`;
+
+          // Check cache first
+          const cached = searchKeyCache.get(fullCacheKey);
+          if (cached && cached.expiresAt > Date.now()) {
+            if (!abortController.signal.aborted) {
+              setSearchResults(cached.results);
+              setIsSearching(false);
+            }
+            return;
+          }
+
+          // Check for inflight request
+          const inflight = searchKeyInflight.get(fullCacheKey);
+          if (inflight) {
+            const results = await inflight;
+            if (!abortController.signal.aborted) {
+              setSearchResults(results);
+              setIsSearching(false);
+            }
+            return;
+          }
+
+          // Make request and cache it
+          const request = (async (): Promise<Ticket[]> => {
+            const response = await searchService.vespaSearch(vespaFilters);
+            return response.results.map(toTicket);
+          })();
+
+          searchKeyInflight.set(fullCacheKey, request);
+
+          try {
+            const results = await request;
+            searchKeyCache.set(fullCacheKey, {
+              expiresAt: Date.now() + SEARCH_CACHE_TTL_MS,
+              results,
+            });
+            if (!abortController.signal.aborted) {
+              setSearchResults(results);
+              setIsSearching(false);
+            }
+          } finally {
+            searchKeyInflight.delete(fullCacheKey);
           }
           return;
         }
@@ -315,12 +371,57 @@ export const useVespaTicketSearch = ({
       fetchAllDynamicFieldMatches,
       maxFetchedResults,
       rankProfile,
+      searchKey,
     ],
   );
+
+  // Build cache key for immediate lookup (must match performSearch logic)
+  const immediateCacheKey = useMemo(() => {
+    if (!searchKey) return null;
+    const query = searchTerm.trim() || '*';
+    const vespaFilters: VespaSearchFilters = {
+      query,
+      type: 'tickets',
+      apps: 'ticket',
+      limit: safeLimit,
+      rankProfile,
+    };
+    if (projectId) vespaFilters.projectId = projectId;
+    if (boardId) vespaFilters.board = boardId;
+    if (status) vespaFilters.status = status;
+    if (stage) vespaFilters.stage = stage;
+    if (priority) vespaFilters.priority = priority;
+    if (assignee) vespaFilters.assignee = assignee;
+    if (tags) vespaFilters.tags = tags;
+    if (createdBy) vespaFilters.from = createdBy;
+    if (normalizedDynamicFieldValues.length > 0) {
+      vespaFilters.dynamicFieldValues = normalizedDynamicFieldValues;
+    }
+    if (Object.keys(normalizedDynamicFieldDateRanges).length > 0) {
+      vespaFilters.dynamicFieldDateRanges = normalizedDynamicFieldDateRanges;
+    }
+    return `${searchKey}:${JSON.stringify(vespaFilters)}`;
+  }, [
+    searchKey,
+    searchTerm,
+    safeLimit,
+    rankProfile,
+    projectId,
+    boardId,
+    status,
+    stage,
+    priority,
+    assignee,
+    tags,
+    createdBy,
+    normalizedDynamicFieldValues,
+    normalizedDynamicFieldDateRanges,
+  ]);
 
   useEffect(() => {
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
     }
 
     const trimmed = searchTerm.trim();
@@ -333,7 +434,28 @@ export const useVespaTicketSearch = ({
       return;
     }
 
+    // Check cache immediately for instant results when filters change
+    if (immediateCacheKey) {
+      const cached = searchKeyCache.get(immediateCacheKey);
+      if (cached && cached.expiresAt > Date.now()) {
+        setSearchResults(cached.results);
+        setIsSearching(false);
+        return;
+      }
+      // Check for inflight request - wait for it instead of starting new one
+      const inflight = searchKeyInflight.get(immediateCacheKey);
+      if (inflight) {
+        setIsSearching(true);
+        void inflight.then(results => {
+          setSearchResults(results);
+          setIsSearching(false);
+        });
+        return;
+      }
+    }
+
     setIsSearching(true);
+
     debounceTimerRef.current = setTimeout(() => {
       void performSearch(trimmed || '*');
     }, SEARCH_DEBOUNCE_MS);
@@ -341,6 +463,7 @@ export const useVespaTicketSearch = ({
     return (): void => {
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
       }
     };
   }, [
@@ -349,7 +472,9 @@ export const useVespaTicketSearch = ({
     normalizedDynamicFieldDateRanges,
     enabled,
     performSearch,
+    immediateCacheKey,
     searchKey,
+    assignee,
   ]);
 
   useEffect(() => {
@@ -360,5 +485,7 @@ export const useVespaTicketSearch = ({
     };
   }, []);
 
+  // With the shared debounce mechanism, we can trust the isSearching state directly.
+  // The effect properly coordinates across hook instances via pendingDebounces map.
   return { searchResults, isSearching };
 };

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -3494,8 +3494,12 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   useEffect(() => {
     if (!isKanbanLayout) return;
     if (hasSearchTerm) return;
+
+    // Don't reset lastKnownKanbanGroupsRef to null when query key changes.
+    // Keep the old groups visible until new ones load to prevent the view
+    // from disappearing when filters are applied in group-by mode.
+    // Only update the query key ref to track that we're waiting for new data.
     if (lastKnownKanbanGroupsQueryKeyRef.current !== kanbanColumnQueryKey) {
-      lastKnownKanbanGroupsRef.current = null;
       lastKnownKanbanGroupsQueryKeyRef.current = kanbanColumnQueryKey;
     }
 
@@ -3509,14 +3513,8 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
   useEffect(() => {
     if (!isKanbanLayout) return;
-
-    // On the pass where the query key changes, `localTickets` here still holds the previous
-    // query's rows: the reset above only queues setLocalTickets(null), which lands next render.
-    // Stamping the new key onto those rows would make the queryKey check below always pass, so
-    // drop the remembered rows instead and let a later pass re-record the new query's results.
     if (lastKnownKanbanTicketsQueryKeyRef.current !== kanbanColumnQueryKey) {
       lastKnownKanbanTicketsQueryKeyRef.current = kanbanColumnQueryKey;
-      lastKnownKanbanTicketsRef.current = null;
       return;
     }
 
@@ -3539,16 +3537,30 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const kanbanTicketsForGrouping = useMemo(() => {
     if (localTickets && localTickets.length > 0) return localTickets;
     const lastKnownKanbanTickets = lastKnownKanbanTicketsRef.current;
-    if (
-      hasSearchTerm &&
-      lastKnownKanbanTickets !== null &&
-      lastKnownKanbanTickets.queryKey === kanbanColumnQueryKey &&
-      lastKnownKanbanTickets.tickets.length > 0
-    ) {
-      return lastKnownKanbanTickets.tickets;
+    // Use last known tickets as fallback when localTickets is empty/null.
+    // This prevents the view from disappearing when filters are applied in group-by mode.
+    // IMPORTANT: Apply current filters to fallback tickets so stale data doesn't show.
+    if (lastKnownKanbanTickets !== null && lastKnownKanbanTickets.tickets.length > 0) {
+      // Apply current filters to the fallback tickets
+      const filteredFallback = applyTicketFilters(
+        lastKnownKanbanTickets.tickets,
+        deferredFilters,
+        tagsByTicketId,
+        formValuesByTicketId,
+        formFieldsById,
+        user?.id,
+      );
+      return filteredFallback;
     }
     return localTickets ?? [];
-  }, [hasSearchTerm, kanbanColumnQueryKey, localTickets]);
+  }, [
+    localTickets,
+    deferredFilters,
+    tagsByTicketId,
+    formValuesByTicketId,
+    formFieldsById,
+    user?.id,
+  ]);
 
   const processedGroups = useMemo(() => {
     const groupedRows = groupTickets(kanbanTicketsForGrouping, groupBy);

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
@@ -431,18 +431,13 @@ export const useKanbanTicketsPage = (
     : null;
   // Only send to Vespa when we have real IDs and not inverted/includeUnassigned
   // (those semantics require the Zero/local filter path).
-  // Send all 4 identity forms to match prefixedKanbanIdentityValues storage variants.
+  // Send bare IDs - the backend expands to all identity forms for Vespa matching.
   const vespaAssignee =
     parsedAssignee &&
     parsedAssignee.ids.length > 0 &&
     !parsedAssignee.inverted &&
     !parsedAssignee.includeUnassigned
-      ? parsedAssignee.ids
-          .flatMap(id => {
-            const bareId = id.replace(/^(user:|group:|userGroup:)/, '');
-            return [bareId, `user:${bareId}`, `group:${bareId}`, `userGroup:${bareId}`];
-          })
-          .join(',')
+      ? parsedAssignee.ids.map(id => id.replace(/^(user:|group:|userGroup:)/, '')).join(',')
       : undefined;
 
   const vespaTags =
@@ -450,15 +445,10 @@ export const useKanbanTicketsPage = (
       ? options.filters.tags.join(',')
       : undefined;
 
-  // Send all 4 identity forms to match prefixedKanbanIdentityValues storage variants.
+  // Send bare IDs - the backend expands to all identity forms for Vespa matching.
   const vespaCreatedBy =
     options.filters?.createdBy && options.filters.createdBy.length > 0
-      ? options.filters.createdBy
-          .flatMap(id => {
-            const bareId = id.replace(/^(user:|group:|userGroup:)/, '');
-            return [bareId, `user:${bareId}`, `group:${bareId}`, `userGroup:${bareId}`];
-          })
-          .join(',')
+      ? options.filters.createdBy.map(id => id.replace(/^(user:|group:|userGroup:)/, '')).join(',')
       : undefined;
 
   // Compute group-specific filter for Vespa based on groupBy/groupKey
@@ -475,12 +465,9 @@ export const useKanbanTicketsPage = (
     if (options.groupBy === 'assignee') {
       // Don't filter if groupKey is "Unassigned" - Vespa can't filter for null assignee easily
       if (options.groupKey === 'Unassigned') return {};
-      // Vespa may store assignedTo in any of these forms (see prefixedKanbanIdentityValues).
-      // Send all variants so we match regardless of storage format.
+      // Send bare ID - the backend expands to all identity forms for Vespa matching.
       const bareId = options.groupKey.replace(/^(user:|group:|userGroup:)/, '');
-      return {
-        assignee: [bareId, `user:${bareId}`, `group:${bareId}`, `userGroup:${bareId}`].join(','),
-      };
+      return { assignee: bareId };
     }
     if (options.groupBy === 'status') {
       // Filter by the group's status value
@@ -490,34 +477,59 @@ export const useKanbanTicketsPage = (
     return {};
   })();
 
+  // When searching, skip stage/status/groupBy filters - fetch all results and segregate in frontend.
+  // For dynamic field grouping, keep the filters as-is.
+  const isFormFieldGroupBy =
+    typeof options.groupBy === 'object' && options.groupBy?.type === 'formField';
+  const skipColumnFiltersForSearch = hasSearchTerm && !isFormFieldGroupBy;
+
   // Create a search key that changes when the group context changes
   // This forces the search to re-trigger when switching views
+  // When searching without column filters, use a shared key so all columns share one search call
+  // Include filter values in the key so that filter changes trigger a new search
   const groupByKey =
     typeof options.groupBy === 'object'
       ? `${options.groupBy.type}:${options.groupBy.fieldId}`
       : String(options.groupBy ?? 'none');
-  const vespaSearchKey = `${groupByKey}:${options.groupKey ?? ''}:${options.stageName}`;
+  // Include filter values in search key so all columns re-search when filters change
+  const filterKey = skipColumnFiltersForSearch
+    ? JSON.stringify({
+        priority: vespaPriority ?? '',
+        assignee: vespaAssignee ?? '',
+        tags: vespaTags ?? '',
+        createdBy: vespaCreatedBy ?? '',
+      })
+    : '';
+  const vespaSearchKey = skipColumnFiltersForSearch
+    ? `search:${groupByKey}:${filterKey}` // Shared key includes filters
+    : `${groupByKey}:${options.groupKey ?? ''}:${options.stageName}`;
 
   const vespaTicketSearch = useVespaTicketSearch({
     searchTerm: trimmedSearchTerm,
     dynamicFieldValues: pageVespaTokens,
     enabled: requiresVespaTicketIds,
-    limit: 200,
+    limit: hasSearchTerm ? 400 : 200,
     fetchAllDynamicFieldMatches: true,
-    maxFetchedResults: 400,
+    maxFetchedResults: hasSearchTerm ? 800 : 400,
     searchKey: vespaSearchKey,
     ...(options.dynamicFieldDateRanges
       ? { dynamicFieldDateRanges: options.dynamicFieldDateRanges }
       : {}),
     ...(options.projectId ? { projectId: options.projectId } : {}),
     ...(effectiveVespaBoardId ? { boardId: effectiveVespaBoardId } : {}),
-    ...(options.columnType === 'status' ? { status: options.stageName } : {}),
-    ...(options.columnType === 'stage' ? { stage: options.stageName } : {}),
+    // Skip column filters when searching (will segregate in frontend)
+    ...(!skipColumnFiltersForSearch && options.columnType === 'status'
+      ? { status: options.stageName }
+      : {}),
+    ...(!skipColumnFiltersForSearch && options.columnType === 'stage'
+      ? { stage: options.stageName }
+      : {}),
     ...(vespaPriority ? { priority: vespaPriority } : {}),
     ...(vespaAssignee ? { assignee: vespaAssignee } : {}),
     ...(vespaTags ? { tags: vespaTags } : {}),
     ...(vespaCreatedBy ? { createdBy: vespaCreatedBy } : {}),
-    ...vespaGroupFilter,
+    // Skip group filters when searching (will segregate in frontend)
+    ...(!skipColumnFiltersForSearch ? vespaGroupFilter : {}),
   });
   const localFilterKey = JSON.stringify({
     priority: options.filters?.priority ?? [],
@@ -530,20 +542,76 @@ export const useKanbanTicketsPage = (
     ticketTypes: options.filters?.ticketTypes ?? [],
     sourceChannels: options.filters?.sourceChannels ?? [],
   });
-  const directVespaPage = useMemo(
-    () =>
-      shouldUseDirectVespaRows
-        ? applyLocalVespaFilters(
-            options.channelId
-              ? (vespaTicketSearch.searchResults?.filter(
-                  ticket => ticket.channelId === options.channelId,
-                ) ?? null)
-              : vespaTicketSearch.searchResults,
-            options.filters,
-          )
-        : null,
-    [localFilterKey, options.channelId, shouldUseDirectVespaRows, vespaTicketSearch.searchResults],
-  );
+  const directVespaPage = useMemo(() => {
+    if (!shouldUseDirectVespaRows) return null;
+
+    // When a new search is in progress, don't apply current filters to stale results
+    // as they may not match (e.g., user added a filter while search was cached).
+    // Return null to show loading state until fresh results arrive.
+    if (vespaTicketSearch.isSearching) return null;
+
+    let results = vespaTicketSearch.searchResults;
+    if (!results) return null;
+
+    // Filter by channelId if specified
+    if (options.channelId) {
+      results = results.filter(ticket => ticket.channelId === options.channelId);
+    }
+
+    // Apply local filters (priority, boards, assignee, etc.)
+    const filtered = applyLocalVespaFilters(results, options.filters);
+    if (!filtered) return null;
+
+    // When searching without column filters, segregate by stage/status in frontend
+    if (skipColumnFiltersForSearch) {
+      const segregated = filtered.filter(ticket => {
+        // Filter by column stage/status
+        if (options.columnType === 'status' && (ticket.statusV2 as string) !== options.stageName) {
+          return false;
+        }
+        if (options.columnType === 'stage' && ticket.stageName !== options.stageName) {
+          return false;
+        }
+
+        // Filter by groupBy (assignee, priority, status)
+        if (options.groupBy === 'assignee' && options.groupKey) {
+          const ticketAssignee = normalizeIdentity(ticket.assignedTo);
+          if (options.groupKey === 'Unassigned') {
+            if (ticketAssignee) return false;
+          } else {
+            const groupAssignee = normalizeIdentity(options.groupKey);
+            if (ticketAssignee !== groupAssignee) return false;
+          }
+        }
+        if (options.groupBy === 'priority' && options.groupKey) {
+          if (options.groupKey === 'No Priority') {
+            if (ticket.priority) return false;
+          } else {
+            if ((ticket.priority as string) !== options.groupKey) return false;
+          }
+        }
+        if (options.groupBy === 'status' && options.groupKey) {
+          if ((ticket.statusV2 as string) !== options.groupKey) return false;
+        }
+
+        return true;
+      });
+      return segregated;
+    }
+
+    return filtered;
+  }, [
+    localFilterKey,
+    options.channelId,
+    options.columnType,
+    options.stageName,
+    options.groupBy,
+    options.groupKey,
+    shouldUseDirectVespaRows,
+    skipColumnFiltersForSearch,
+    vespaTicketSearch.isSearching,
+    vespaTicketSearch.searchResults,
+  ]);
   const vespaTicketIds = requiresVespaTicketIds
     ? (vespaTicketSearch.searchResults?.map(ticket => ticket.id) ?? [])
     : undefined;

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
@@ -491,13 +491,22 @@ export const useKanbanTicketsPage = (
     typeof options.groupBy === 'object'
       ? `${options.groupBy.type}:${options.groupBy.fieldId}`
       : String(options.groupBy ?? 'none');
-  // Include filter values in search key so all columns re-search when filters change
+  // Include ALL filter values in search key so all columns re-search when filters change
+  // Previously this only included priority, assignee, tags, createdBy - missing boards, stages, etc.
   const filterKey = skipColumnFiltersForSearch
     ? JSON.stringify({
         priority: vespaPriority ?? '',
         assignee: vespaAssignee ?? '',
         tags: vespaTags ?? '',
         createdBy: vespaCreatedBy ?? '',
+        boards: options.filters?.boards ?? [],
+        stages: options.filters?.stages ?? [],
+        ticketTypes: options.filters?.ticketTypes ?? [],
+        sourceChannels: options.filters?.sourceChannels ?? [],
+        userGroups: options.filters?.userGroups ?? [],
+        dynamicFields: options.filters?.dynamicFields ?? {},
+        boardId: effectiveVespaBoardId ?? '',
+        projectId: options.projectId ?? '',
       })
     : '';
   const vespaSearchKey = skipColumnFiltersForSearch


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
