### PR TITLE
fix: XYNE-60272 keep SDLC frame route sync pointed at where each side really is

### DIFF
--- a/apps/dashboard/src/routes/SdlcScreen/SdlcFrameHost.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcFrameHost.tsx
@@ -33,9 +33,8 @@ const SdlcFrameHost = (): ReactElement | null => {
   const initiateCallRef = useRef(initiateCall);
   initiateCallRef.current = initiateCall;
 
-  // Last path each side told the other, so echoes do not loop.
-  const lastFromFrameRef = useRef<string | null>(null);
-  const lastToFrameRef = useRef<string | null>(null);
+  // Where the frame is now, from its last report or our last send; sending it again only echoes.
+  const frameLocationRef = useRef<string | null>(null);
 
   const container = useMemo(() => {
     if (typeof document === 'undefined') return null;
@@ -93,8 +92,7 @@ const SdlcFrameHost = (): ReactElement | null => {
         // request a true cache-bypassing reload.
         const root = `/${workspaceId}/sdlc`;
         initialSrcRef.current = `${SDLC_APP_BASE_PATH}${root}?_reset=${Date.now()}`;
-        lastFromFrameRef.current = null;
-        lastToFrameRef.current = null;
+        frameLocationRef.current = null;
         setIsReady(false);
         setResetCount(count => count + 1);
         if (location.pathname !== root) void navigate(root, { replace: true });
@@ -103,7 +101,7 @@ const SdlcFrameHost = (): ReactElement | null => {
 
       if (message.type !== SDLC_FRAME_MESSAGE.route) return;
 
-      lastFromFrameRef.current = message.path;
+      frameLocationRef.current = message.path;
       // Only while on screen — a hidden frame must not move the address bar.
       const current = `${location.pathname}${location.search}${location.hash}`;
       if (viewport && isSdlcPath(message.path) && message.path !== current) {
@@ -124,11 +122,22 @@ const SdlcFrameHost = (): ReactElement | null => {
     // The hash carries #origin/#messageId scroll targets, so it must ride along.
     const path = `${location.pathname}${location.search}${location.hash}`;
     if (!isSdlcPath(location.pathname)) return;
-    if (path === lastFromFrameRef.current || path === lastToFrameRef.current) return;
+    if (path === frameLocationRef.current) return;
 
-    lastToFrameRef.current = path;
+    // The bare hub link means "back to SDLC", so it returns to wherever the frame already is.
+    const frameLocation = frameLocationRef.current;
+    if (
+      frameLocation &&
+      isSdlcPath(frameLocation) &&
+      /^\/[^/]+\/sdlc\/?$/.test(location.pathname)
+    ) {
+      void navigate(frameLocation, { replace: true });
+      return;
+    }
+
+    frameLocationRef.current = path;
     target.postMessage({ type: SDLC_FRAME_MESSAGE.navigate, path }, window.location.origin);
-  }, [isReady, viewport, location.pathname, location.search, location.hash]);
+  }, [isReady, viewport, location.pathname, location.search, location.hash, navigate]);
 
   if (!container || !hasActivated || !initialSrcRef.current) return null;
 

--- a/apps/dashboard/src/routes/SdlcScreen/useSdlcFrameBridge.ts
+++ b/apps/dashboard/src/routes/SdlcScreen/useSdlcFrameBridge.ts
@@ -33,9 +33,8 @@ export function useSdlcFrameBridge(): void {
   const location = useLocation();
   const navigate = useNavigate();
 
-  // Skip reporting a route the parent just asked for.
-  const lastFromParentRef = useRef<string | null>(null);
-  const lastReportedRef = useRef<string | null>(null);
+  // Where the parent is now, from its last NAVIGATE or our last report; reporting it again only echoes.
+  const parentLocationRef = useRef<string | null>(null);
 
   const enabled = isFramedSdlcSurface();
 
@@ -49,7 +48,7 @@ export function useSdlcFrameBridge(): void {
       const message = parseSdlcFrameMessage(event.data);
       if (!message || message.type !== SDLC_FRAME_MESSAGE.navigate) return;
 
-      lastFromParentRef.current = message.path;
+      parentLocationRef.current = message.path;
       void navigate(message.path);
     };
 
@@ -63,9 +62,9 @@ export function useSdlcFrameBridge(): void {
     if (!enabled) return;
 
     const path = `${location.pathname}${location.search}${location.hash}`;
-    if (path === lastFromParentRef.current || path === lastReportedRef.current) return;
+    if (path === parentLocationRef.current) return;
 
-    lastReportedRef.current = path;
+    parentLocationRef.current = path;
     window.parent.postMessage({ type: SDLC_FRAME_MESSAGE.route, path }, window.location.origin);
   }, [enabled, location.pathname, location.search, location.hash]);
 }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

XYNE-60272. Clicking an SDLC activity or notification sometimes left the hub on the page it was already showing instead of opening the target canvas and conversation.

Cause: the SDLC hub runs in a long-lived iframe (`SdlcFrameHost`) that syncs its route with the main window over postMessage (`useSdlcFrameBridge`). Each side skipped a navigation when the path matched the last path it had *sent* or *reported*, not where the other side currently was.

Repro: open an SDLC activity (hub goes to the canvas), move to Repo Knowledge inside the hub, open Activity and click the same activity again. The host has already sent that path once, so it sends nothing and the hub stays on Repo Knowledge. The frame had the mirror problem: a page it had reported earlier was not reported again when it went back to it.

Fix:
- Each side keeps one ref for where the other side is now (`frameLocationRef` in the host, `parentLocationRef` in the frame), updated on every send and every report.
- The bare `/<workspace>/sdlc` link (sidebar) now restores the frame's current page instead of sending the hub back to its root. The old refs only did this by accident.

## Areas Touched

- [x] `apps/dashboard`

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Dashboard `typecheck` passes, eslint reports 0 errors and prettier is clean on both files, and the pre-commit checks passed. Not yet exercised in a running app.

### Automated

- [x] Not covered by tests <!-- no dashboard test runner for these hooks -->

### Manual

To verify, in the browser and Electron:
1. SDLC hub → Repo Knowledge → Activity → click an SDLC reply activity: the canvas opens with the thread.
2. Move to another page inside the hub → Activity → click the same activity again: the canvas opens with the thread (failed before).
3. Open a canvas → go to Chat → click SDLC in the sidebar: the same canvas is still open.
4. Back/forward and window resize inside the hub: the address bar follows the hub, no loops.

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Formatting clean in the packages I touched
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] No debug logging or commented-out code left behind

<details>
<summary>Debug</summary>

- Claude Code `session_01N9ZgVuG2jMU48PxQgCsnTa` — `b52061404` — made SDLC frame route sync track where each side really is, so repeat activity clicks and sidebar returns land on the right hub page.

</details>
