### PR TITLE
fix: XYNE-60272 keep SDLC frame route sync pointed at where each side really is [backport to release-20260904]

### DIFF
--- a/apps/dashboard/src/routes/SdlcScreen/SdlcFrameHost.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcFrameHost.tsx
@@ -33,9 +33,8 @@ const SdlcFrameHost = (): ReactElement | null => {
   const initiateCallRef = useRef(initiateCall);
   initiateCallRef.current = initiateCall;
 
-  // Last path each side told the other, so echoes do not loop.
-  const lastFromFrameRef = useRef<string | null>(null);
-  const lastToFrameRef = useRef<string | null>(null);
+  // Where the frame is now, from its last report or our last send; sending it again only echoes.
+  const frameLocationRef = useRef<string | null>(null);
 
   const container = useMemo(() => {
     if (typeof document === 'undefined') return null;
@@ -93,8 +92,7 @@ const SdlcFrameHost = (): ReactElement | null => {
         // request a true cache-bypassing reload.
         const root = `/${workspaceId}/sdlc`;
         initialSrcRef.current = `${SDLC_APP_BASE_PATH}${root}?_reset=${Date.now()}`;
-        lastFromFrameRef.current = null;
-        lastToFrameRef.current = null;
+        frameLocationRef.current = null;
         setIsReady(false);
         setResetCount(count => count + 1);
         if (location.pathname !== root) void navigate(root, { replace: true });
@@ -103,7 +101,7 @@ const SdlcFrameHost = (): ReactElement | null => {
 
       if (message.type !== SDLC_FRAME_MESSAGE.route) return;
 
-      lastFromFrameRef.current = message.path;
+      frameLocationRef.current = message.path;
       // Only while on screen — a hidden frame must not move the address bar.
       const current = `${location.pathname}${location.search}${location.hash}`;
       if (viewport && isSdlcPath(message.path) && message.path !== current) {
@@ -124,11 +122,22 @@ const SdlcFrameHost = (): ReactElement | null => {
     // The hash carries #origin/#messageId scroll targets, so it must ride along.
     const path = `${location.pathname}${location.search}${location.hash}`;
     if (!isSdlcPath(location.pathname)) return;
-    if (path === lastFromFrameRef.current || path === lastToFrameRef.current) return;
+    if (path === frameLocationRef.current) return;
 
-    lastToFrameRef.current = path;
+    // The bare hub link means "back to SDLC", so it returns to wherever the frame already is.
+    const frameLocation = frameLocationRef.current;
+    if (
+      frameLocation &&
+      isSdlcPath(frameLocation) &&
+      /^\/[^/]+\/sdlc\/?$/.test(location.pathname)
+    ) {
+      void navigate(frameLocation, { replace: true });
+      return;
+    }
+
+    frameLocationRef.current = path;
     target.postMessage({ type: SDLC_FRAME_MESSAGE.navigate, path }, window.location.origin);
-  }, [isReady, viewport, location.pathname, location.search, location.hash]);
+  }, [isReady, viewport, location.pathname, location.search, location.hash, navigate]);
 
   if (!container || !hasActivated || !initialSrcRef.current) return null;
 

--- a/apps/dashboard/src/routes/SdlcScreen/useSdlcFrameBridge.ts
+++ b/apps/dashboard/src/routes/SdlcScreen/useSdlcFrameBridge.ts
@@ -33,9 +33,8 @@ export function useSdlcFrameBridge(): void {
   const location = useLocation();
   const navigate = useNavigate();
 
-  // Skip reporting a route the parent just asked for.
-  const lastFromParentRef = useRef<string | null>(null);
-  const lastReportedRef = useRef<string | null>(null);
+  // Where the parent is now, from its last NAVIGATE or our last report; reporting it again only echoes.
+  const parentLocationRef = useRef<string | null>(null);
 
   const enabled = isFramedSdlcSurface();
 
@@ -49,7 +48,7 @@ export function useSdlcFrameBridge(): void {
       const message = parseSdlcFrameMessage(event.data);
       if (!message || message.type !== SDLC_FRAME_MESSAGE.navigate) return;
 
-      lastFromParentRef.current = message.path;
+      parentLocationRef.current = message.path;
       void navigate(message.path);
     };
 
@@ -63,9 +62,9 @@ export function useSdlcFrameBridge(): void {
     if (!enabled) return;
 
     const path = `${location.pathname}${location.search}${location.hash}`;
-    if (path === lastFromParentRef.current || path === lastReportedRef.current) return;
+    if (path === parentLocationRef.current) return;
 
-    lastReportedRef.current = path;
+    parentLocationRef.current = path;
     window.parent.postMessage({ type: SDLC_FRAME_MESSAGE.route, path }, window.location.origin);
   }, [enabled, location.pathname, location.search, location.hash]);
 }


### PR DESCRIPTION
## Type of Change
Main: https://github.com/juspay/xyne-spaces/pull/1727

- [x] Bugfix

## Description

XYNE-60272. Backport of #1727 (main) to `release-20260904`. Same commit, cherry-picked cleanly with no conflicts: `SdlcFrameHost.tsx` and `useSdlcFrameBridge.ts` were identical to main on this branch before the pick.

Clicking an SDLC activity or notification sometimes left the hub on the page it was already showing instead of opening the target canvas and conversation. The SDLC iframe and the main window each skipped a navigation when the path matched the last path they had sent or reported, not where the other side currently was. Each side now tracks one location for the other side, and the bare `/<workspace>/sdlc` sidebar link restores the hub's current page. Full write-up in #1727.

## Areas Touched

- [x] `apps/dashboard`

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Same checks as #1727 on main (dashboard typecheck, eslint 0 errors, prettier). The cherry-pick applied cleanly; checks were not re-run on this branch. Not yet exercised in a running app.

### Automated

- [x] Not covered by tests

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`

<details>
<summary>Debug</summary>

- Claude Code `session_01N9ZgVuG2jMU48PxQgCsnTa` — `e25889ab1` — cherry-picked the SDLC frame route sync fix from #1727 onto release-20260904.

</details>
