### PR TITLE
fix: XYNE-63176 open one group row at a time and restore it on back

### DIFF
--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -731,12 +731,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const toggleGroupExpansion = useCallback(
     (groupKey: string) => {
       setExpandedGroups(prev => {
-        const next = new Set(prev);
-        if (next.has(groupKey)) {
-          next.delete(groupKey);
-        } else {
-          next.add(groupKey);
-        }
+        const next = new Set<string>(prev.has(groupKey) ? [] : [groupKey]);
         try {
           const raw = sessionStorage.getItem(expandedGroupsStorageKey);
           const map = (raw ? JSON.parse(raw) : {}) as Record<string, string[]>;
@@ -760,7 +755,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     try {
       const raw = sessionStorage.getItem(expandedGroupsStorageKey);
       const map = (raw ? JSON.parse(raw) : {}) as Record<string, string[]>;
-      setExpandedGroups(new Set(map[groupByKey] ?? []));
+      setExpandedGroups(new Set((map[groupByKey] ?? []).slice(0, 1)));
     } catch (err) {
       logger.error(Event.FRONTEND_ERROR, {
         type: 'migrated_console_error',
@@ -3696,6 +3691,17 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const isTableEmpty = processedGroups.every(group => group.allTickets.length === 0);
   const tableGroups = isTableEmpty ? [] : processedGroups;
 
+  const hasScrolledToExpandedGroup = useRef(false);
+  useEffect(() => {
+    if (hasScrolledToExpandedGroup.current) return;
+    const [expandedGroupKey] = [...expandedGroups];
+    if (!expandedGroupKey || processedGroups.length === 0) return;
+    const el = document.querySelector(`[data-group-key="${CSS.escape(expandedGroupKey)}"]`);
+    if (!el) return;
+    hasScrolledToExpandedGroup.current = true;
+    el.scrollIntoView({ block: 'start' });
+  }, [expandedGroups, processedGroups]);
+
   const filteredAvailableColumns = useMemo(() => {
     if (layoutView === 'table' || layoutView === 'flow') {
       // In table mode, hide TicketCard metadata columns
@@ -5163,6 +5169,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
             return (
               <div
                 key={group.key}
+                data-group-key={group.key}
                 className='flex flex-col rounded-lg border border-border overflow-hidden'
               >
                 {showGroupHeader && (
@@ -5261,7 +5268,11 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                   : null;
 
                 return (
-                  <div key={group.key} className={isExpanded || !showGroupHeader ? 'h-full' : ''}>
+                  <div
+                    key={group.key}
+                    data-group-key={group.key}
+                    className={isExpanded || !showGroupHeader ? 'h-full' : ''}
+                  >
                     {showGroupHeader && (
                       <button
                         onClick={() => toggleGroupExpansion(group.key)}


### PR DESCRIPTION
POT - https://drive.google.com/file/d/1aQuI-vFGMp8jua2JXOI260CvfcebSrQZ/view?usp=sharing

## Type of Change

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-63176 — two changes to the **Group by** view on the kanban board.

**1. Only one group row open at a time.**

Expanding a group mounts `KanbanColumns`, which mounts one `PaginatedStageList` per stage column, each calling `useKanbanTicketsPage` → a joined Zero live query (tickets + assignments + role + tagMappings). When grouping by a form field every column *also* fires a Vespa search plus a second `ticketsByIds` Zero query. So an open group costs `S` live queries for `S` columns, and nothing capped how many groups could be open — cost scaled as `S × groupsOpen`.

Worse, `expandedGroups` is persisted to `sessionStorage` and the **whole set** was restored on mount, so a user who left four groups open came back to four groups re-expanding simultaneously and firing every one of those queries in parallel.

`toggleGroupExpansion` now builds a fresh single-element set instead of mutating a copy, and the restore path clamps a previously-stored multi-group set to one entry so existing sessions don't reopen everything.

**2. Scroll back to the group row after visiting a ticket.**

`KanbanBoardScreen` fully unmounts when a ticket is opened (the row click pushes to `/chat/dir/:channelId`, `/support/…` or `/sdlc/…`, all disjoint routes), and there's no `<ScrollRestoration>` or keep-alive. The *remembering* half already worked — the existing sessionStorage restore rehydrates the open group — and with change 1 there's now exactly one, so "the row" is unambiguous. What was missing was scrolling to it: the group wrappers had no id or ref.

Both the table and kanban layouts now render `data-group-key={group.key}`, and a one-shot mount effect scrolls the restored group into view. It fires once per mount, so manual toggles afterwards don't yank the viewport; if the group hasn't rendered yet (counts still loading) the guard stays unset and it retries on the next `processedGroups` change.

Net diff is 19 insertions / 8 deletions in one file.

### Known adjacent issues, deliberately not fixed here

Both predate this change and are out of scope, but worth tickets:

- `kanban-scroll-${stageId}` (`KanbanColumns.tsx:175`, mounted at `:418`) is keyed only by stage id, so every group's "In Progress" column shares one scroll key — restoring group B's column gives you group A's offset. Single-open makes the collision sequential rather than simultaneous, but it's still wrong; the key needs the group in it.
- `DEFAULT_QUERY_TTL = '2m'` (`packages/shared/src/hooks/useQuery.ts:188`) means collapsing unmounts the component but leaves each column's Zero pipeline live for ~2 minutes. This change bounds the steady state, not the transient from rapid toggling.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

No mutator, schema, query or ACL was touched. The change only affects how many existing queries are mounted concurrently.

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

**Static verification only — this has not been exercised in a running app yet and wants a manual pass before merge.**

What actually ran, in the worktree built on this branch's base:

- `tsc --noEmit --project tsconfig.app.json` — clean
- `eslint src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx` — 0 errors. 13 warnings, all pre-existing and none on the changed lines
- `prettier --check` on the touched file — clean

Not run: `vite build`, `build:shared`, backend typecheck/build (nothing outside `apps/dashboard` changed), and any manual/browser testing.

Worth exercising by hand: expand a group and confirm the previously-open one closes; open a ticket from inside a group and hit back, confirming the same group reopens and scrolls into view; repeat in both the table and kanban layouts; and check a session that already had several groups open still comes back to just one.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- UI state behaviour in a 5.6k-line screen component; verified statically, needs the manual pass described above -->

### Manual

None yet — see above.

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes <!-- not run; packages/shared untouched -->
- [ ] Backend `typecheck` + `build` pass <!-- not run; apps/backend untouched -->
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass <!-- lint + typecheck pass; build NOT run -->
- [x] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides` <!-- n/a, no new deps -->
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed <!-- behaviour changed, no docs touched -->
- [x] No debug logging or commented-out code left behind
