### PR TITLE
feat: XYNE-63206 quick schedule presets in the DM send menu

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
@@ -1241,6 +1241,7 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
                 sendDisabledReason: 'Attachment is still uploading',
               })}
               onScheduleSend={handleScheduleSend}
+              showSchedulePresets={!!isDM && !conversationId}
               {...(globalShortcuts.length > 0 && {
                 bottomLeftSlot: (
                   <>

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -36,6 +36,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../dropdown-menu';
 
@@ -91,7 +93,10 @@ import { VoiceInput } from './VoiceInput';
 import type { VoiceInputHandle } from './VoiceInput';
 import { v4 as uuidv4 } from 'uuid';
 import { logger, Event } from '../../../utils/logger';
-import { ScheduleMessageDialog } from '../ScheduleMessageDialog/ScheduleMessageDialog';
+import {
+  getSchedulePresets,
+  ScheduleMessageDialog,
+} from '../ScheduleMessageDialog/ScheduleMessageDialog';
 import { Checkbox } from '../Checkbox/Checkbox';
 
 /** Extract file extension (e.g. ".pdf") from a filename. Returns empty string if none. */
@@ -255,6 +260,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       onCreateCanvas,
       onTranscriptSelect,
       onScheduleSend,
+      showSchedulePresets = false,
       hasTicket = false,
       disableEnterToSend = false,
       hideSendButton = false,
@@ -380,6 +386,10 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
     const [isSendMenuOpen, setIsSendMenuOpen] = useState(false);
     const [isScheduleDialogOpen, setIsScheduleDialogOpen] = useState(false);
     const openScheduleDialog = useCallback((): void => setIsScheduleDialogOpen(true), []);
+    const schedulePresets = React.useMemo(
+      () => (isSendMenuOpen && showSchedulePresets ? getSchedulePresets() : []),
+      [isSendMenuOpen, showSchedulePresets],
+    );
     const [isPlusMenuOpen, setIsPlusMenuOpen] = useState(false);
     const [showFormatToolbar, setShowFormatToolbar] = useState(defaultFormattingToolbarOpen);
     const [isTranscriptSelectorOpen, setIsTranscriptSelectorOpen] = useState(false);
@@ -1266,6 +1276,17 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
     );
 
     const trackedChannel = useChannel(channelId ?? '');
+
+    const submitScheduled = useCallback(
+      (scheduledFor: number): void => {
+        if (!onScheduleSend) return;
+        const html = editor?.getHTML() ?? '';
+        const files = allAttachments.map(a => a.file).filter((f): f is File => f instanceof File);
+        void onScheduleSend(scheduledFor, html, files);
+        editor?.commands.clearContent(true);
+      },
+      [onScheduleSend, editor, allAttachments],
+    );
 
     const handleSend = useCallback(async () => {
       if (!editor || isSending) return;
@@ -2211,27 +2232,56 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                             className={`w-px h-4 ${hasSendableContent ? 'bg-background/20' : 'bg-muted-foreground/20'}`}
                           ></div>
                           <DropdownMenu open={isSendMenuOpen} onOpenChange={setIsSendMenuOpen}>
-                            <DropdownMenuTrigger asChild>
-                              <button
-                                type='button'
-                                disabled={disabled || isSending}
-                                className='p-1.5 hover:bg-black/10 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#FF4F4F] focus-visible:outline-offset-2'
-                                data-testid='send-options-menu'
-                              >
-                                <ChevronBigDown className='h-3 w-3' />
-                              </button>
-                            </DropdownMenuTrigger>
+                            <Tooltip
+                              content='Schedule for later'
+                              side='top'
+                              delayDuration={1000}
+                              skipDelayDuration={1000}
+                              {...(!showSchedulePresets && { open: false })}
+                            >
+                              <DropdownMenuTrigger asChild>
+                                <button
+                                  type='button'
+                                  disabled={disabled || isSending}
+                                  className='p-1.5 hover:bg-black/10 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#FF4F4F] focus-visible:outline-offset-2'
+                                  data-testid='send-options-menu'
+                                >
+                                  <ChevronBigDown className='h-3 w-3' />
+                                </button>
+                              </DropdownMenuTrigger>
+                            </Tooltip>
                             <DropdownMenuContent side='top' align='end'>
-                              <DropdownMenuItem
-                                onClick={() => {
-                                  void handleSend();
-                                  setIsSendMenuOpen(false);
-                                }}
-                                data-track-category='CHAT_INPUT'
-                                data-track-name='SEND_FROM_MENU'
-                              >
-                                <ArrowUp className='h-4 w-4' /> Send now
-                              </DropdownMenuItem>
+                              {showSchedulePresets ? (
+                                <>
+                                  <DropdownMenuLabel>Schedule message</DropdownMenuLabel>
+                                  {schedulePresets.map(option => (
+                                    <DropdownMenuItem
+                                      key={option.key}
+                                      disabled={!hasSendableContent}
+                                      onClick={() => {
+                                        setIsSendMenuOpen(false);
+                                        submitScheduled(option.at.getTime());
+                                      }}
+                                      data-track-category='CHAT_INPUT'
+                                      data-track-name={`SCHEDULE_PRESET_${option.trackId}`}
+                                    >
+                                      {option.label}
+                                    </DropdownMenuItem>
+                                  ))}
+                                  <DropdownMenuSeparator />
+                                </>
+                              ) : (
+                                <DropdownMenuItem
+                                  onClick={() => {
+                                    void handleSend();
+                                    setIsSendMenuOpen(false);
+                                  }}
+                                  data-track-category='CHAT_INPUT'
+                                  data-track-name='SEND_FROM_MENU'
+                                >
+                                  <ArrowUp className='h-4 w-4' /> Send now
+                                </DropdownMenuItem>
+                              )}
                               <DropdownMenuItem
                                 onClick={() => {
                                   setIsSendMenuOpen(false);
@@ -2240,7 +2290,8 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                                 data-track-category='CHAT_INPUT'
                                 data-track-name='OPEN_SCHEDULE_DIALOG'
                               >
-                                <Clock className='h-4 w-4' /> Schedule message
+                                <Clock className='h-4 w-4' />{' '}
+                                {showSchedulePresets ? 'Custom time' : 'Schedule message'}
                               </DropdownMenuItem>
                             </DropdownMenuContent>
                           </DropdownMenu>
@@ -2312,14 +2363,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
           <ScheduleMessageDialog
             open={isScheduleDialogOpen}
             onOpenChange={setIsScheduleDialogOpen}
-            onConfirm={scheduledFor => {
-              const html = editor?.getHTML() ?? '';
-              const files = allAttachments
-                .map(a => a.file)
-                .filter((f): f is File => f instanceof File);
-              void onScheduleSend(scheduledFor, html, files);
-              editor?.commands.clearContent(true);
-            }}
+            onConfirm={submitScheduled}
           />
         )}
 

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -1279,13 +1279,13 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
 
     const submitScheduled = useCallback(
       (scheduledFor: number): void => {
-        if (!onScheduleSend) return;
+        if (!onScheduleSend || !hasSendableContent) return;
         const html = editor?.getHTML() ?? '';
         const files = allAttachments.map(a => a.file).filter((f): f is File => f instanceof File);
         void onScheduleSend(scheduledFor, html, files);
         editor?.commands.clearContent(true);
       },
-      [onScheduleSend, editor, allAttachments],
+      [onScheduleSend, hasSendableContent, editor, allAttachments],
     );
 
     const handleSend = useCallback(async () => {
@@ -2097,7 +2097,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                         onClick={onCancel}
                         data-track-category='CHAT_INPUT'
                         data-track-name='CANCEL_EDITING'
-                        className='p-2 rounded-md bg-muted text-foreground hover:bg-border transition-all duration-200 ease-in-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#FF4F4F] focus-visible:outline-offset-2'
+                        className='p-2 rounded-md bg-muted text-foreground hover:bg-border transition-all duration-200 ease-in-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2'
                         aria-label='Cancel editing'
                       >
                         <X className='h-4 w-4' />
@@ -2121,11 +2121,11 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                     <div className='relative flex items-center'>
                       {onCreateTicket ? (
                         <div
-                          className={`flex items-center rounded-md overflow-hidden transition-all duration-200 ease-in-out ${
+                          className={`flex items-stretch rounded-md overflow-hidden transition-all duration-200 ease-in-out ${
                             hasSendableContent && !sendDisabled
                               ? artifactComposerDefinition
-                                ? 'bg-orange-500 text-white hover:bg-orange-600'
-                                : 'bg-primary text-primary-foreground hover:bg-primary/90'
+                                ? 'bg-orange-500 text-white'
+                                : 'bg-primary text-primary-foreground'
                               : 'bg-muted text-muted-foreground cursor-not-allowed opacity-50'
                           }`}
                         >
@@ -2141,7 +2141,11 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                               disabled={
                                 disabled || sendDisabled || isSending || !hasSendableContent
                               }
-                              className='p-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#FF4F4F] focus-visible:outline-offset-2'
+                              className={`p-2 flex items-center justify-center transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2 ${
+                                hasSendableContent && !sendDisabled
+                                  ? 'cursor-pointer hover:bg-background/10'
+                                  : 'cursor-not-allowed'
+                              }`}
                               aria-label='Send message'
                               data-testid='send-message-button'
                             >
@@ -2153,7 +2157,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                             </button>
                           </Tooltip>
                           <div
-                            className={`w-px h-4 ${
+                            className={`w-px h-4 self-center ${
                               hasSendableContent ? 'bg-background/20' : 'bg-muted-foreground/20'
                             }`}
                           ></div>
@@ -2162,7 +2166,11 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                               <button
                                 type='button'
                                 disabled={disabled || sendDisabled || isSending}
-                                className='p-1.5 hover:bg-black/10 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#FF4F4F] focus-visible:outline-offset-2'
+                                className={`p-1.5 flex items-center justify-center transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2 ${
+                                  hasSendableContent && !sendDisabled
+                                    ? 'cursor-pointer hover:bg-background/10'
+                                    : 'cursor-not-allowed'
+                                }`}
                                 data-testid='send-options-menu'
                               >
                                 <ChevronBigDown className='h-3 w-3' />
@@ -2183,6 +2191,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                               )}
                               {onScheduleSend && (
                                 <DropdownMenuItem
+                                  disabled={!hasSendableContent}
                                   onClick={() => {
                                     setIsSendMenuOpen(false);
                                     openScheduleDialog();
@@ -2199,11 +2208,11 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                       ) : onScheduleSend ? (
                         // No ticket creation but schedule send is available — split button
                         <div
-                          className={`flex items-center rounded-md overflow-hidden transition-all duration-200 ease-in-out ${
+                          className={`flex items-stretch rounded-md overflow-hidden transition-all duration-200 ease-in-out ${
                             hasSendableContent
                               ? artifactComposerDefinition
-                                ? 'bg-orange-500 text-white hover:bg-orange-600'
-                                : 'bg-primary text-white hover:bg-primary/90'
+                                ? 'bg-orange-500 text-white'
+                                : 'bg-primary text-white'
                               : 'bg-muted text-muted-foreground cursor-not-allowed opacity-80'
                           }`}
                         >
@@ -2217,7 +2226,11 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                               type='button'
                               onClick={() => void handleSend()}
                               disabled={disabled || isSending || !hasSendableContent}
-                              className='p-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#FF4F4F] focus-visible:outline-offset-2'
+                              className={`p-2 flex items-center justify-center transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2 ${
+                                hasSendableContent
+                                  ? 'cursor-pointer hover:bg-background/10'
+                                  : 'cursor-not-allowed'
+                              }`}
                               aria-label='Send message'
                               data-testid='send-message-button'
                             >
@@ -2229,9 +2242,12 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                             </button>
                           </Tooltip>
                           <div
-                            className={`w-px h-4 ${hasSendableContent ? 'bg-background/20' : 'bg-muted-foreground/20'}`}
+                            className={`w-px h-4 self-center ${hasSendableContent ? 'bg-background/20' : 'bg-muted-foreground/20'}`}
                           ></div>
-                          <DropdownMenu open={isSendMenuOpen} onOpenChange={setIsSendMenuOpen}>
+                          <DropdownMenu
+                            open={isSendMenuOpen && hasSendableContent}
+                            onOpenChange={next => setIsSendMenuOpen(next && hasSendableContent)}
+                          >
                             <Tooltip
                               content='Schedule for later'
                               side='top'
@@ -2242,8 +2258,12 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                               <DropdownMenuTrigger asChild>
                                 <button
                                   type='button'
-                                  disabled={disabled || isSending}
-                                  className='p-1.5 hover:bg-black/10 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#FF4F4F] focus-visible:outline-offset-2'
+                                  disabled={disabled || isSending || !hasSendableContent}
+                                  className={`p-1.5 flex items-center justify-center transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2 ${
+                                    hasSendableContent
+                                      ? 'cursor-pointer hover:bg-background/10'
+                                      : 'cursor-not-allowed'
+                                  }`}
                                   data-testid='send-options-menu'
                                 >
                                   <ChevronBigDown className='h-3 w-3' />
@@ -2257,7 +2277,6 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                                   {schedulePresets.map(option => (
                                     <DropdownMenuItem
                                       key={option.key}
-                                      disabled={!hasSendableContent}
                                       onClick={() => {
                                         setIsSendMenuOpen(false);
                                         submitScheduled(option.at.getTime());
@@ -2307,7 +2326,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                             type='button'
                             onClick={() => void handleSend()}
                             disabled={disabled || sendDisabled || isSending || !hasSendableContent}
-                            className={`${compact ? 'flex size-8 items-center justify-center rounded-full p-0' : 'rounded-md p-2'} transition-all duration-200 ease-in-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#FF4F4F] focus-visible:outline-offset-2 ${
+                            className={`${compact ? 'flex size-8 items-center justify-center rounded-full p-0' : 'rounded-md p-2'} transition-all duration-200 ease-in-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2 ${
                               hasSendableContent && !disabled && !sendDisabled
                                 ? 'bg-primary text-primary-foreground hover:bg-primary/90'
                                 : 'bg-muted text-muted-foreground cursor-not-allowed opacity-80'

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.types.ts
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.types.ts
@@ -64,6 +64,7 @@ export interface InputBoxProps {
   onCreateCanvas?: (initialContent?: string) => void;
   onTranscriptSelect?: (content: string) => void;
   onScheduleSend?: (scheduledFor: number, content: string, files: File[]) => void | Promise<void>;
+  showSchedulePresets?: boolean;
   hasTicket?: boolean;
   disableEnterToSend?: boolean;
   hideSendButton?: boolean;

--- a/apps/dashboard/src/components/ui/ScheduleMessageDialog/ScheduleMessageDialog.tsx
+++ b/apps/dashboard/src/components/ui/ScheduleMessageDialog/ScheduleMessageDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { format } from 'date-fns';
 import { X } from 'lucide-react';
 import { Dialog } from '../Dialog';
@@ -6,7 +6,15 @@ import { cn } from '../../../utils/classNames';
 
 const MAX_SCHEDULE_DAYS = 100;
 
-type SchedulePreset = 'tomorrow' | 'nextMonday' | 'custom';
+const SCHEDULE_HOUR = 9;
+const WEEKEND_DAYS = [0, 6];
+
+export interface SchedulePresetOption {
+  key: string;
+  trackId: string;
+  label: string;
+  at: Date;
+}
 
 export interface ScheduleMessageDialogProps {
   open: boolean;
@@ -22,21 +30,35 @@ const padDatetimePart = (n: number): string => String(n).padStart(2, '0');
 const toDatetimeLocalValue = (d: Date): string =>
   `${d.getFullYear()}-${padDatetimePart(d.getMonth() + 1)}-${padDatetimePart(d.getDate())}T${padDatetimePart(d.getHours())}:${padDatetimePart(d.getMinutes())}`;
 
-const getTomorrowAtNine = (): Date => {
-  const d = new Date();
-  d.setDate(d.getDate() + 1);
-  d.setHours(9, 0, 0, 0);
-  d.setSeconds(0, 0);
+const atScheduleHour = (from: Date, dayOffset: number): Date => {
+  const d = new Date(from);
+  d.setDate(d.getDate() + dayOffset);
+  d.setHours(SCHEDULE_HOUR, 0, 0, 0);
   return d;
 };
 
-const getNextMondayAtNine = (): Date => {
-  const d = new Date();
-  const daysUntilMonday = (1 - d.getDay() + 7) % 7 || 7;
-  d.setDate(d.getDate() + daysUntilMonday);
-  d.setHours(9, 0, 0, 0);
-  d.setSeconds(0, 0);
-  return d;
+export const getSchedulePresets = (now: Date = new Date()): SchedulePresetOption[] => {
+  const tomorrow = atScheduleHour(now, 1);
+  const nextMonday = atScheduleHour(now, (1 - now.getDay() + 7) % 7 || 7);
+
+  const presets: SchedulePresetOption[] = [];
+  if (!WEEKEND_DAYS.includes(tomorrow.getDay())) {
+    presets.push({
+      key: 'tomorrow',
+      trackId: 'TOMORROW',
+      label: `Tomorrow at ${format(tomorrow, 'h:mm a')}`,
+      at: tomorrow,
+    });
+  }
+  if (!presets.some(p => p.at.getTime() === nextMonday.getTime())) {
+    presets.push({
+      key: 'next-monday',
+      trackId: 'NEXT_MONDAY',
+      label: `${format(nextMonday, 'EEEE')} at ${format(nextMonday, 'h:mm a')}`,
+      at: nextMonday,
+    });
+  }
+  return presets;
 };
 
 export const ScheduleMessageDialog = ({
@@ -48,13 +70,13 @@ export const ScheduleMessageDialog = ({
   trackCategory = 'CHAT_INPUT',
 }: ScheduleMessageDialogProps): React.ReactElement => {
   const [step, setStep] = useState<'pick' | 'confirm'>('pick');
-  const [preset, setPreset] = useState<SchedulePreset | null>(null);
+  const [preset, setPreset] = useState<string | null>(null);
   const [showCustomPicker, setShowCustomPicker] = useState(false);
   const [scheduleDateValue, setScheduleDateValue] = useState('');
   const [pendingScheduleFor, setPendingScheduleFor] = useState<number | null>(null);
 
-  const tomorrowAtNine = useMemo(() => getTomorrowAtNine(), []);
-  const nextMondayAtNine = useMemo(() => getNextMondayAtNine(), []);
+  const presets = open ? getSchedulePresets() : [];
+  const defaultPreset = presets[0];
 
   const resetDialog = (): void => {
     setStep('pick');
@@ -75,22 +97,18 @@ export const ScheduleMessageDialog = ({
     onOpenChange(nextOpen);
   };
 
-  const handlePresetSelect = (nextPreset: SchedulePreset): void => {
-    if (nextPreset === 'tomorrow') {
-      setPreset('tomorrow');
-      setShowCustomPicker(false);
-      setScheduleDateValue(toDatetimeLocalValue(tomorrowAtNine));
+  const handlePresetSelect = (nextPreset: SchedulePresetOption | 'custom'): void => {
+    if (nextPreset === 'custom') {
+      setPreset('custom');
+      setShowCustomPicker(true);
+      if (!scheduleDateValue && defaultPreset) {
+        setScheduleDateValue(toDatetimeLocalValue(defaultPreset.at));
+      }
       return;
     }
-    if (nextPreset === 'nextMonday') {
-      setPreset('nextMonday');
-      setShowCustomPicker(false);
-      setScheduleDateValue(toDatetimeLocalValue(nextMondayAtNine));
-      return;
-    }
-    setPreset('custom');
-    setShowCustomPicker(true);
-    if (!scheduleDateValue) setScheduleDateValue(toDatetimeLocalValue(tomorrowAtNine));
+    setPreset(nextPreset.key);
+    setShowCustomPicker(false);
+    setScheduleDateValue(toDatetimeLocalValue(nextPreset.at));
   };
 
   const scheduledForMs = scheduleDateValue ? new Date(scheduleDateValue).getTime() : NaN;
@@ -140,40 +158,26 @@ export const ScheduleMessageDialog = ({
             </p>
           </div>
           <div className='px-6 py-4 space-y-2.5'>
-            <button
-              type='button'
-              onClick={() => handlePresetSelect('tomorrow')}
-              className={cn(
-                'w-full flex items-center justify-between gap-3 rounded-xl border px-4 py-3 text-left text-sm transition-colors',
-                preset === 'tomorrow'
-                  ? 'border-2 border-primary bg-primary/5'
-                  : 'border border-border hover:bg-accent/50',
-              )}
-              data-track-category={trackCategory}
-              data-track-name='schedule-preset-tomorrow'
-            >
-              <span className='font-medium text-foreground'>Tomorrow 9:00 AM</span>
-              <span className='text-muted-foreground tabular-nums shrink-0'>
-                {format(tomorrowAtNine, 'MMM d')}
-              </span>
-            </button>
-            <button
-              type='button'
-              onClick={() => handlePresetSelect('nextMonday')}
-              className={cn(
-                'w-full flex items-center justify-between gap-3 rounded-xl border px-4 py-3 text-left text-sm transition-colors',
-                preset === 'nextMonday'
-                  ? 'border-2 border-primary bg-primary/5'
-                  : 'border border-border hover:bg-accent/50',
-              )}
-              data-track-category={trackCategory}
-              data-track-name='schedule-preset-next-monday'
-            >
-              <span className='font-medium text-foreground'>Next Monday 9:00 AM</span>
-              <span className='text-muted-foreground tabular-nums shrink-0'>
-                {format(nextMondayAtNine, 'MMM d')}
-              </span>
-            </button>
+            {presets.map(option => (
+              <button
+                key={option.key}
+                type='button'
+                onClick={() => handlePresetSelect(option)}
+                className={cn(
+                  'w-full flex items-center justify-between gap-3 rounded-xl border px-4 py-3 text-left text-sm transition-colors',
+                  preset === option.key
+                    ? 'border-2 border-primary bg-primary/5'
+                    : 'border border-border hover:bg-accent/50',
+                )}
+                data-track-category={trackCategory}
+                data-track-name={`schedule-preset-${option.key}`}
+              >
+                <span className='font-medium text-foreground'>{option.label}</span>
+                <span className='text-muted-foreground tabular-nums shrink-0'>
+                  {format(option.at, 'MMM d')}
+                </span>
+              </button>
+            ))}
             <button
               type='button'
               onClick={() => handlePresetSelect('custom')}

--- a/apps/dashboard/src/components/ui/dropdown-menu.tsx
+++ b/apps/dashboard/src/components/ui/dropdown-menu.tsx
@@ -79,6 +79,18 @@ const DropdownMenuSubContent = React.forwardRef<
 ));
 DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
 
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn('px-2 py-1.5 text-xs font-medium text-muted-foreground', className)}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
 const DropdownMenuSeparator = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
@@ -99,5 +111,6 @@ export {
   DropdownMenuSubContent,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
 };


### PR DESCRIPTION
[POT](https://drive.google.com/file/d/13wDMBY2wDI4d4ZxmNeZrrKgTdp8LN6ZE/view?usp=sharing)
[POT-1](https://drive.google.com/file/d/1vnQH5dRikB62UpPaY_5Ub2ymypWsoEbY/view?usp=sharing)
Thread: https://app.spaces.xyne.juspay.net/6642623f-cca7-43ad-9a6b-5e49c33226b4/chat/dir/cmlavlf4w0h2i2egl1vt3ntfz#origin=1fc25197-6a52-41e7-9076-a97b5b863aad&createdAt=1789031521545
Add Slack-style quick scheduling to the DM composer. The caret menu now lists the next working-day slots directly ("Tomorrow at 9:00 AM", "Monday at 9:00 AM") and schedules on click; "Custom time" still opens the existing dialog.

Replace the two hardcoded preset helpers with one weekday-aware getSchedulePresets(now): weekend dates are never offered, the Sunday collision where "Tomorrow" and "Next Monday" resolved to the same timestamp is deduped, and labels derive from the real date.

Drop "Send now" from the DM menu, redundant with the split button, and add a "Schedule for later" tooltip on the caret.

Front-end only. Channels, threads and support channels keep the existing menu; the shared dialog picks up the weekend fix everywhere.

Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
