### PR TITLE
fix: XYNE-62304 derive DM list attachment preview from live initial message

### DIFF
--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -4152,6 +4152,7 @@ dmChannelsLatestMessagesPaginated: defineQuery(
                 ),
               ),
             )
+            .related('initialMessage')
             .orderBy('createdAt', 'desc')
             .limit(1),
         ),

--- a/apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx
+++ b/apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx
@@ -29,7 +29,17 @@ interface DmListItemProps {
   channel: Channel;
   unreadCount?: number;
   isSelected?: boolean;
-  latestConversation?: { initial_message_md?: string | null; workspaceId: string } | undefined;
+  latestConversation?:
+    | {
+        initial_message_md?: string | null;
+        workspaceId: string;
+        // Live initial-message row (from the DM query's `initialMessage` relation).
+        // Authoritative attachment signal for conversations whose denormalized
+        // initial_message_md snapshot predates the hasAttachment field and would
+        // otherwise serialize it as false.
+        initialMessage?: { hasAttachment: boolean } | null | undefined;
+      }
+    | undefined;
 }
 
 const getSenderLabel = (isCurrentUser: boolean, isDM: boolean, senderName?: string): string => {
@@ -87,14 +97,20 @@ export const DmListItem = ({
     // which is truthy but renders blank. Fall back to a label whenever the message
     // has no visible text, so an attachment preview is not shown as an empty line.
     const hasVisibleText = htmlToPlainText(lastMessage.content).length > 0;
+    // Prefer the snapshot flag, but fall back to the live initial-message row.
+    // Conversations created before initial_message_md carried hasAttachment
+    // serialize it as false, so relying on the snapshot alone drops the label
+    // for every historical attachment DM.
+    const hasAttachment =
+      lastMessage.hasAttachment || !!latestConversation?.initialMessage?.hasAttachment;
     const rawContent = hasVisibleText
       ? lastMessage.content
-      : lastMessage.hasAttachment
+      : hasAttachment
         ? 'Sent an attachment'
         : lastMessage.content || 'Message';
 
     return sanitizeHtmlString(rawContent);
-  }, [lastMessage]);
+  }, [lastMessage, latestConversation?.initialMessage?.hasAttachment]);
 
   // FlowJSON messages carry the whole interactive flow in their content. Feeding
   // that to RenderMessageWithHTML mounts the full flow card (title, textarea,

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -3536,6 +3536,7 @@ export const queries = defineQueries({
                   ),
                 ),
               )
+              .related('initialMessage')
               .orderBy('createdAt', 'desc')
               .limit(1),
           ),


### PR DESCRIPTION
## What
The DM list preview decides whether to show "Sent an attachment" from the denormalized `initial_message_md` snapshot's `hasAttachment` flag. That field was only added to the snapshot serializer/parser recently (XYNE-62304 label fix, PRs #1495 / #1633), so every conversation whose snapshot predates it serializes `hasAttachment=false` and the label is dropped — leaving a blank preview line for historical attachment DMs (and any future snapshot that omits the field).

## Change
- `dmChannelsLatestMessagesPaginated` (shared + backend copies) now `.related('initialMessage')` so the live message row is available.
- `DmListItem` falls back to the live `initialMessage.hasAttachment` when the snapshot flag is false.

## Why this over a backfill
Fixes historical attachment DMs immediately without a data migration, and is deploy-order-independent. Complements the already-merged snapshot label fix rather than replacing it.

## Validation
- `packages/shared` build (tsc): pass
- `apps/dashboard` typecheck (tsc --noEmit): pass

## Test manually
Open an old attachment-only DM (created before the snapshot carried hasAttachment) — the list preview should read "Sent an attachment" instead of a blank line. Text DMs still preview their text.

Related: XYNE-62304.