### PR TITLE
fix: XYNE-63176 ticket fixes

### DIFF
--- a/apps/backend/src/services/vespaSearch/index.ts
+++ b/apps/backend/src/services/vespaSearch/index.ts
@@ -616,6 +616,30 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       return;
     }
 
+    // Ticket tags search — uses Vespa grouping to get distinct tag values.
+    // Short-circuits the normal search pipeline and returns just tag strings.
+    if (String(type).trim() === 'ticket_tags') {
+      const projectIds = projectId ? toFilterValues(projectId, 'projectId') : undefined;
+      const boardIds = board ? toFilterValues(board, 'board') : undefined;
+      const { tags: tagResults, total } = await vespaService.searchService.searchTicketTags(
+        workspaceId,
+        {
+          projectId: projectIds?.[0],
+          boardIds,
+          query: q ? String(q) : undefined,
+          limit: limit ? Number(limit) : 100,
+        },
+      );
+      res.json({
+        success: true,
+        data: {
+          tags: tagResults,
+          total,
+        },
+      });
+      return;
+    }
+
     const isFilterOnlyDynamicFieldSearch =
       filterOnly === 'true' &&
       (dynamicFieldValues !== undefined || dynamicFieldDateRanges !== undefined);

--- a/apps/backend/src/utils/idValidator.ts
+++ b/apps/backend/src/utils/idValidator.ts
@@ -195,7 +195,7 @@ export async function validateTicketIds(ticketIds: string[]): Promise<IdValidati
 export const VALID_DOC_TYPES = [
   'messages', 'attachments', 'channels', 'tickets', 'users', 'files',
   'canvas', 'transcript', 'rca',
-  'people', 'emails', 'calls'
+  'people', 'emails', 'calls', 'ticket_tags'
 ] as const;
 
 /**

--- a/apps/backend/src/validators/vespaSearchValidator.ts
+++ b/apps/backend/src/validators/vespaSearchValidator.ts
@@ -45,11 +45,12 @@ export const vespaSearchQuerySchema = Joi.object({
 
   // Frontend-compatible filters (includes subApp types: canvas, transcript, rca)
   // Supports comma-separated values: messages,files or canvas,transcript
+  // Special type 'ticket_tags' is used for tag search aggregation
   type: Joi.string()
-    .pattern(/^(messages|attachments|calls|channels|tickets|users|files|canvas|transcript|rca|people|emails)(,(messages|attachments|calls|channels|tickets|users|files|canvas|transcript|rca|people|emails))*$/)
+    .pattern(/^(messages|attachments|calls|channels|tickets|users|files|canvas|transcript|rca|people|emails|ticket_tags)(,(messages|attachments|calls|channels|tickets|users|files|canvas|transcript|rca|people|emails|ticket_tags))*$/)
     .optional()
     .messages({
-      'string.pattern.base': 'Type must be comma-separated values of: messages, attachments, calls, channels, tickets, users, files, canvas, transcript, rca, people, emails, calls'
+      'string.pattern.base': 'Type must be comma-separated values of: messages, attachments, calls, channels, tickets, users, files, canvas, transcript, rca, people, emails, ticket_tags'
     }),
 
   from: Joi.alternatives()

--- a/apps/backend/src/validators/vespaSearchValidator.ts
+++ b/apps/backend/src/validators/vespaSearchValidator.ts
@@ -31,11 +31,11 @@ export const vespaSearchQuerySchema = Joi.object({
     'number.max': 'Offset cannot exceed 1000',
   }),
 
-  limit: Joi.number().integer().min(1).max(200).default(20).messages({
+  limit: Joi.number().integer().min(1).max(400).default(20).messages({
     'number.base': 'Limit must be a number',
     'number.integer': 'Limit must be an integer',
     'number.min': 'Limit must be at least 1',
-    'number.max': 'Limit cannot exceed 200'
+    'number.max': 'Limit cannot exceed 400'
   }),
 
   // Rank profile

--- a/apps/backend/src/vespa/src/services/searchService.ts
+++ b/apps/backend/src/vespa/src/services/searchService.ts
@@ -727,13 +727,13 @@ export class SearchService {
       conditions.push(`(${boardConditions})`);
     }
 
-    // If query is provided, filter tags that match the prefix using regexp
-    // This is done post-grouping since Vespa doesn't support prefix filtering on array elements in WHERE
-    const queryPrefix = query?.trim().toLowerCase();
+    // If query is provided, filter tags that contain the search term
+    // This is done post-grouping since Vespa doesn't support substring filtering on array elements in WHERE
+    const queryLower = query?.trim().toLowerCase();
 
-    // YQL with grouping on each element of the tags array
-    // This returns each unique tag value with its count
-    const yql = `select * from ticket where ${conditions.join(' and ')} | all(group(each(tags)) max(${limit}) order(-count()) each(output(count())))`;
+    // YQL with grouping on the tags array
+    // Vespa automatically expands array fields in grouping, returning each unique tag value with its count
+    const yql = `select * from ticket where ${conditions.join(' and ')} | all(group(tags) max(${limit}) order(-count()) each(output(count())))`;
 
     try {
       const response = await this.vespa.search<VespaSearchResponse>({
@@ -745,19 +745,27 @@ export class SearchService {
       // Parse grouped results
       const tags: string[] = [];
       const root = (response?.root ?? {}) as any;
-      const children = (root?.children ?? []) as Array<any>;
+      const rootChildren = (root?.children ?? []) as Array<any>;
 
-      // Navigate the grouping structure: grouplist -> group -> value
-      for (const child of children) {
-        if (child.id?.startsWith('grouplist:')) {
-          const groups = child.children ?? [];
-          for (const group of groups) {
-            if (group.id?.startsWith('group:')) {
-              const tagValue = group.value;
-              if (typeof tagValue === 'string' && tagValue.trim()) {
-                // Apply prefix filter if query provided
-                if (!queryPrefix || tagValue.toLowerCase().startsWith(queryPrefix)) {
-                  tags.push(tagValue);
+      // Navigate the grouping structure: group:root -> grouplist:tags -> group:string:* -> value
+      for (const rootChild of rootChildren) {
+        // First level: group:root:0
+        if (rootChild.id?.startsWith('group:root:')) {
+          const groupListChildren = rootChild.children ?? [];
+          for (const groupList of groupListChildren) {
+            // Second level: grouplist:tags
+            if (groupList.id?.startsWith('grouplist:')) {
+              const groups = groupList.children ?? [];
+              for (const group of groups) {
+                // Third level: group:string:tagname
+                if (group.id?.startsWith('group:')) {
+                  const tagValue = group.value;
+                  if (typeof tagValue === 'string' && tagValue.trim()) {
+                    // Apply substring filter if query provided
+                    if (!queryLower || tagValue.toLowerCase().includes(queryLower)) {
+                      tags.push(tagValue);
+                    }
+                  }
                 }
               }
             }

--- a/apps/backend/src/vespa/src/services/searchService.ts
+++ b/apps/backend/src/vespa/src/services/searchService.ts
@@ -692,4 +692,86 @@ export class SearchService {
       throw error;
     }
   };
+
+  /**
+   * Search for distinct ticket tags from Vespa.
+   * Uses grouping to aggregate unique tag values from ticket documents.
+   *
+   * @param workspaceId - Workspace ID for isolation
+   * @param options - Search options (projectId, boardIds, query prefix, limit)
+   * @returns Array of distinct tag strings sorted alphabetically
+   */
+  async searchTicketTags(
+    workspaceId: string,
+    options: {
+      projectId?: string;
+      boardIds?: string[];
+      query?: string;
+      limit?: number;
+    } = {},
+  ): Promise<{ tags: string[]; total: number }> {
+    const { projectId, boardIds, query, limit = 100 } = options;
+
+    // Build WHERE conditions
+    const conditions: string[] = [
+      `docType contains "ticket"`,
+      `workspaceId contains "${workspaceId}"`,
+    ];
+
+    if (projectId) {
+      conditions.push(`projectId contains "${projectId}"`);
+    }
+
+    if (boardIds && boardIds.length > 0) {
+      const boardConditions = boardIds.map(id => `boardId contains "${id}"`).join(' or ');
+      conditions.push(`(${boardConditions})`);
+    }
+
+    // If query is provided, filter tags that match the prefix using regexp
+    // This is done post-grouping since Vespa doesn't support prefix filtering on array elements in WHERE
+    const queryPrefix = query?.trim().toLowerCase();
+
+    // YQL with grouping on each element of the tags array
+    // This returns each unique tag value with its count
+    const yql = `select * from ticket where ${conditions.join(' and ')} | all(group(each(tags)) max(${limit}) order(-count()) each(output(count())))`;
+
+    try {
+      const response = await this.vespa.search<VespaSearchResponse>({
+        yql,
+        hits: 0, // We only want grouping results, not individual docs
+        timeout: '10s',
+      } as any);
+
+      // Parse grouped results
+      const tags: string[] = [];
+      const root = (response?.root ?? {}) as any;
+      const children = (root?.children ?? []) as Array<any>;
+
+      // Navigate the grouping structure: grouplist -> group -> value
+      for (const child of children) {
+        if (child.id?.startsWith('grouplist:')) {
+          const groups = child.children ?? [];
+          for (const group of groups) {
+            if (group.id?.startsWith('group:')) {
+              const tagValue = group.value;
+              if (typeof tagValue === 'string' && tagValue.trim()) {
+                // Apply prefix filter if query provided
+                if (!queryPrefix || tagValue.toLowerCase().startsWith(queryPrefix)) {
+                  tags.push(tagValue);
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // Sort alphabetically
+      tags.sort((a, b) => a.localeCompare(b));
+
+      return { tags, total: tags.length };
+    } catch (error) {
+      this.logger.error(`Error searching ticket tags: ${getErrorMessage(error)}`);
+      return { tags: [], total: 0 };
+    }
+  }
 }

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -4186,12 +4186,47 @@ dmChannelsLatestMessagesPaginated: defineQuery(
   getAllTicketTags: defineQuery(() => {
     return zql.ticket_tags;
   }),
+  // Query for project tags by project ID (paginated with bidirectional cursor)
   projectTagsByProjectId: defineQuery(
-    z.object({ projectId: z.string() }),
-    ({ args: { projectId } }) => {
-      return zql.project_tags
+    z.object({
+      projectId: z.string(),
+      limit: z.number().optional(),
+      start: z.object({ name: z.string(), id: z.string() }).nullish(),
+      direction: z.enum(['forward', 'backward']).optional(),
+    }),
+    ({ args: { projectId, limit = 100, start, direction = 'forward' } }) => {
+      const isBackward = direction === 'backward';
+      let q = zql.project_tags
         .where('projectId', projectId)
-        .orderBy('name', 'asc');
+        .orderBy('name', isBackward ? 'desc' : 'asc')
+        .orderBy('id', isBackward ? 'desc' : 'asc');
+      if (start) {
+        q = q.start({ name: start.name, id: start.id }, { inclusive: false });
+      }
+      return q.limit(limit);
+    },
+  ),
+  // Query for project tags by multiple project IDs (paginated with bidirectional cursor)
+  projectTagsByProjectIds: defineQuery(
+    z.object({
+      projectIds: z.array(z.string()),
+      limit: z.number().optional(),
+      start: z.object({ name: z.string(), id: z.string() }).nullish(),
+      direction: z.enum(['forward', 'backward']).optional(),
+    }),
+    ({ args: { projectIds, limit = 100, start, direction = 'forward' } }) => {
+      if (projectIds.length === 0) {
+        return zql.project_tags.where('id', 'nonexistent').limit(0);
+      }
+      const isBackward = direction === 'backward';
+      let q = zql.project_tags
+        .where('projectId', 'IN', projectIds)
+        .orderBy('name', isBackward ? 'desc' : 'asc')
+        .orderBy('id', isBackward ? 'desc' : 'asc');
+      if (start) {
+        q = q.start({ name: start.name, id: start.id }, { inclusive: false });
+      }
+      return q.limit(limit);
     },
   ),
 

--- a/apps/dashboard/src/components/Tickets/KanbanColumns/KanbanColumns.tsx
+++ b/apps/dashboard/src/components/Tickets/KanbanColumns/KanbanColumns.tsx
@@ -92,6 +92,9 @@ const SortableTicketCard: React.FC<SortableTicketCardProps> = ({
   tags,
   onClick,
   availableTags = [],
+  onLoadMoreTags,
+  hasMoreTags = false,
+  onSearchTags,
   visibleColumns,
   activeTicketId,
   showEmailReads,
@@ -124,6 +127,9 @@ const SortableTicketCard: React.FC<SortableTicketCardProps> = ({
         tags={tags}
         onClick={onClick}
         availableTags={availableTags}
+        onLoadMoreTags={onLoadMoreTags}
+        hasMoreTags={hasMoreTags}
+        onSearchTags={onSearchTags}
         visibleColumns={visibleColumns}
         {...(activeTicketId !== undefined && { activeTicketId })}
         {...(showEmailReads !== undefined && { showEmailReads })}
@@ -145,14 +151,17 @@ const VirtualizedStageList: React.FC<{
   stageTickets: Ticket[];
   hasMore?: boolean;
   isLoadingMore?: boolean;
-  onLoadMore?: () => void;
-  onTicketsChange?: (columnKey: string, tickets: Ticket[]) => void;
+  onLoadMore?: (() => void) | undefined;
+  onTicketsChange?: ((columnKey: string, tickets: Ticket[]) => void) | undefined;
   availableTags: string[];
+  onLoadMoreTags?: (() => void) | undefined;
+  hasMoreTags?: boolean;
+  onSearchTags?: ((query: string) => void) | undefined;
   visibleColumns?: Set<string> | undefined;
   activeTicketId?: string;
   showEmailReads?: boolean;
   onTicketClick: (e: React.MouseEvent | KeyboardEvent, ticket: Ticket) => void;
-  onAddTicket?: () => void;
+  onAddTicket?: (() => void) | undefined;
   slaPolicies?: BoardSlaPolicy[];
 }> = ({
   stageId,
@@ -164,6 +173,9 @@ const VirtualizedStageList: React.FC<{
   onTicketsChange,
   onAddTicket,
   availableTags,
+  onLoadMoreTags,
+  hasMoreTags = false,
+  onSearchTags,
   visibleColumns,
   activeTicketId,
   showEmailReads,
@@ -245,6 +257,9 @@ const VirtualizedStageList: React.FC<{
                   ticketId: m.ticketId,
                 }))}
                 availableTags={availableTags}
+                onLoadMoreTags={onLoadMoreTags}
+                hasMoreTags={hasMoreTags}
+                onSearchTags={onSearchTags}
                 onClick={e => onTicketClick(e, ticket)}
                 visibleColumns={visibleColumns}
                 {...(activeTicketId !== undefined && { activeTicketId })}
@@ -280,13 +295,16 @@ const PaginatedStageList: React.FC<{
   paginationArgs: KanbanTicketsPageBaseArgs;
   columnType: 'stage' | 'status';
   allKnownTickets: Ticket[];
-  onTicketsChange?: (columnKey: string, tickets: Ticket[]) => void;
+  onTicketsChange?: ((columnKey: string, tickets: Ticket[]) => void) | undefined;
   availableTags: string[];
+  onLoadMoreTags?: (() => void) | undefined;
+  hasMoreTags?: boolean;
+  onSearchTags?: ((query: string) => void) | undefined;
   visibleColumns?: Set<string> | undefined;
   activeTicketId?: string;
   showEmailReads?: boolean;
   onTicketClick: (e: React.MouseEvent | KeyboardEvent, ticket: Ticket) => void;
-  onAddTicket?: () => void;
+  onAddTicket?: (() => void) | undefined;
   slaPolicies?: BoardSlaPolicy[];
 }> = ({
   stage,
@@ -296,6 +314,9 @@ const PaginatedStageList: React.FC<{
   allKnownTickets,
   onTicketsChange,
   availableTags,
+  onLoadMoreTags,
+  hasMoreTags = false,
+  onSearchTags,
   visibleColumns,
   activeTicketId,
   showEmailReads,
@@ -434,6 +455,9 @@ const PaginatedStageList: React.FC<{
         isLoadingMore={isLoadingMore}
         onLoadMore={loadMore}
         availableTags={availableTags}
+        onLoadMoreTags={onLoadMoreTags}
+        hasMoreTags={hasMoreTags}
+        onSearchTags={onSearchTags}
         visibleColumns={visibleColumns}
         {...(activeTicketId !== undefined && { activeTicketId })}
         {...(showEmailReads !== undefined && { showEmailReads })}
@@ -467,6 +491,12 @@ interface KanbanColumnsProps {
   /** Scopes the saved layout: status columns carry the same ids on every board. */
   layoutScope?: string;
   availableTags?: string[];
+  /** Callback to load more tags */
+  onLoadMoreTags?: () => void;
+  /** Whether there are more tags to load */
+  hasMoreTags?: boolean;
+  /** Callback for server-side tag search */
+  onSearchTags?: (query: string) => void;
   containerClassName?: string;
   visibleColumns?: Set<string> | undefined;
   paginatedColumnConfig?: {
@@ -523,6 +553,9 @@ export const KanbanColumns: React.FC<KanbanColumnsProps> = ({
   layoutScope = '',
   containerClassName,
   availableTags = [],
+  onLoadMoreTags,
+  hasMoreTags = false,
+  onSearchTags,
   visibleColumns,
   activeTicketId,
   showEmailReads,
@@ -807,6 +840,9 @@ export const KanbanColumns: React.FC<KanbanColumnsProps> = ({
                       allKnownTickets={knownTicketsForOptimisticMerge}
                       {...(onTicketsChange !== undefined ? { onTicketsChange } : {})}
                       availableTags={availableTags}
+                      onLoadMoreTags={onLoadMoreTags}
+                      hasMoreTags={hasMoreTags}
+                      onSearchTags={onSearchTags}
                       visibleColumns={visibleColumns}
                       {...(activeTicketId !== undefined && { activeTicketId })}
                       {...(showEmailReads !== undefined && { showEmailReads })}
@@ -824,6 +860,9 @@ export const KanbanColumns: React.FC<KanbanColumnsProps> = ({
                         stageTickets={stageTickets}
                         {...(onTicketsChange !== undefined ? { onTicketsChange } : {})}
                         availableTags={availableTags}
+                        onLoadMoreTags={onLoadMoreTags}
+                        hasMoreTags={hasMoreTags}
+                        onSearchTags={onSearchTags}
                         visibleColumns={visibleColumns}
                         {...(activeTicketId !== undefined && { activeTicketId })}
                         {...(showEmailReads !== undefined && { showEmailReads })}

--- a/apps/dashboard/src/components/Tickets/KanbanColumns/KanbanColumns.tsx
+++ b/apps/dashboard/src/components/Tickets/KanbanColumns/KanbanColumns.tsx
@@ -318,11 +318,29 @@ const PaginatedStageList: React.FC<{
     // When using direct Vespa rows, trust the results - they're already filtered
     // by group-specific Vespa filters (dynamic field tokens, assignee, priority, etc.)
     if (isUsingDirectVespaRows) {
-      // Merge with cached tickets for optimistic updates if available
-      if (allKnownTickets.length > 0) {
-        const knownTicketsById = new Map(allKnownTickets.map(t => [t.id, t]));
-        return tickets.map(ticket => knownTicketsById.get(ticket.id) ?? ticket);
+      // If Vespa returned tickets, merge with cached tickets for optimistic updates
+      if (tickets.length > 0) {
+        if (allKnownTickets.length > 0) {
+          const knownTicketsById = new Map(allKnownTickets.map(t => [t.id, t]));
+          return tickets.map(ticket => knownTicketsById.get(ticket.id) ?? ticket);
+        }
+        return tickets;
       }
+      // Vespa returned 0 tickets. This could be:
+      // 1. A valid empty result (filters matched nothing) - respect it
+      // 2. Vespa segregation filtered out tickets due to stage mismatch - use allKnownTickets
+      //
+      // To distinguish: if allKnownTickets has tickets that belong to this column,
+      // use them (case 2). Otherwise, trust the empty result (case 1).
+      if (allKnownTickets.length > 0) {
+        const columnTickets = allKnownTickets.filter(ticket =>
+          ticketBelongsToColumn(ticket, columnType, columnValue, columnStatus),
+        );
+        if (columnTickets.length > 0) {
+          return columnTickets;
+        }
+      }
+      // No tickets match - return empty (this is a valid filtered result)
       return tickets;
     }
 
@@ -345,7 +363,15 @@ const PaginatedStageList: React.FC<{
     // In group by mode without direct Vespa rows, use allKnownTickets as source of truth.
     // This path is used when Zero query provides the tickets.
     if (allKnownTickets.length === 0) {
-      // Grouping not ready yet - return empty to prevent showing wrong tickets
+      // When allKnownTickets is empty but we have tickets from the hook, use them directly.
+      // This prevents the view from being empty when filtering in group-by mode,
+      // especially for priority grouping where the chicken-and-egg problem can occur:
+      // - allKnownTickets comes from kanbanTicketsForGrouping
+      // - kanbanTicketsForGrouping is built from tickets reported by columns
+      // - But columns can't report tickets if they don't render any
+      if (tickets.length > 0) {
+        return tickets;
+      }
       return [];
     }
 

--- a/apps/dashboard/src/components/Tickets/TagsListContent/TagsListContent.tsx
+++ b/apps/dashboard/src/components/Tickets/TagsListContent/TagsListContent.tsx
@@ -1,0 +1,245 @@
+import { ReactElement, useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import {
+  SearchDefault as Search,
+  CheckTickSingle as Check,
+  Tag,
+  PlusDefault as Plus,
+} from '@xyne/icons';
+import Input from '../../ui/Input/Input';
+
+export interface TagsListContentProps {
+  selectedTags: string[];
+  onChange: (tags: string[]) => void;
+  availableTags?: string[] | undefined;
+  /** Callback to load more tags */
+  onLoadMore?: (() => void) | undefined;
+  /** Whether there are more tags to load */
+  hasMore?: boolean | undefined;
+  /** Whether to show the "Select All" button (default: true) */
+  showSelectAll?: boolean | undefined;
+  /** Whether to allow creating new tags (default: false) */
+  allowCreate?: boolean | undefined;
+  /** Callback when creating a new tag */
+  onCreateTag?: ((tagName: string) => void) | undefined;
+  /** Callback after a tag is toggled (e.g., to close the popover) */
+  onTagToggled?: (() => void) | undefined;
+  /** Keyboard event handler for search input */
+  onKeyDown?: ((e: React.KeyboardEvent) => void) | undefined;
+  /** Callback for server-side search (debounced internally) */
+  onSearch?: ((query: string) => void) | undefined;
+}
+
+export const TagsListContent = ({
+  selectedTags,
+  onChange,
+  availableTags = [],
+  onLoadMore,
+  hasMore = false,
+  showSelectAll = true,
+  allowCreate = false,
+  onCreateTag,
+  onTagToggled,
+  onKeyDown,
+  onSearch,
+}: TagsListContentProps): ReactElement => {
+  const [searchQuery, setSearchQuery] = useState('');
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const listContainerRef = useRef<HTMLDivElement>(null);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Focus search input when component mounts
+  useEffect(() => {
+    searchInputRef.current?.focus();
+  }, []);
+
+  // Debounced search callback
+  useEffect(() => {
+    if (!onSearch) return;
+
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    debounceTimerRef.current = setTimeout(() => {
+      onSearch(searchQuery);
+    }, 300);
+
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [searchQuery, onSearch]);
+
+  // Scroll detection for infinite loading (only when not searching)
+  const handleScroll = useCallback(() => {
+    if (!listContainerRef.current || !onLoadMore || !hasMore || searchQuery.trim()) return;
+
+    const { scrollTop, scrollHeight, clientHeight } = listContainerRef.current;
+    // Load more when scrolled to within 50px of bottom
+    if (scrollHeight - scrollTop - clientHeight < 50) {
+      onLoadMore();
+    }
+  }, [onLoadMore, hasMore, searchQuery]);
+
+  useEffect(() => {
+    const container = listContainerRef.current;
+    if (!container) return;
+
+    container.addEventListener('scroll', handleScroll);
+    return () => container.removeEventListener('scroll', handleScroll);
+  }, [handleScroll]);
+
+  const finalResults = useMemo(() => {
+    if (!availableTags || availableTags.length === 0) {
+      return [];
+    }
+
+    // Filter by search query if present
+    let filtered = availableTags;
+    if (searchQuery.trim()) {
+      const lower = searchQuery.toLowerCase();
+      filtered = availableTags.filter(tag => tag.toLowerCase().includes(lower));
+    }
+
+    // Sort selected items to top
+    const selectedSet = new Set(selectedTags);
+    return [...filtered].sort((a, b) => {
+      const aSel = selectedSet.has(a) ? 1 : 0;
+      const bSel = selectedSet.has(b) ? 1 : 0;
+      return bSel - aSel;
+    });
+  }, [availableTags, searchQuery, selectedTags]);
+
+  // Check if we can create a new tag
+  const canCreate = useMemo(() => {
+    if (!allowCreate) return false;
+    const trimmed = searchQuery.trim();
+    return trimmed && !availableTags.some(t => t.toLowerCase() === trimmed.toLowerCase());
+  }, [searchQuery, availableTags, allowCreate]);
+
+  const handleTagToggle = (tag: string) => {
+    const isSelected = selectedTags.includes(tag);
+    onChange(isSelected ? selectedTags.filter(t => t !== tag) : [...selectedTags, tag]);
+    onTagToggled?.();
+  };
+
+  const handleCreateTag = () => {
+    const trimmed = searchQuery.trim();
+    if (canCreate) {
+      onCreateTag?.(trimmed);
+      onChange([...selectedTags, trimmed]);
+      setSearchQuery('');
+      onTagToggled?.();
+    }
+  };
+
+  const visibleTagNames = finalResults.map(t => t);
+  const allVisibleSelected =
+    visibleTagNames.length > 0 && visibleTagNames.every(t => selectedTags.includes(t));
+
+  const handleSelectAllToggle = (): void => {
+    if (allVisibleSelected) {
+      onChange(selectedTags.filter(t => !visibleTagNames.includes(t)));
+    } else {
+      const merged = new Set([...selectedTags, ...visibleTagNames]);
+      onChange([...merged]);
+    }
+  };
+
+  return (
+    <>
+      <div className='p-3 border-b sticky top-0 bg-background z-10'>
+        <div className='relative'>
+          <Search className='absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none' />
+          <Input
+            ref={searchInputRef}
+            type='text'
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder='Search labels...'
+            className='pl-9 h-9'
+          />
+        </div>
+      </div>
+      <div
+        ref={listContainerRef}
+        className='max-h-80 overflow-y-auto p-1'
+        role='listbox'
+        aria-multiselectable='true'
+      >
+        {!availableTags || availableTags.length === 0 ? (
+          <div className='p-8 text-center text-sm text-muted-foreground'>No labels available</div>
+        ) : finalResults.length > 0 ? (
+          <div className='space-y-0.5'>
+            {showSelectAll && (
+              <button
+                type='button'
+                onClick={handleSelectAllToggle}
+                className={`
+                  w-full flex items-center gap-3 px-3 py-2 rounded-md transition-all outline-none
+                  ${allVisibleSelected ? 'bg-accent text-accent-foreground' : 'hover:bg-muted text-foreground'}
+                  focus-visible:ring-2 focus-visible:ring-ring border-b border-border/50
+                `}
+                data-track-category='Tickets'
+                data-track-name='ToggleSelectAllTags'
+              >
+                <span className='flex-1 text-left text-sm font-medium text-primary'>
+                  {allVisibleSelected ? 'Deselect all' : 'Select all'}
+                </span>
+                {allVisibleSelected && (
+                  <Check className='w-4 h-4 text-primary shrink-0' aria-hidden='true' />
+                )}
+              </button>
+            )}
+            {finalResults.map(tag => {
+              const isSelected = selectedTags.includes(tag);
+              return (
+                <button
+                  key={tag}
+                  type='button'
+                  onClick={() => handleTagToggle(tag)}
+                  className={`
+                    w-full flex items-center gap-3 px-3 py-2 rounded-md transition-all outline-none
+                    ${isSelected ? 'bg-accent text-accent-foreground' : 'hover:bg-muted text-foreground'}
+                    focus-visible:ring-2 focus-visible:ring-ring
+                  `}
+                  data-track-category='Tickets'
+                  data-track-name='ToggleTagFilter'
+                  data-track-metadata={JSON.stringify({ tag, selected: !isSelected })}
+                >
+                  <div className='flex items-center justify-center w-5 h-5 shrink-0'>
+                    <Tag className='w-4 h-4 text-muted-foreground' />
+                  </div>
+                  <span className='flex-1 text-left text-sm truncate'>{tag}</span>
+                  {isSelected && (
+                    <Check className='w-4 h-4 text-primary shrink-0' aria-hidden='true' />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <div className='p-8 text-center text-sm text-muted-foreground'>No labels found</div>
+        )}
+
+        {canCreate && (
+          <div className='border-t border-border mt-1 pt-1'>
+            <button
+              type='button'
+              onClick={handleCreateTag}
+              className='flex items-center gap-2 w-full px-3 py-2 text-sm rounded font-medium text-blue-600 hover:bg-blue-50'
+              data-track-category='Tickets'
+              data-track-name='CreateTag'
+              data-track-metadata={JSON.stringify({ tagName: searchQuery.trim() })}
+            >
+              <Plus className='size-4' />
+              Create {searchQuery.trim()}
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+};

--- a/apps/dashboard/src/components/Tickets/TagsListContent/index.ts
+++ b/apps/dashboard/src/components/Tickets/TagsListContent/index.ts
@@ -1,0 +1,2 @@
+export { TagsListContent } from './TagsListContent';
+export type { TagsListContentProps } from './TagsListContent';

--- a/apps/dashboard/src/components/Tickets/TicketCard/TicketCard.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketCard/TicketCard.tsx
@@ -192,21 +192,27 @@ const AssigneeEditor: React.FC<{
 
 interface TicketCardProps {
   ticket: Ticket;
-  tags?: TicketTag[];
-  availableTags?: string[];
-  onClick?: (e: React.MouseEvent | KeyboardEvent) => void;
-  width?: string;
-  isCompact?: boolean;
+  tags?: TicketTag[] | undefined;
+  availableTags?: string[] | undefined;
+  /** Callback to load more tags */
+  onLoadMoreTags?: (() => void) | undefined;
+  /** Whether there are more tags to load */
+  hasMoreTags?: boolean | undefined;
+  /** Callback for server-side tag search */
+  onSearchTags?: ((query: string) => void) | undefined;
+  onClick?: ((e: React.MouseEvent | KeyboardEvent) => void) | undefined;
+  width?: string | undefined;
+  isCompact?: boolean | undefined;
   visibleColumns?: Set<string> | undefined;
-  isConversation?: boolean;
-  activeTicketId?: string;
+  isConversation?: boolean | undefined;
+  activeTicketId?: string | undefined;
   /** Only true for email-type desks; hides the email unread indicator everywhere else. */
-  showEmailReads?: boolean;
+  showEmailReads?: boolean | undefined;
   /**
    * SLA policies pre-fetched by the parent for the whole board.
    * When omitted, SLA badges are not shown — no per-card fetch is performed.
    */
-  slaPolicies?: BoardSlaPolicy[];
+  slaPolicies?: BoardSlaPolicy[] | undefined;
 }
 
 export const TicketCard: React.FC<TicketCardProps> = ({
@@ -215,6 +221,9 @@ export const TicketCard: React.FC<TicketCardProps> = ({
   width = 'w-full',
   tags,
   availableTags = [],
+  onLoadMoreTags,
+  hasMoreTags = false,
+  onSearchTags,
   isCompact = false,
   visibleColumns = DEFAULT_VISIBLE_COLUMNS,
   isConversation = false,
@@ -858,6 +867,9 @@ export const TicketCard: React.FC<TicketCardProps> = ({
                           selectedTags={selectedTagNames}
                           onTagsChange={handleTagsChange}
                           stopEditing={() => setIsEditingTags(false)}
+                          onLoadMore={onLoadMoreTags}
+                          hasMore={hasMoreTags}
+                          onSearch={onSearchTags}
                         />
                       </div>
                     ) : hasTags ? (

--- a/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/TagsSubmenu/TagsSubmenu.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/TagsSubmenu/TagsSubmenu.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useState, useEffect, useMemo, useRef } from 'react';
+import { ReactElement, useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { SearchDefault as Search, CheckTickSingle as Check, Tag } from '@xyne/icons';
 import Input from '../../../../ui/Input/Input';
 
@@ -7,6 +7,10 @@ interface TagsSubmenuProps {
   onChange: (tags: string[]) => void;
   availableTags?: string[];
   className?: string;
+  /** Callback to load more tags */
+  onLoadMore?: (() => void) | undefined;
+  /** Whether there are more tags to load */
+  hasMore?: boolean | undefined;
 }
 
 export const TagsSubmenu = ({
@@ -14,43 +18,57 @@ export const TagsSubmenu = ({
   onChange,
   availableTags = [],
   className = '',
+  onLoadMore,
+  hasMore = false,
 }: TagsSubmenuProps): ReactElement => {
   const [searchQuery, setSearchQuery] = useState('');
-  const [searchTerm, setSearchTerm] = useState('');
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const listContainerRef = useRef<HTMLDivElement>(null);
 
   // Focus search input when component mounts
   useEffect(() => {
     searchInputRef.current?.focus();
   }, []);
 
-  // Debounced Search
+  // Scroll detection for infinite loading (only when not searching)
+  const handleScroll = useCallback(() => {
+    if (!listContainerRef.current || !onLoadMore || !hasMore || searchQuery.trim()) return;
+
+    const { scrollTop, scrollHeight, clientHeight } = listContainerRef.current;
+    // Load more when scrolled to within 50px of bottom
+    if (scrollHeight - scrollTop - clientHeight < 50) {
+      onLoadMore();
+    }
+  }, [onLoadMore, hasMore, searchQuery]);
+
   useEffect(() => {
-    const timer = setTimeout(() => setSearchTerm(searchQuery), 300);
-    return () => clearTimeout(timer);
-  }, [searchQuery]);
+    const container = listContainerRef.current;
+    if (!container) return;
+
+    container.addEventListener('scroll', handleScroll);
+    return () => container.removeEventListener('scroll', handleScroll);
+  }, [handleScroll]);
 
   const finalResults = useMemo(() => {
-    if (!availableTags || availableTags.length === 0) return [];
+    if (!availableTags || availableTags.length === 0) {
+      return [];
+    }
 
-    let list = [...availableTags];
-
-    // Filter by search term
-    if (searchTerm.trim()) {
-      const lower = searchTerm.toLowerCase();
-      list = list.filter(tag => tag.toLowerCase().includes(lower));
+    // Filter by search query if present
+    let filtered = availableTags;
+    if (searchQuery.trim()) {
+      const lower = searchQuery.toLowerCase();
+      filtered = availableTags.filter(tag => tag.toLowerCase().includes(lower));
     }
 
     // Sort selected items to top
     const selectedSet = new Set(selectedTags);
-    return list
-      .sort((a, b) => {
-        const aSel = selectedSet.has(a) ? 1 : 0;
-        const bSel = selectedSet.has(b) ? 1 : 0;
-        return bSel - aSel;
-      })
-      .slice(0, 50); // Limit to 50 tags for performance
-  }, [availableTags, searchTerm, selectedTags]);
+    return [...filtered].sort((a, b) => {
+      const aSel = selectedSet.has(a) ? 1 : 0;
+      const bSel = selectedSet.has(b) ? 1 : 0;
+      return bSel - aSel;
+    });
+  }, [availableTags, searchQuery, selectedTags]);
 
   const handleTagToggle = (tag: string) => {
     const isSelected = selectedTags.includes(tag);
@@ -87,7 +105,12 @@ export const TagsSubmenu = ({
           />
         </div>
       </div>
-      <div className='max-h-80 overflow-y-auto p-1' role='listbox' aria-multiselectable='true'>
+      <div
+        ref={listContainerRef}
+        className='max-h-80 overflow-y-auto p-1'
+        role='listbox'
+        aria-multiselectable='true'
+      >
         {!availableTags || availableTags.length === 0 ? (
           <div className='p-8 text-center text-sm text-muted-foreground'>No labels available</div>
         ) : finalResults.length > 0 ? (

--- a/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/TagsSubmenu/TagsSubmenu.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/TagsSubmenu/TagsSubmenu.tsx
@@ -1,16 +1,17 @@
-import { ReactElement, useState, useEffect, useMemo, useRef, useCallback } from 'react';
-import { SearchDefault as Search, CheckTickSingle as Check, Tag } from '@xyne/icons';
-import Input from '../../../../ui/Input/Input';
+import { ReactElement } from 'react';
+import { TagsListContent } from '../../../TagsListContent';
 
 interface TagsSubmenuProps {
   selectedTags: string[];
   onChange: (tags: string[]) => void;
-  availableTags?: string[];
-  className?: string;
+  availableTags?: string[] | undefined;
+  className?: string | undefined;
   /** Callback to load more tags */
   onLoadMore?: (() => void) | undefined;
   /** Whether there are more tags to load */
   hasMore?: boolean | undefined;
+  /** Callback for server-side search */
+  onSearch?: ((query: string) => void) | undefined;
 }
 
 export const TagsSubmenu = ({
@@ -20,150 +21,21 @@ export const TagsSubmenu = ({
   className = '',
   onLoadMore,
   hasMore = false,
+  onSearch,
 }: TagsSubmenuProps): ReactElement => {
-  const [searchQuery, setSearchQuery] = useState('');
-  const searchInputRef = useRef<HTMLInputElement>(null);
-  const listContainerRef = useRef<HTMLDivElement>(null);
-
-  // Focus search input when component mounts
-  useEffect(() => {
-    searchInputRef.current?.focus();
-  }, []);
-
-  // Scroll detection for infinite loading (only when not searching)
-  const handleScroll = useCallback(() => {
-    if (!listContainerRef.current || !onLoadMore || !hasMore || searchQuery.trim()) return;
-
-    const { scrollTop, scrollHeight, clientHeight } = listContainerRef.current;
-    // Load more when scrolled to within 50px of bottom
-    if (scrollHeight - scrollTop - clientHeight < 50) {
-      onLoadMore();
-    }
-  }, [onLoadMore, hasMore, searchQuery]);
-
-  useEffect(() => {
-    const container = listContainerRef.current;
-    if (!container) return;
-
-    container.addEventListener('scroll', handleScroll);
-    return () => container.removeEventListener('scroll', handleScroll);
-  }, [handleScroll]);
-
-  const finalResults = useMemo(() => {
-    if (!availableTags || availableTags.length === 0) {
-      return [];
-    }
-
-    // Filter by search query if present
-    let filtered = availableTags;
-    if (searchQuery.trim()) {
-      const lower = searchQuery.toLowerCase();
-      filtered = availableTags.filter(tag => tag.toLowerCase().includes(lower));
-    }
-
-    // Sort selected items to top
-    const selectedSet = new Set(selectedTags);
-    return [...filtered].sort((a, b) => {
-      const aSel = selectedSet.has(a) ? 1 : 0;
-      const bSel = selectedSet.has(b) ? 1 : 0;
-      return bSel - aSel;
-    });
-  }, [availableTags, searchQuery, selectedTags]);
-
-  const handleTagToggle = (tag: string) => {
-    const isSelected = selectedTags.includes(tag);
-    onChange(isSelected ? selectedTags.filter(t => t !== tag) : [...selectedTags, tag]);
-  };
-
-  const visibleTagNames = finalResults.map(t => t);
-  const allVisibleSelected =
-    visibleTagNames.length > 0 && visibleTagNames.every(t => selectedTags.includes(t));
-
-  const handleSelectAllToggle = (): void => {
-    if (allVisibleSelected) {
-      onChange(selectedTags.filter(t => !visibleTagNames.includes(t)));
-    } else {
-      const merged = new Set([...selectedTags, ...visibleTagNames]);
-      onChange([...merged]);
-    }
-  };
-
   return (
     <div
       className={`w-80 border border-border flex flex-col rounded-lg shadow-lg bg-background overflow-hidden ${className}`}
     >
-      <div className='p-3 border-b sticky top-0 bg-background z-10'>
-        <div className='relative'>
-          <Search className='absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none' />
-          <Input
-            ref={searchInputRef}
-            type='text'
-            value={searchQuery}
-            onChange={e => setSearchQuery(e.target.value)}
-            placeholder='Search labels...'
-            className='pl-9 h-9'
-          />
-        </div>
-      </div>
-      <div
-        ref={listContainerRef}
-        className='max-h-80 overflow-y-auto p-1'
-        role='listbox'
-        aria-multiselectable='true'
-      >
-        {!availableTags || availableTags.length === 0 ? (
-          <div className='p-8 text-center text-sm text-muted-foreground'>No labels available</div>
-        ) : finalResults.length > 0 ? (
-          <div className='space-y-0.5'>
-            <button
-              type='button'
-              onClick={handleSelectAllToggle}
-              className={`
-                w-full flex items-center gap-3 px-3 py-2 rounded-md transition-all outline-none
-                ${allVisibleSelected ? 'bg-accent text-accent-foreground' : 'hover:bg-muted text-foreground'}
-                focus-visible:ring-2 focus-visible:ring-ring border-b border-border/50
-              `}
-              data-track-category='Tickets'
-              data-track-name='ToggleSelectAllTags'
-            >
-              <span className='flex-1 text-left text-sm font-medium text-primary'>
-                {allVisibleSelected ? 'Deselect all' : 'Select all'}
-              </span>
-              {allVisibleSelected && (
-                <Check className='w-4 h-4 text-primary shrink-0' aria-hidden='true' />
-              )}
-            </button>
-            {finalResults.map(tag => {
-              const isSelected = selectedTags.includes(tag);
-              return (
-                <button
-                  key={tag}
-                  type='button'
-                  onClick={() => handleTagToggle(tag)}
-                  className={`
-                    w-full flex items-center gap-3 px-3 py-2 rounded-md transition-all outline-none
-                    ${isSelected ? 'bg-accent text-accent-foreground' : 'hover:bg-muted text-foreground'}
-                    focus-visible:ring-2 focus-visible:ring-ring
-                  `}
-                  data-track-category='Tickets'
-                  data-track-name='ToggleTagFilter'
-                  data-track-metadata={JSON.stringify({ tag, selected: !isSelected })}
-                >
-                  <div className='flex items-center justify-center w-5 h-5 shrink-0'>
-                    <Tag className='w-4 h-4 text-muted-foreground' />
-                  </div>
-                  <span className='flex-1 text-left text-sm truncate'>{tag}</span>
-                  {isSelected && (
-                    <Check className='w-4 h-4 text-primary shrink-0' aria-hidden='true' />
-                  )}
-                </button>
-              );
-            })}
-          </div>
-        ) : (
-          <div className='p-8 text-center text-sm text-muted-foreground'>No labels found</div>
-        )}
-      </div>
+      <TagsListContent
+        selectedTags={selectedTags}
+        onChange={onChange}
+        availableTags={availableTags}
+        onLoadMore={onLoadMore}
+        hasMore={hasMore}
+        showSelectAll={true}
+        onSearch={onSearch}
+      />
       {selectedTags.length > 0 && (
         <div className='p-3 border-t bg-muted'>
           <div className='text-xs text-muted-foreground'>

--- a/apps/dashboard/src/components/Tickets/TicketFilters/TicketFiltersDropdown.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/TicketFiltersDropdown.tsx
@@ -117,6 +117,8 @@ export const TicketFiltersDropdown = ({
   sourceChannelProjectIds,
   showBoardsFilter = false,
   availableTags,
+  onLoadMoreTags,
+  hasMoreTags,
   availableStages,
   hideAssigneeFilter = false,
   hasPrReviewers,
@@ -653,6 +655,8 @@ export const TicketFiltersDropdown = ({
             selectedTags={filters.tags || []}
             onChange={(tags: string[]) => handleFilterChange('tags', tags)}
             availableTags={availableTags || []}
+            onLoadMore={onLoadMoreTags}
+            hasMore={hasMoreTags}
           />
         );
       case 'stages':

--- a/apps/dashboard/src/components/Tickets/TicketFilters/TicketFiltersDropdown.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/TicketFiltersDropdown.tsx
@@ -119,6 +119,7 @@ export const TicketFiltersDropdown = ({
   availableTags,
   onLoadMoreTags,
   hasMoreTags,
+  onSearchTags,
   availableStages,
   hideAssigneeFilter = false,
   hasPrReviewers,
@@ -657,6 +658,7 @@ export const TicketFiltersDropdown = ({
             availableTags={availableTags || []}
             onLoadMore={onLoadMoreTags}
             hasMore={hasMoreTags}
+            onSearch={onSearchTags}
           />
         );
       case 'stages':

--- a/apps/dashboard/src/components/Tickets/TicketFilters/types.ts
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/types.ts
@@ -57,6 +57,8 @@ export interface TicketFiltersProps {
   onLoadMoreTags?: () => void;
   /** Whether there are more tags to load */
   hasMoreTags?: boolean;
+  /** Callback for server-side tag search */
+  onSearchTags?: (query: string) => void;
   availableStages?: { name: string; status?: TicketStatusV2 | undefined }[] | undefined;
   hideAssigneeFilter?: boolean;
   hasPrReviewers?: boolean;

--- a/apps/dashboard/src/components/Tickets/TicketFilters/types.ts
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/types.ts
@@ -53,6 +53,10 @@ export interface TicketFiltersProps {
   sourceChannelProjectIds?: string[] | undefined;
   showBoardsFilter?: boolean;
   availableTags?: string[] | undefined;
+  /** Callback to load more tags (for pagination) */
+  onLoadMoreTags?: () => void;
+  /** Whether there are more tags to load */
+  hasMoreTags?: boolean;
   availableStages?: { name: string; status?: TicketStatusV2 | undefined }[] | undefined;
   hideAssigneeFilter?: boolean;
   hasPrReviewers?: boolean;

--- a/apps/dashboard/src/components/Tickets/TicketTable/TagSelector.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketTable/TagSelector.tsx
@@ -1,20 +1,23 @@
-import React, { useState, useMemo, useEffect, useRef } from 'react';
+import React, { useState } from 'react';
 import * as Popover from '@radix-ui/react-popover';
-import {
-  CheckTickSingle as Check,
-  MultipleCrossCancelDefault as X,
-  PlusDefault as Plus,
-} from '@xyne/icons';
+import { MultipleCrossCancelDefault as X } from '@xyne/icons';
 import { cn } from '../../../utils/classNames';
+import { TagsListContent } from '../TagsListContent';
 
 interface TagSelectorProps {
   availableTags: string[];
   selectedTags: string[];
   onTagsChange: (tags: string[]) => void;
-  onCreateTag?: (tagName: string) => void;
-  stopEditing?: () => void;
-  inlineTags?: boolean;
-  allowCreate?: boolean;
+  onCreateTag?: ((tagName: string) => void) | undefined;
+  stopEditing?: (() => void) | undefined;
+  inlineTags?: boolean | undefined;
+  allowCreate?: boolean | undefined;
+  /** Callback to load more tags */
+  onLoadMore?: (() => void) | undefined;
+  /** Whether there are more tags to load */
+  hasMore?: boolean | undefined;
+  /** Callback for server-side search */
+  onSearch?: ((query: string) => void) | undefined;
 }
 
 export const TagSelector: React.FC<TagSelectorProps> = ({
@@ -25,75 +28,21 @@ export const TagSelector: React.FC<TagSelectorProps> = ({
   stopEditing,
   inlineTags = false,
   allowCreate = true,
+  onLoadMore,
+  hasMore = false,
+  onSearch,
 }) => {
   const [isOpen, setIsOpen] = useState(true);
-  const [search, setSearch] = useState('');
-  const [activeIdx, setActiveIdx] = useState(0);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    inputRef.current?.focus();
-  }, []);
-
-  useEffect(() => setActiveIdx(0), [search]);
-
-  const filtered = useMemo(() => {
-    const lower = search.toLowerCase().trim();
-    return lower ? availableTags.filter(t => t.toLowerCase().includes(lower)) : availableTags;
-  }, [availableTags, search]);
-
-  const canCreate = useMemo(() => {
-    if (!allowCreate) return false;
-    const trimmed = search.trim();
-    return trimmed && !availableTags.some(t => t.toLowerCase() === trimmed.toLowerCase());
-  }, [search, availableTags, allowCreate]);
 
   const toggle = (tag: string) => {
     const next = selectedTags.includes(tag)
       ? selectedTags.filter(t => t !== tag)
       : [...selectedTags, tag];
     onTagsChange(next);
+  };
+
+  const handleTagToggled = () => {
     setTimeout(() => stopEditing?.(), 100);
-  };
-
-  const create = () => {
-    const trimmed = search.trim();
-    if (canCreate) {
-      if (onCreateTag) {
-        onCreateTag(trimmed);
-      }
-      onTagsChange([...selectedTags, trimmed]);
-      setSearch('');
-      setTimeout(() => stopEditing?.(), 100);
-    }
-  };
-
-  const handleKey = (e: React.KeyboardEvent) => {
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      const maxIdx = canCreate ? filtered.length : filtered.length - 1;
-      setActiveIdx(prev => Math.min(prev + 1, maxIdx));
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      setActiveIdx(prev => Math.max(prev - 1, 0));
-    } else if (e.key === 'Backspace' && !search && selectedTags.length) {
-      onTagsChange(selectedTags.slice(0, -1));
-    } else if (e.key === 'Enter') {
-      e.preventDefault();
-      e.stopPropagation();
-
-      if (filtered[activeIdx]) {
-        toggle(filtered[activeIdx]);
-        setSearch('');
-      } else if (canCreate && activeIdx === filtered.length) {
-        create();
-      } else if (canCreate && filtered.length === 0) {
-        create();
-      }
-    } else if (e.key === 'Escape') {
-      setIsOpen(false);
-      stopEditing?.();
-    }
   };
 
   return (
@@ -137,17 +86,9 @@ export const TagSelector: React.FC<TagSelectorProps> = ({
               </button>
             </span>
           ))}
-          <input
-            ref={inputRef}
-            className='flex-1 min-w-[60px] bg-transparent border-none text-sm p-1 outline-none'
-            placeholder={selectedTags.length === 0 ? 'Add labels...' : ''}
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-            onKeyDown={handleKey}
-            data-track-event='blur'
-            data-track-category='Tickets'
-            data-track-name='TagSearchInput'
-          />
+          <span className='flex-1 min-w-[60px] text-sm p-1 text-muted-foreground'>
+            {selectedTags.length === 0 ? 'Add labels...' : ''}
+          </span>
         </label>
       </Popover.Trigger>
 
@@ -156,68 +97,22 @@ export const TagSelector: React.FC<TagSelectorProps> = ({
           side='bottom'
           align='start'
           sideOffset={4}
-          className='z-[100] w-[var(--radix-popover-trigger-width)] bg-background border border-border rounded-lg shadow-lg mr-auto'
+          className='z-[100] w-80 bg-background border border-border rounded-lg shadow-lg'
           avoidCollisions={true}
           onOpenAutoFocus={e => e.preventDefault()}
         >
-          <div className='max-h-[240px] overflow-y-auto p-1'>
-            {filtered.length > 0 ? (
-              filtered.map((tag, i) => {
-                const selected = selectedTags.includes(tag);
-                const active = i === activeIdx;
-                return (
-                  <button
-                    key={tag}
-                    data-ph-capture-attribute-track-id='ticket_toggle_tag'
-                    onClick={() => {
-                      toggle(tag);
-                      setSearch('');
-                    }}
-                    onMouseEnter={() => setActiveIdx(i)}
-                    className={`flex items-center justify-between w-full px-3 py-2 text-sm rounded text-left ${
-                      active ? 'bg-muted' : ''
-                    } ${selected ? 'text-blue-700 font-medium' : 'text-foreground'}`}
-                    data-track-category='Tickets'
-                    data-track-name='SelectTag'
-                    data-track-metadata={JSON.stringify({ tag, selected: !selected })}
-                  >
-                    <div className='flex items-center gap-2'>
-                      <span className='w-2 h-2 rounded-full bg-xyne-purple-400' />
-                      {tag}
-                    </div>
-                    {selected && <Check className='size-4 text-blue-600' />}
-                  </button>
-                );
-              })
-            ) : search.trim() ? (
-              <div className='p-3 text-center text-sm text-muted-foreground'>
-                No matching labels
-              </div>
-            ) : (
-              <div className='p-3 text-center text-sm text-muted-foreground'>
-                No labels available
-              </div>
-            )}
-
-            {canCreate && (
-              <div className='border-t border-border mt-1 pt-1'>
-                <button
-                  data-ph-capture-attribute-track-id='ticket_create_tag'
-                  onClick={create}
-                  onMouseEnter={() => setActiveIdx(filtered.length)}
-                  className={`flex items-center gap-2 w-full px-3 py-2 text-sm rounded font-medium ${
-                    activeIdx === filtered.length ? 'bg-blue-50 text-blue-700' : 'text-blue-600'
-                  }`}
-                  data-track-category='Tickets'
-                  data-track-name='CreateTag'
-                  data-track-metadata={JSON.stringify({ tagName: search.trim() })}
-                >
-                  <Plus className='size-4' />
-                  Create {search.trim()}
-                </button>
-              </div>
-            )}
-          </div>
+          <TagsListContent
+            selectedTags={selectedTags}
+            onChange={onTagsChange}
+            availableTags={availableTags}
+            onLoadMore={onLoadMore}
+            hasMore={hasMore}
+            showSelectAll={false}
+            allowCreate={allowCreate}
+            onCreateTag={onCreateTag}
+            onTagToggled={handleTagToggled}
+            onSearch={onSearch}
+          />
         </Popover.Content>
       </Popover.Portal>
     </Popover.Root>

--- a/apps/dashboard/src/hooks/useVespaTagSearch.ts
+++ b/apps/dashboard/src/hooks/useVespaTagSearch.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { searchService } from '../services/searchService';
+
+const DEFAULT_LIMIT = 100;
+
+interface UseVespaTagSearchParams {
+  projectId?: string | undefined;
+  boardIds?: string[] | undefined;
+  searchQuery?: string | undefined;
+  enabled?: boolean | undefined;
+  limit?: number | undefined;
+}
+
+interface UseVespaTagSearchResult {
+  tags: string[];
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+/**
+ * Hook for searching ticket tags via Vespa.
+ * Note: Caller should debounce searchQuery changes - this hook fetches immediately.
+ */
+export const useVespaTagSearch = ({
+  projectId,
+  boardIds,
+  searchQuery = '',
+  enabled = true,
+  limit = DEFAULT_LIMIT,
+}: UseVespaTagSearchParams): UseVespaTagSearchResult => {
+  const [tags, setTags] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const fetchTags = useCallback(
+    async (query: string) => {
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+
+      setIsLoading(true);
+
+      try {
+        const result = await searchService.searchTags(
+          {
+            projectId,
+            boardIds,
+            query: query || undefined,
+            limit,
+          },
+          abortController.signal,
+        );
+
+        if (!abortController.signal.aborted) {
+          setTags(result.tags);
+          setError(null);
+        }
+      } catch (err) {
+        if (!abortController.signal.aborted) {
+          setError(err instanceof Error ? err : new Error('Failed to fetch tags'));
+          setTags([]);
+        }
+      } finally {
+        if (!abortController.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [projectId, boardIds, limit],
+  );
+
+  const refetch = useCallback(() => {
+    if (!enabled) return;
+    void fetchTags(searchQuery);
+  }, [enabled, searchQuery, fetchTags]);
+
+  // Fetch immediately when searchQuery or enabled changes (no internal debounce)
+  useEffect(() => {
+    if (!enabled) {
+      setTags([]);
+      setIsLoading(false);
+      return;
+    }
+
+    void fetchTags(searchQuery);
+  }, [searchQuery, enabled, fetchTags]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+    };
+  }, []);
+
+  return { tags, isLoading, error, refetch };
+};

--- a/apps/dashboard/src/hooks/useVespaTicketSearch.ts
+++ b/apps/dashboard/src/hooks/useVespaTicketSearch.ts
@@ -5,8 +5,9 @@ import type { Ticket } from '@xyne/shared';
 import { TicketPriority, TicketStatusV2 } from '@xyne/shared';
 import { useCmdkDefaultRankProfiles } from './useCmdkSearchConfig';
 
-const MAX_VESPA_TICKET_SEARCH_LIMIT = 200;
+const MAX_VESPA_TICKET_SEARCH_LIMIT = 400;
 const FILTER_ONLY_DYNAMIC_FIELD_CACHE_TTL_MS = 30_000;
+const SEARCH_CACHE_TTL_MS = 10_000;
 const SEARCH_DEBOUNCE_MS = 300;
 
 interface UseVespaTicketSearchParams {
@@ -42,6 +43,10 @@ const filterOnlyDynamicFieldCache = new Map<
   { expiresAt: number; results: DisplaySearchResult[] }
 >();
 const filterOnlyDynamicFieldInflight = new Map<string, Promise<DisplaySearchResult[]>>();
+
+// Shared cache for search results (keyed by searchKey from caller)
+const searchKeyCache = new Map<string, { expiresAt: number; results: Ticket[] }>();
+const searchKeyInflight = new Map<string, Promise<Ticket[]>>();
 
 const getFilterOnlyDynamicFieldCacheKey = (filters: VespaSearchFilters): string =>
   JSON.stringify({
@@ -282,6 +287,57 @@ export const useVespaTicketSearch = ({
           );
           if (!abortController.signal.aborted) {
             setSearchResults(results.map(toTicket));
+            setIsSearching(false);
+          }
+          return;
+        }
+
+        // Use shared cache when searchKey is provided (for deduplicating calls across columns)
+        if (searchKey) {
+          // Include all filters in cache key so different filter combinations don't return stale results
+          const fullCacheKey = `${searchKey}:${JSON.stringify(vespaFilters)}`;
+
+          // Check cache first
+          const cached = searchKeyCache.get(fullCacheKey);
+          if (cached && cached.expiresAt > Date.now()) {
+            if (!abortController.signal.aborted) {
+              setSearchResults(cached.results);
+              setIsSearching(false);
+            }
+            return;
+          }
+
+          // Check for inflight request
+          const inflight = searchKeyInflight.get(fullCacheKey);
+          if (inflight) {
+            const results = await inflight;
+            if (!abortController.signal.aborted) {
+              setSearchResults(results);
+              setIsSearching(false);
+            }
+            return;
+          }
+
+          // Make request and cache it
+          const request = (async (): Promise<Ticket[]> => {
+            const response = await searchService.vespaSearch(vespaFilters);
+            return response.results.map(toTicket);
+          })();
+
+          searchKeyInflight.set(fullCacheKey, request);
+
+          try {
+            const results = await request;
+            searchKeyCache.set(fullCacheKey, {
+              expiresAt: Date.now() + SEARCH_CACHE_TTL_MS,
+              results,
+            });
+            if (!abortController.signal.aborted) {
+              setSearchResults(results);
+              setIsSearching(false);
+            }
+          } finally {
+            searchKeyInflight.delete(fullCacheKey);
           }
           return;
         }
@@ -315,12 +371,57 @@ export const useVespaTicketSearch = ({
       fetchAllDynamicFieldMatches,
       maxFetchedResults,
       rankProfile,
+      searchKey,
     ],
   );
+
+  // Build cache key for immediate lookup (must match performSearch logic)
+  const immediateCacheKey = useMemo(() => {
+    if (!searchKey) return null;
+    const query = searchTerm.trim() || '*';
+    const vespaFilters: VespaSearchFilters = {
+      query,
+      type: 'tickets',
+      apps: 'ticket',
+      limit: safeLimit,
+      rankProfile,
+    };
+    if (projectId) vespaFilters.projectId = projectId;
+    if (boardId) vespaFilters.board = boardId;
+    if (status) vespaFilters.status = status;
+    if (stage) vespaFilters.stage = stage;
+    if (priority) vespaFilters.priority = priority;
+    if (assignee) vespaFilters.assignee = assignee;
+    if (tags) vespaFilters.tags = tags;
+    if (createdBy) vespaFilters.from = createdBy;
+    if (normalizedDynamicFieldValues.length > 0) {
+      vespaFilters.dynamicFieldValues = normalizedDynamicFieldValues;
+    }
+    if (Object.keys(normalizedDynamicFieldDateRanges).length > 0) {
+      vespaFilters.dynamicFieldDateRanges = normalizedDynamicFieldDateRanges;
+    }
+    return `${searchKey}:${JSON.stringify(vespaFilters)}`;
+  }, [
+    searchKey,
+    searchTerm,
+    safeLimit,
+    rankProfile,
+    projectId,
+    boardId,
+    status,
+    stage,
+    priority,
+    assignee,
+    tags,
+    createdBy,
+    normalizedDynamicFieldValues,
+    normalizedDynamicFieldDateRanges,
+  ]);
 
   useEffect(() => {
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
     }
 
     const trimmed = searchTerm.trim();
@@ -333,7 +434,28 @@ export const useVespaTicketSearch = ({
       return;
     }
 
+    // Check cache immediately for instant results when filters change
+    if (immediateCacheKey) {
+      const cached = searchKeyCache.get(immediateCacheKey);
+      if (cached && cached.expiresAt > Date.now()) {
+        setSearchResults(cached.results);
+        setIsSearching(false);
+        return;
+      }
+      // Check for inflight request - wait for it instead of starting new one
+      const inflight = searchKeyInflight.get(immediateCacheKey);
+      if (inflight) {
+        setIsSearching(true);
+        void inflight.then(results => {
+          setSearchResults(results);
+          setIsSearching(false);
+        });
+        return;
+      }
+    }
+
     setIsSearching(true);
+
     debounceTimerRef.current = setTimeout(() => {
       void performSearch(trimmed || '*');
     }, SEARCH_DEBOUNCE_MS);
@@ -341,6 +463,7 @@ export const useVespaTicketSearch = ({
     return (): void => {
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
       }
     };
   }, [
@@ -349,7 +472,9 @@ export const useVespaTicketSearch = ({
     normalizedDynamicFieldDateRanges,
     enabled,
     performSearch,
+    immediateCacheKey,
     searchKey,
+    assignee,
   ]);
 
   useEffect(() => {
@@ -360,5 +485,7 @@ export const useVespaTicketSearch = ({
     };
   }, []);
 
+  // With the shared debounce mechanism, we can trust the isSearching state directly.
+  // The effect properly coordinates across hook instances via pendingDebounces map.
   return { searchResults, isSearching };
 };

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -74,6 +74,7 @@ import type { TicketFilters } from '../../components/Tickets/TicketFilters/types
 import { KanbanColumns } from '../../components/Tickets/KanbanColumns/KanbanColumns';
 import { ViewBoardPicker } from '../../components/Project/ViewBoardPicker/ViewBoardPicker';
 import { useDragAndDrop, type StageTransitionInfo } from '../../hooks/useDragAndDrop';
+import { useVespaTagSearch } from '../../hooks/useVespaTagSearch';
 import {
   useAllChannels,
   useChannel,
@@ -1937,6 +1938,16 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         (filters.boards?.length ?? 0) > 0,
     },
   );
+
+  // Fetch board details for workspace views to get project IDs for tags
+  // This is always enabled for workspace views (unlike workspaceSelectedBoards which is only for dropdowns)
+  const [workspaceBoardsForTags] = useCachedQuery(
+    queries.boardsByIds({ boardIds: filters.boards ?? [] }),
+    {
+      enabled: isWorkspaceView && (filters.boards?.length ?? 0) > 0,
+    },
+  );
+
   const sourceChannelProjectIds = useMemo(() => {
     if (isMyTicketsView) {
       const selected = filters.boards ?? [];
@@ -1986,99 +1997,130 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     }
   }, [isMyTicketsView, filters.boards, availableBoards, setFilters]);
 
-  // Determine if we're in single-project or multi-project mode for tags
-  const isMultiProjectView = !effectiveProjectId && sourceChannelProjectIds.length > 0;
-  const tagsProjectId = effectiveProjectId || availableBoardDetails?.[0]?.projectId;
-
-  // State for cursor-based tag pagination
-  const [tagsCursor, setTagsCursor] = useState<{ name: string; id: string } | null>(null);
-  const [allLoadedTags, setAllLoadedTags] = useState<Array<{ name: string; id: string }>>([]);
-  const [hasMoreTags, setHasMoreTags] = useState(true);
-  const tagsLimitPerPage = 20;
-
-  // Fetch project tags for single project view (paginated with cursor)
-  const [singleProjectTags, singleProjectTagsDetails] = useCachedQuery(
-    queries.projectTagsByProjectId({
-      projectId: tagsProjectId || '',
-      limit: tagsLimitPerPage,
-      start: tagsCursor,
-      direction: 'forward',
-    }),
-    { enabled: !!tagsProjectId && !isMultiProjectView, cursorEnabled: true },
-  );
-
-  // Fetch project tags for multi-project views (paginated with cursor)
-  const [multiProjectTags, projectTagsDetails] = useCachedQuery(
-    queries.projectTagsByProjectIds({
-      projectIds: sourceChannelProjectIds,
-      limit: tagsLimitPerPage,
-      start: tagsCursor,
-      direction: 'forward',
-    }),
-    { enabled: isMultiProjectView, cursorEnabled: true },
-  );
-
-  // Combine tags from either query
-  const currentPageTags = isMultiProjectView ? multiProjectTags : singleProjectTags;
-  const currentPageDetails = isMultiProjectView ? projectTagsDetails : singleProjectTagsDetails;
-
-  // Track processed cursor to avoid re-processing same page
-  const lastProcessedCursorRef = useRef<string>('initial');
-  const isLoadingMoreRef = useRef(false);
-
-  // Accumulate tags as pages load
-  useEffect(() => {
-    if (currentPageDetails?.type === 'complete' && currentPageTags) {
-      const newTags = currentPageTags as Array<{ name: string; id: string }>;
-      const cursorKey = tagsCursor ? `${tagsCursor.id}` : 'initial';
-
-      // For first page (cursor null), always process
-      if (tagsCursor === null) {
-        // Only update if tags actually changed
-        const newTagIds = newTags.map(t => t.id).join(',');
-        const existingTagIds = allLoadedTags.map(t => t.id).join(',');
-        if (newTagIds !== existingTagIds) {
-          setAllLoadedTags(newTags);
-        }
-        setHasMoreTags(newTags.length >= tagsLimitPerPage);
-        lastProcessedCursorRef.current = 'initial';
-        isLoadingMoreRef.current = false;
-      } else if (isLoadingMoreRef.current && lastProcessedCursorRef.current !== cursorKey) {
-        // Subsequent page - only process if we're actively loading more and cursor changed
-        setAllLoadedTags(prev => {
-          const existingIds = new Set(prev.map(t => t.id));
-          const uniqueNew = newTags.filter(t => !existingIds.has(t.id));
-          if (uniqueNew.length === 0) {
-            return prev;
-          }
-          return [...prev, ...uniqueNew];
-        });
-        setHasMoreTags(newTags.length >= tagsLimitPerPage);
-        lastProcessedCursorRef.current = cursorKey;
-        isLoadingMoreRef.current = false;
-      }
+  // Determine project IDs for tag search
+  // For my-tickets and workspace views, we may have multiple projects
+  const tagsProjectIds = useMemo(() => {
+    if (isMyTicketsView) {
+      const selected = filters.boards ?? [];
+      const details = availableBoardDetails ?? [];
+      // No board selected -> all projects; otherwise only selected boards' projects
+      return uniqueProjectIds(
+        selected.length === 0 ? details : details.filter(board => selected.includes(board.id)),
+      );
     }
-  }, [currentPageTags, currentPageDetails, tagsCursor, tagsLimitPerPage, allLoadedTags]);
+    if (isWorkspaceView) {
+      // Use workspaceBoardsForTags which is always enabled for workspace views
+      return uniqueProjectIds(workspaceBoardsForTags ?? []);
+    }
+    // Single project view
+    const singleProjectId = effectiveProjectId || availableBoardDetails?.[0]?.projectId;
+    return singleProjectId ? [singleProjectId] : [];
+  }, [
+    isMyTicketsView,
+    isWorkspaceView,
+    filters.boards,
+    availableBoardDetails,
+    workspaceBoardsForTags,
+    effectiveProjectId,
+  ]);
 
-  // Reset tags when project changes
-  const tagsProjectKey = tagsProjectId || sourceChannelProjectIds.join(',');
+  // For my-tickets and workspace views, always use multi-project query
+  // This ensures proper tag fetching across all selected boards/projects
+  const shouldUseMultiProjectQuery = isMyTicketsView || isWorkspaceView;
+  const shouldUseSingleProjectQuery = !shouldUseMultiProjectQuery && tagsProjectIds.length === 1;
+
+  // State for tag search query (debounced value passed to Vespa)
+  const [tagsSearchQuery, setTagsSearchQuery] = useState('');
+
+  // Pagination state for Zero query tags
+  const TAGS_PAGE_SIZE = 20;
+  const [tagsCursor, setTagsCursor] = useState<{ name: string; id: string } | null>(null);
+  const [accumulatedTags, setAccumulatedTags] = useState<Array<{ name: string; id: string }>>([]);
+  const [hasMoreZeroTags, setHasMoreZeroTags] = useState(true);
+
+  // Reset pagination when project IDs change or search starts
+  const tagsProjectIdsKey = tagsProjectIds.join(',');
   useEffect(() => {
     setTagsCursor(null);
-    setAllLoadedTags([]);
-    setHasMoreTags(true);
-    lastProcessedCursorRef.current = 'initial';
-    isLoadingMoreRef.current = false;
-  }, [tagsProjectKey]);
+    setAccumulatedTags([]);
+    setHasMoreZeroTags(true);
+  }, [tagsProjectIdsKey, tagsSearchQuery]);
 
-  // Load more tags callback
+  // Fetch tags via Zero query for single project (for initial load without search)
+  // Only used for regular board views (not my-tickets or workspace views)
+  const [singleProjectTags, singleProjectTagsDetails] = useCachedQuery(
+    queries.projectTagsByProjectId({
+      projectId: tagsProjectIds[0] || '',
+      limit: TAGS_PAGE_SIZE,
+      start: tagsCursor,
+    }),
+    { enabled: shouldUseSingleProjectQuery && !tagsSearchQuery.trim() },
+  );
+
+  // Fetch tags via Zero query for multiple projects (for initial load without search)
+  // Used for my-tickets, workspace views, and any multi-project scenarios
+  const [multiProjectTags, multiProjectTagsDetails] = useCachedQuery(
+    queries.projectTagsByProjectIds({
+      projectIds: tagsProjectIds,
+      limit: TAGS_PAGE_SIZE,
+      start: tagsCursor,
+    }),
+    { enabled: shouldUseMultiProjectQuery && tagsProjectIds.length > 0 && !tagsSearchQuery.trim() },
+  );
+
+  // Combine Zero query results
+  const currentPageTags = shouldUseSingleProjectQuery ? singleProjectTags : multiProjectTags;
+  const projectTagsDetails = shouldUseSingleProjectQuery
+    ? singleProjectTagsDetails
+    : multiProjectTagsDetails;
+
+  // Accumulate tags from pagination
+  useEffect(() => {
+    if (!currentPageTags || currentPageTags.length === 0) {
+      if (tagsCursor !== null) {
+        // No more results from this page
+        setHasMoreZeroTags(false);
+      }
+      return;
+    }
+
+    // Check if we got less than page size (no more pages)
+    if (currentPageTags.length < TAGS_PAGE_SIZE) {
+      setHasMoreZeroTags(false);
+    }
+
+    // Append new tags, avoiding duplicates
+    setAccumulatedTags(prev => {
+      const existingIds = new Set(prev.map(t => t.id));
+      const newTags = currentPageTags.filter(t => !existingIds.has(t.id));
+      return [...prev, ...newTags];
+    });
+  }, [currentPageTags, tagsCursor]);
+
+  // Combine accumulated tags for display
+  const projectTags = accumulatedTags;
+
+  // Handle load more tags (pagination)
   const handleLoadMoreTags = useCallback(() => {
-    if (!hasMoreTags || allLoadedTags.length === 0 || isLoadingMoreRef.current) return;
-    const lastTag = allLoadedTags[allLoadedTags.length - 1];
+    if (!hasMoreZeroTags || tagsSearchQuery.trim()) return;
+    const lastTag = accumulatedTags[accumulatedTags.length - 1];
     if (lastTag) {
-      isLoadingMoreRef.current = true;
       setTagsCursor({ name: lastTag.name, id: lastTag.id });
     }
-  }, [hasMoreTags, allLoadedTags]);
+  }, [hasMoreZeroTags, tagsSearchQuery, accumulatedTags]);
+
+  // Fetch tags via Vespa search (only when there's a search query)
+  const { tags: vespaTags } = useVespaTagSearch({
+    projectId: tagsProjectIds[0],
+    searchQuery: tagsSearchQuery,
+    enabled: tagsProjectIds.length > 0 && !!tagsSearchQuery.trim(),
+    limit: 20,
+  });
+
+  // Handle tag search callback
+  const handleSearchTags = useCallback((query: string) => {
+    setTagsSearchQuery(query);
+  }, []);
 
   // Create a map of stageId -> formId for quick lookup (from stages.formId).
   // NON_LINEAR boards also include transition-level forms (toStageId -> formId).
@@ -3295,22 +3337,29 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
   const lastSentFilteredTicketIdsRef = useRef<string | null>(null);
 
-  // Compute availableTags directly from query results to avoid state timing issues
-  // For initial load, use query results directly; for pagination, use accumulated state
+  // Compute availableTags: use Vespa when searching, Zero query otherwise
+  // Fallback to client-side filtering if Vespa returns no results
   const availableTags = useMemo(() => {
-    // Use allLoadedTags if it has data (from pagination accumulation)
-    // Otherwise fall back to currentPageTags for immediate display
-    const tagsSource =
-      allLoadedTags.length > 0
-        ? allLoadedTags
-        : (currentPageTags as Array<{ name: string; id: string }> | undefined);
+    const zeroTags =
+      projectTags && projectTags.length > 0
+        ? Array.from(new Set(projectTags.map(tag => tag.name))).sort()
+        : [];
 
-    if (!tagsSource || tagsSource.length === 0) {
-      return undefined;
+    // If there's a search query, prefer Vespa results
+    if (tagsSearchQuery.trim()) {
+      // If Vespa has results, use them
+      if (vespaTags && vespaTags.length > 0) {
+        return vespaTags;
+      }
+      // Fallback to client-side filtering on Zero tags
+      const lower = tagsSearchQuery.toLowerCase();
+      const filtered = zeroTags.filter(tag => tag.toLowerCase().includes(lower));
+      return filtered.length > 0 ? filtered : undefined;
     }
-    const uniqueTags = new Set(tagsSource.map(tag => tag.name));
-    return Array.from(uniqueTags).sort();
-  }, [allLoadedTags, currentPageTags]);
+
+    // No search - return Zero query results
+    return zeroTags.length > 0 ? zeroTags : undefined;
+  }, [tagsSearchQuery, vespaTags, projectTags]);
 
   const availableStages = useMemo(() => {
     if (!stages || stages.length === 0) return undefined;
@@ -3878,8 +3927,9 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
               sourceChannelProjectIds={sourceChannelProjectIds}
               showBoardsFilter={!!channelId || isMyTicketsView}
               availableTags={availableTags}
+              onSearchTags={handleSearchTags}
               onLoadMoreTags={handleLoadMoreTags}
-              hasMoreTags={hasMoreTags}
+              hasMoreTags={!tagsSearchQuery.trim() && hasMoreZeroTags}
               availableStages={availableStages}
               hasPrReviewers={hasPrReviewers}
               hasQaAssigned={hasQaAssigned}
@@ -5449,6 +5499,9 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                           onTicketClick={handleTicketClick}
                           visibleColumns={visibleColumns}
                           availableTags={availableTags || []}
+                          onLoadMoreTags={handleLoadMoreTags}
+                          hasMoreTags={!tagsSearchQuery.trim() && hasMoreZeroTags}
+                          onSearchTags={handleSearchTags}
                           keyPrefix={`${group.key}::`}
                           layoutScope={`${viewMode}:${channelId ?? ''}:${projectIdParam ?? ''}:${boardId ?? ''}`}
                           searchActive={hasSearchTerm}
@@ -5495,6 +5548,9 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                   tags={tagsByTicketId.get(activeTicket.id) || []}
                   visibleColumns={visibleColumns}
                   availableTags={availableTags || []}
+                  onLoadMoreTags={handleLoadMoreTags}
+                  hasMoreTags={!tagsSearchQuery.trim() && hasMoreZeroTags}
+                  onSearchTags={handleSearchTags}
                   slaPolicies={kanbanSlaPolicies}
                 />
               )}

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -1930,7 +1930,11 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const [workspaceSelectedBoards] = useCachedQuery(
     queries.boardsByIds({ boardIds: filters.boards ?? [] }),
     {
-      enabled: isWorkspaceView && isSourceChannelsOpen && (filters.boards?.length ?? 0) > 0,
+      // Enable when dropdown is open (for source channels or filters/tags)
+      enabled:
+        isWorkspaceView &&
+        (isSourceChannelsOpen || isFiltersDropdownOpen) &&
+        (filters.boards?.length ?? 0) > 0,
     },
   );
   const sourceChannelProjectIds = useMemo(() => {
@@ -1982,11 +1986,99 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     }
   }, [isMyTicketsView, filters.boards, availableBoards, setFilters]);
 
+  // Determine if we're in single-project or multi-project mode for tags
+  const isMultiProjectView = !effectiveProjectId && sourceChannelProjectIds.length > 0;
   const tagsProjectId = effectiveProjectId || availableBoardDetails?.[0]?.projectId;
-  const [projectTags, projectTagsDetails] = useCachedQuery(
-    queries.projectTagsByProjectId({ projectId: tagsProjectId || '' }),
-    { enabled: !!tagsProjectId },
+
+  // State for cursor-based tag pagination
+  const [tagsCursor, setTagsCursor] = useState<{ name: string; id: string } | null>(null);
+  const [allLoadedTags, setAllLoadedTags] = useState<Array<{ name: string; id: string }>>([]);
+  const [hasMoreTags, setHasMoreTags] = useState(true);
+  const tagsLimitPerPage = 20;
+
+  // Fetch project tags for single project view (paginated with cursor)
+  const [singleProjectTags, singleProjectTagsDetails] = useCachedQuery(
+    queries.projectTagsByProjectId({
+      projectId: tagsProjectId || '',
+      limit: tagsLimitPerPage,
+      start: tagsCursor,
+      direction: 'forward',
+    }),
+    { enabled: !!tagsProjectId && !isMultiProjectView, cursorEnabled: true },
   );
+
+  // Fetch project tags for multi-project views (paginated with cursor)
+  const [multiProjectTags, projectTagsDetails] = useCachedQuery(
+    queries.projectTagsByProjectIds({
+      projectIds: sourceChannelProjectIds,
+      limit: tagsLimitPerPage,
+      start: tagsCursor,
+      direction: 'forward',
+    }),
+    { enabled: isMultiProjectView, cursorEnabled: true },
+  );
+
+  // Combine tags from either query
+  const currentPageTags = isMultiProjectView ? multiProjectTags : singleProjectTags;
+  const currentPageDetails = isMultiProjectView ? projectTagsDetails : singleProjectTagsDetails;
+
+  // Track processed cursor to avoid re-processing same page
+  const lastProcessedCursorRef = useRef<string>('initial');
+  const isLoadingMoreRef = useRef(false);
+
+  // Accumulate tags as pages load
+  useEffect(() => {
+    if (currentPageDetails?.type === 'complete' && currentPageTags) {
+      const newTags = currentPageTags as Array<{ name: string; id: string }>;
+      const cursorKey = tagsCursor ? `${tagsCursor.id}` : 'initial';
+
+      // For first page (cursor null), always process
+      if (tagsCursor === null) {
+        // Only update if tags actually changed
+        const newTagIds = newTags.map(t => t.id).join(',');
+        const existingTagIds = allLoadedTags.map(t => t.id).join(',');
+        if (newTagIds !== existingTagIds) {
+          setAllLoadedTags(newTags);
+        }
+        setHasMoreTags(newTags.length >= tagsLimitPerPage);
+        lastProcessedCursorRef.current = 'initial';
+        isLoadingMoreRef.current = false;
+      } else if (isLoadingMoreRef.current && lastProcessedCursorRef.current !== cursorKey) {
+        // Subsequent page - only process if we're actively loading more and cursor changed
+        setAllLoadedTags(prev => {
+          const existingIds = new Set(prev.map(t => t.id));
+          const uniqueNew = newTags.filter(t => !existingIds.has(t.id));
+          if (uniqueNew.length === 0) {
+            return prev;
+          }
+          return [...prev, ...uniqueNew];
+        });
+        setHasMoreTags(newTags.length >= tagsLimitPerPage);
+        lastProcessedCursorRef.current = cursorKey;
+        isLoadingMoreRef.current = false;
+      }
+    }
+  }, [currentPageTags, currentPageDetails, tagsCursor, tagsLimitPerPage, allLoadedTags]);
+
+  // Reset tags when project changes
+  const tagsProjectKey = tagsProjectId || sourceChannelProjectIds.join(',');
+  useEffect(() => {
+    setTagsCursor(null);
+    setAllLoadedTags([]);
+    setHasMoreTags(true);
+    lastProcessedCursorRef.current = 'initial';
+    isLoadingMoreRef.current = false;
+  }, [tagsProjectKey]);
+
+  // Load more tags callback
+  const handleLoadMoreTags = useCallback(() => {
+    if (!hasMoreTags || allLoadedTags.length === 0 || isLoadingMoreRef.current) return;
+    const lastTag = allLoadedTags[allLoadedTags.length - 1];
+    if (lastTag) {
+      isLoadingMoreRef.current = true;
+      setTagsCursor({ name: lastTag.name, id: lastTag.id });
+    }
+  }, [hasMoreTags, allLoadedTags]);
 
   // Create a map of stageId -> formId for quick lookup (from stages.formId).
   // NON_LINEAR boards also include transition-level forms (toStageId -> formId).
@@ -3203,11 +3295,22 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
   const lastSentFilteredTicketIdsRef = useRef<string | null>(null);
 
+  // Compute availableTags directly from query results to avoid state timing issues
+  // For initial load, use query results directly; for pagination, use accumulated state
   const availableTags = useMemo(() => {
-    if (!projectTags || projectTags.length === 0) return undefined;
-    const uniqueTags = new Set(projectTags.map(tag => tag.name));
+    // Use allLoadedTags if it has data (from pagination accumulation)
+    // Otherwise fall back to currentPageTags for immediate display
+    const tagsSource =
+      allLoadedTags.length > 0
+        ? allLoadedTags
+        : (currentPageTags as Array<{ name: string; id: string }> | undefined);
+
+    if (!tagsSource || tagsSource.length === 0) {
+      return undefined;
+    }
+    const uniqueTags = new Set(tagsSource.map(tag => tag.name));
     return Array.from(uniqueTags).sort();
-  }, [projectTags]);
+  }, [allLoadedTags, currentPageTags]);
 
   const availableStages = useMemo(() => {
     if (!stages || stages.length === 0) return undefined;
@@ -3775,6 +3878,8 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
               sourceChannelProjectIds={sourceChannelProjectIds}
               showBoardsFilter={!!channelId || isMyTicketsView}
               availableTags={availableTags}
+              onLoadMoreTags={handleLoadMoreTags}
+              hasMoreTags={hasMoreTags}
               availableStages={availableStages}
               hasPrReviewers={hasPrReviewers}
               hasQaAssigned={hasQaAssigned}

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -3489,8 +3489,12 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   useEffect(() => {
     if (!isKanbanLayout) return;
     if (hasSearchTerm) return;
+
+    // Don't reset lastKnownKanbanGroupsRef to null when query key changes.
+    // Keep the old groups visible until new ones load to prevent the view
+    // from disappearing when filters are applied in group-by mode.
+    // Only update the query key ref to track that we're waiting for new data.
     if (lastKnownKanbanGroupsQueryKeyRef.current !== kanbanColumnQueryKey) {
-      lastKnownKanbanGroupsRef.current = null;
       lastKnownKanbanGroupsQueryKeyRef.current = kanbanColumnQueryKey;
     }
 
@@ -3504,14 +3508,8 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
   useEffect(() => {
     if (!isKanbanLayout) return;
-
-    // On the pass where the query key changes, `localTickets` here still holds the previous
-    // query's rows: the reset above only queues setLocalTickets(null), which lands next render.
-    // Stamping the new key onto those rows would make the queryKey check below always pass, so
-    // drop the remembered rows instead and let a later pass re-record the new query's results.
     if (lastKnownKanbanTicketsQueryKeyRef.current !== kanbanColumnQueryKey) {
       lastKnownKanbanTicketsQueryKeyRef.current = kanbanColumnQueryKey;
-      lastKnownKanbanTicketsRef.current = null;
       return;
     }
 
@@ -3534,16 +3532,30 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const kanbanTicketsForGrouping = useMemo(() => {
     if (localTickets && localTickets.length > 0) return localTickets;
     const lastKnownKanbanTickets = lastKnownKanbanTicketsRef.current;
-    if (
-      hasSearchTerm &&
-      lastKnownKanbanTickets !== null &&
-      lastKnownKanbanTickets.queryKey === kanbanColumnQueryKey &&
-      lastKnownKanbanTickets.tickets.length > 0
-    ) {
-      return lastKnownKanbanTickets.tickets;
+    // Use last known tickets as fallback when localTickets is empty/null.
+    // This prevents the view from disappearing when filters are applied in group-by mode.
+    // IMPORTANT: Apply current filters to fallback tickets so stale data doesn't show.
+    if (lastKnownKanbanTickets !== null && lastKnownKanbanTickets.tickets.length > 0) {
+      // Apply current filters to the fallback tickets
+      const filteredFallback = applyTicketFilters(
+        lastKnownKanbanTickets.tickets,
+        deferredFilters,
+        tagsByTicketId,
+        formValuesByTicketId,
+        formFieldsById,
+        user?.id,
+      );
+      return filteredFallback;
     }
     return localTickets ?? [];
-  }, [hasSearchTerm, kanbanColumnQueryKey, localTickets]);
+  }, [
+    localTickets,
+    deferredFilters,
+    tagsByTicketId,
+    formValuesByTicketId,
+    formFieldsById,
+    user?.id,
+  ]);
 
   const processedGroups = useMemo(() => {
     const groupedRows = groupTickets(kanbanTicketsForGrouping, groupBy);

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -1928,20 +1928,8 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     return undefined;
   }, [myTicketBoardsQuery.data, viewMode]);
 
+  // Fetch board details for workspace views - used for source channels and tags
   const [workspaceSelectedBoards] = useCachedQuery(
-    queries.boardsByIds({ boardIds: filters.boards ?? [] }),
-    {
-      // Enable when dropdown is open (for source channels or filters/tags)
-      enabled:
-        isWorkspaceView &&
-        (isSourceChannelsOpen || isFiltersDropdownOpen) &&
-        (filters.boards?.length ?? 0) > 0,
-    },
-  );
-
-  // Fetch board details for workspace views to get project IDs for tags
-  // This is always enabled for workspace views (unlike workspaceSelectedBoards which is only for dropdowns)
-  const [workspaceBoardsForTags] = useCachedQuery(
     queries.boardsByIds({ boardIds: filters.boards ?? [] }),
     {
       enabled: isWorkspaceView && (filters.boards?.length ?? 0) > 0,
@@ -2009,8 +1997,8 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
       );
     }
     if (isWorkspaceView) {
-      // Use workspaceBoardsForTags which is always enabled for workspace views
-      return uniqueProjectIds(workspaceBoardsForTags ?? []);
+      // Use workspaceSelectedBoards which is always enabled for workspace views
+      return uniqueProjectIds(workspaceSelectedBoards ?? []);
     }
     // Single project view
     const singleProjectId = effectiveProjectId || availableBoardDetails?.[0]?.projectId;
@@ -2020,7 +2008,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     isWorkspaceView,
     filters.boards,
     availableBoardDetails,
-    workspaceBoardsForTags,
+    workspaceSelectedBoards,
     effectiveProjectId,
   ]);
 

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -732,12 +732,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const toggleGroupExpansion = useCallback(
     (groupKey: string) => {
       setExpandedGroups(prev => {
-        const next = new Set(prev);
-        if (next.has(groupKey)) {
-          next.delete(groupKey);
-        } else {
-          next.add(groupKey);
-        }
+        const next = new Set<string>(prev.has(groupKey) ? [] : [groupKey]);
         try {
           const raw = sessionStorage.getItem(expandedGroupsStorageKey);
           const map = (raw ? JSON.parse(raw) : {}) as Record<string, string[]>;
@@ -761,7 +756,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     try {
       const raw = sessionStorage.getItem(expandedGroupsStorageKey);
       const map = (raw ? JSON.parse(raw) : {}) as Record<string, string[]>;
-      setExpandedGroups(new Set(map[groupByKey] ?? []));
+      setExpandedGroups(new Set((map[groupByKey] ?? []).slice(0, 1)));
     } catch (err) {
       logger.error(Event.FRONTEND_ERROR, {
         type: 'migrated_console_error',
@@ -3696,6 +3691,17 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const isTableEmpty = processedGroups.every(group => group.allTickets.length === 0);
   const tableGroups = isTableEmpty ? [] : processedGroups;
 
+  const hasScrolledToExpandedGroup = useRef(false);
+  useEffect(() => {
+    if (hasScrolledToExpandedGroup.current) return;
+    const [expandedGroupKey] = [...expandedGroups];
+    if (!expandedGroupKey || processedGroups.length === 0) return;
+    const el = document.querySelector(`[data-group-key="${CSS.escape(expandedGroupKey)}"]`);
+    if (!el) return;
+    hasScrolledToExpandedGroup.current = true;
+    el.scrollIntoView({ block: 'start' });
+  }, [expandedGroups, processedGroups]);
+
   const filteredAvailableColumns = useMemo(() => {
     if (layoutView === 'table' || layoutView === 'flow') {
       // In table mode, hide TicketCard metadata columns
@@ -5163,6 +5169,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
             return (
               <div
                 key={group.key}
+                data-group-key={group.key}
                 className='flex flex-col rounded-lg border border-border overflow-hidden'
               >
                 {showGroupHeader && (
@@ -5261,7 +5268,11 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                   : null;
 
                 return (
-                  <div key={group.key} className={isExpanded || !showGroupHeader ? 'h-full' : ''}>
+                  <div
+                    key={group.key}
+                    data-group-key={group.key}
+                    className={isExpanded || !showGroupHeader ? 'h-full' : ''}
+                  >
                     {showGroupHeader && (
                       <button
                         onClick={() => toggleGroupExpansion(group.key)}

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -70,7 +70,6 @@ import { useMachine } from '@xstate/react';
 import { ticketFiltersMachine } from '../../machines/ticketFiltersMachine';
 import { setBoardNavParams } from '../../components/Tickets/boardNavStore';
 import type { KanbanTicketsPageBaseArgs } from './useKanbanTicketsPage';
-import { withTicketChannelScope } from './ticketChannelScope';
 import type { TicketFilters } from '../../components/Tickets/TicketFilters/types';
 import { KanbanColumns } from '../../components/Tickets/KanbanColumns/KanbanColumns';
 import { ViewBoardPicker } from '../../components/Project/ViewBoardPicker/ViewBoardPicker';
@@ -1726,17 +1725,22 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   // CENTRALIZED TICKET QUERY - fetch only tickets relevant to the current context.
   // Dynamic field filtering is done CLIENT-SIDE via applyTicketFilters.
   // When fevFieldIds is non-empty, formEntityValues are fetched as a related query.
+  // NOTE: We intentionally do NOT pass channelId to the query.
+  // The channel ticket tab should show tickets from ALL accessible channels
+  // (public + private where user is member), not just tickets from this channel.
+  // The boardId/projectId already scopes the results appropriately.
+  // Passing channelId would cause the ACL to use scalarChannelBody which
+  // restricts tickets to only that specific channel.
   const ticketsQueryParams = useMemo(() => {
     const params: FlowStepVisibilityOptions & {
       viewMode: 'project' | 'board' | 'my-tickets' | 'user-tickets' | 'group-tickets';
-      channelId?: string;
       projectId?: string;
       boardId?: string;
       boardIds?: string[];
       userId?: string;
       groupId?: string;
       formEntityValueFieldIds?: string[];
-    } = withTicketChannelScope({ viewMode: queryViewMode }, channelId);
+    } = { viewMode: queryViewMode };
 
     // Always pass boardId if it exists (from URL param)
     // Board ID implicitly scopes to project, so no need for projectId in this case
@@ -1795,7 +1799,6 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     filteredSingleBoardId,
     fevFieldIds,
     filters.boards,
-    channelId,
   ]);
 
   const [allProjectTickets, ticketsDetails] = useCachedQuery(

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.types.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.types.ts
@@ -26,13 +26,19 @@ export interface Stage {
 export interface SortableTicketCardProps {
   ticket: Ticket;
   tags: TicketTag[];
-  availableTags?: string[];
+  availableTags?: string[] | undefined;
+  /** Callback to load more tags */
+  onLoadMoreTags?: (() => void) | undefined;
+  /** Whether there are more tags to load */
+  hasMoreTags?: boolean | undefined;
+  /** Callback for server-side tag search */
+  onSearchTags?: ((query: string) => void) | undefined;
   onClick: (e: React.MouseEvent | KeyboardEvent) => void;
   visibleColumns?: Set<string> | undefined;
-  activeTicketId?: string;
-  showEmailReads?: boolean;
+  activeTicketId?: string | undefined;
+  showEmailReads?: boolean | undefined;
   /** SLA policies pre-fetched by the parent; forwarded to TicketCard to avoid per-card fetches. */
-  slaPolicies?: BoardSlaPolicy[];
+  slaPolicies?: BoardSlaPolicy[] | undefined;
 }
 
 export interface DroppableStageProps {

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
@@ -431,18 +431,13 @@ export const useKanbanTicketsPage = (
     : null;
   // Only send to Vespa when we have real IDs and not inverted/includeUnassigned
   // (those semantics require the Zero/local filter path).
-  // Send all 4 identity forms to match prefixedKanbanIdentityValues storage variants.
+  // Send bare IDs - the backend expands to all identity forms for Vespa matching.
   const vespaAssignee =
     parsedAssignee &&
     parsedAssignee.ids.length > 0 &&
     !parsedAssignee.inverted &&
     !parsedAssignee.includeUnassigned
-      ? parsedAssignee.ids
-          .flatMap(id => {
-            const bareId = id.replace(/^(user:|group:|userGroup:)/, '');
-            return [bareId, `user:${bareId}`, `group:${bareId}`, `userGroup:${bareId}`];
-          })
-          .join(',')
+      ? parsedAssignee.ids.map(id => id.replace(/^(user:|group:|userGroup:)/, '')).join(',')
       : undefined;
 
   const vespaTags =
@@ -450,15 +445,10 @@ export const useKanbanTicketsPage = (
       ? options.filters.tags.join(',')
       : undefined;
 
-  // Send all 4 identity forms to match prefixedKanbanIdentityValues storage variants.
+  // Send bare IDs - the backend expands to all identity forms for Vespa matching.
   const vespaCreatedBy =
     options.filters?.createdBy && options.filters.createdBy.length > 0
-      ? options.filters.createdBy
-          .flatMap(id => {
-            const bareId = id.replace(/^(user:|group:|userGroup:)/, '');
-            return [bareId, `user:${bareId}`, `group:${bareId}`, `userGroup:${bareId}`];
-          })
-          .join(',')
+      ? options.filters.createdBy.map(id => id.replace(/^(user:|group:|userGroup:)/, '')).join(',')
       : undefined;
 
   // Compute group-specific filter for Vespa based on groupBy/groupKey
@@ -475,12 +465,9 @@ export const useKanbanTicketsPage = (
     if (options.groupBy === 'assignee') {
       // Don't filter if groupKey is "Unassigned" - Vespa can't filter for null assignee easily
       if (options.groupKey === 'Unassigned') return {};
-      // Vespa may store assignedTo in any of these forms (see prefixedKanbanIdentityValues).
-      // Send all variants so we match regardless of storage format.
+      // Send bare ID - the backend expands to all identity forms for Vespa matching.
       const bareId = options.groupKey.replace(/^(user:|group:|userGroup:)/, '');
-      return {
-        assignee: [bareId, `user:${bareId}`, `group:${bareId}`, `userGroup:${bareId}`].join(','),
-      };
+      return { assignee: bareId };
     }
     if (options.groupBy === 'status') {
       // Filter by the group's status value
@@ -490,34 +477,68 @@ export const useKanbanTicketsPage = (
     return {};
   })();
 
+  // When searching, skip stage/status/groupBy filters - fetch all results and segregate in frontend.
+  // For dynamic field grouping, keep the filters as-is.
+  const isFormFieldGroupBy =
+    typeof options.groupBy === 'object' && options.groupBy?.type === 'formField';
+  const skipColumnFiltersForSearch = hasSearchTerm && !isFormFieldGroupBy;
+
   // Create a search key that changes when the group context changes
   // This forces the search to re-trigger when switching views
+  // When searching without column filters, use a shared key so all columns share one search call
+  // Include filter values in the key so that filter changes trigger a new search
   const groupByKey =
     typeof options.groupBy === 'object'
       ? `${options.groupBy.type}:${options.groupBy.fieldId}`
       : String(options.groupBy ?? 'none');
-  const vespaSearchKey = `${groupByKey}:${options.groupKey ?? ''}:${options.stageName}`;
+  // Include ALL filter values in search key so all columns re-search when filters change
+  // Previously this only included priority, assignee, tags, createdBy - missing boards, stages, etc.
+  const filterKey = skipColumnFiltersForSearch
+    ? JSON.stringify({
+        priority: vespaPriority ?? '',
+        assignee: vespaAssignee ?? '',
+        tags: vespaTags ?? '',
+        createdBy: vespaCreatedBy ?? '',
+        boards: options.filters?.boards ?? [],
+        stages: options.filters?.stages ?? [],
+        ticketTypes: options.filters?.ticketTypes ?? [],
+        sourceChannels: options.filters?.sourceChannels ?? [],
+        userGroups: options.filters?.userGroups ?? [],
+        dynamicFields: options.filters?.dynamicFields ?? {},
+        boardId: effectiveVespaBoardId ?? '',
+        projectId: options.projectId ?? '',
+      })
+    : '';
+  const vespaSearchKey = skipColumnFiltersForSearch
+    ? `search:${groupByKey}:${filterKey}` // Shared key includes filters
+    : `${groupByKey}:${options.groupKey ?? ''}:${options.stageName}`;
 
   const vespaTicketSearch = useVespaTicketSearch({
     searchTerm: trimmedSearchTerm,
     dynamicFieldValues: pageVespaTokens,
     enabled: requiresVespaTicketIds,
-    limit: 200,
+    limit: hasSearchTerm ? 400 : 200,
     fetchAllDynamicFieldMatches: true,
-    maxFetchedResults: 400,
+    maxFetchedResults: hasSearchTerm ? 800 : 400,
     searchKey: vespaSearchKey,
     ...(options.dynamicFieldDateRanges
       ? { dynamicFieldDateRanges: options.dynamicFieldDateRanges }
       : {}),
     ...(options.projectId ? { projectId: options.projectId } : {}),
     ...(effectiveVespaBoardId ? { boardId: effectiveVespaBoardId } : {}),
-    ...(options.columnType === 'status' ? { status: options.stageName } : {}),
-    ...(options.columnType === 'stage' ? { stage: options.stageName } : {}),
+    // Skip column filters when searching (will segregate in frontend)
+    ...(!skipColumnFiltersForSearch && options.columnType === 'status'
+      ? { status: options.stageName }
+      : {}),
+    ...(!skipColumnFiltersForSearch && options.columnType === 'stage'
+      ? { stage: options.stageName }
+      : {}),
     ...(vespaPriority ? { priority: vespaPriority } : {}),
     ...(vespaAssignee ? { assignee: vespaAssignee } : {}),
     ...(vespaTags ? { tags: vespaTags } : {}),
     ...(vespaCreatedBy ? { createdBy: vespaCreatedBy } : {}),
-    ...vespaGroupFilter,
+    // Skip group filters when searching (will segregate in frontend)
+    ...(!skipColumnFiltersForSearch ? vespaGroupFilter : {}),
   });
   const localFilterKey = JSON.stringify({
     priority: options.filters?.priority ?? [],
@@ -530,20 +551,76 @@ export const useKanbanTicketsPage = (
     ticketTypes: options.filters?.ticketTypes ?? [],
     sourceChannels: options.filters?.sourceChannels ?? [],
   });
-  const directVespaPage = useMemo(
-    () =>
-      shouldUseDirectVespaRows
-        ? applyLocalVespaFilters(
-            options.channelId
-              ? (vespaTicketSearch.searchResults?.filter(
-                  ticket => ticket.channelId === options.channelId,
-                ) ?? null)
-              : vespaTicketSearch.searchResults,
-            options.filters,
-          )
-        : null,
-    [localFilterKey, options.channelId, shouldUseDirectVespaRows, vespaTicketSearch.searchResults],
-  );
+  const directVespaPage = useMemo(() => {
+    if (!shouldUseDirectVespaRows) return null;
+
+    // When a new search is in progress, don't apply current filters to stale results
+    // as they may not match (e.g., user added a filter while search was cached).
+    // Return null to show loading state until fresh results arrive.
+    if (vespaTicketSearch.isSearching) return null;
+
+    let results = vespaTicketSearch.searchResults;
+    if (!results) return null;
+
+    // Filter by channelId if specified
+    if (options.channelId) {
+      results = results.filter(ticket => ticket.channelId === options.channelId);
+    }
+
+    // Apply local filters (priority, boards, assignee, etc.)
+    const filtered = applyLocalVespaFilters(results, options.filters);
+    if (!filtered) return null;
+
+    // When searching without column filters, segregate by stage/status in frontend
+    if (skipColumnFiltersForSearch) {
+      const segregated = filtered.filter(ticket => {
+        // Filter by column stage/status
+        if (options.columnType === 'status' && (ticket.statusV2 as string) !== options.stageName) {
+          return false;
+        }
+        if (options.columnType === 'stage' && ticket.stageName !== options.stageName) {
+          return false;
+        }
+
+        // Filter by groupBy (assignee, priority, status)
+        if (options.groupBy === 'assignee' && options.groupKey) {
+          const ticketAssignee = normalizeIdentity(ticket.assignedTo);
+          if (options.groupKey === 'Unassigned') {
+            if (ticketAssignee) return false;
+          } else {
+            const groupAssignee = normalizeIdentity(options.groupKey);
+            if (ticketAssignee !== groupAssignee) return false;
+          }
+        }
+        if (options.groupBy === 'priority' && options.groupKey) {
+          if (options.groupKey === 'No Priority') {
+            if (ticket.priority) return false;
+          } else {
+            if ((ticket.priority as string) !== options.groupKey) return false;
+          }
+        }
+        if (options.groupBy === 'status' && options.groupKey) {
+          if ((ticket.statusV2 as string) !== options.groupKey) return false;
+        }
+
+        return true;
+      });
+      return segregated;
+    }
+
+    return filtered;
+  }, [
+    localFilterKey,
+    options.channelId,
+    options.columnType,
+    options.stageName,
+    options.groupBy,
+    options.groupKey,
+    shouldUseDirectVespaRows,
+    skipColumnFiltersForSearch,
+    vespaTicketSearch.isSearching,
+    vespaTicketSearch.searchResults,
+  ]);
   const vespaTicketIds = requiresVespaTicketIds
     ? (vespaTicketSearch.searchResults?.map(ticket => ticket.id) ?? [])
     : undefined;
@@ -575,7 +652,41 @@ export const useKanbanTicketsPage = (
       !shouldUseDirectVespaRows &&
       (!requiresVespaTicketIds || vespaTicketSearch.searchResults !== null),
   });
-  const effectivePage = shouldUseDirectVespaRows ? directVespaPage : page;
+  // Overlay live Zero fields onto direct-Vespa payload rows. Vespa is an async
+  // search index, so a row's statusV2/stageName can lag a just-applied status
+  // change; rendering that stale stage places the card in its OLD kanban column
+  // (ticket 61697: status changed to B but card stays in A/C until reindex).
+  // Hydrating the live stage/status by id from the Zero store keeps column
+  // membership correct immediately, before Vespa catches up.
+  const [liveDirectRows] = useCachedQuery(
+    queries.ticketsByIds({
+      ticketIds: shouldUseDirectVespaRows ? (vespaTicketIds ?? []) : [],
+    }),
+    { enabled: shouldUseDirectVespaRows && (vespaTicketIds?.length ?? 0) > 0 },
+  );
+  const liveDirectRowsById = useMemo(() => {
+    const byId = new Map<string, Ticket>();
+    for (const row of liveDirectRows ?? []) byId.set(row.id, row as Ticket);
+    return byId;
+  }, [liveDirectRows]);
+  const overlaidDirectVespaPage = useMemo(() => {
+    if (!shouldUseDirectVespaRows || directVespaPage === null) return directVespaPage;
+    if (liveDirectRowsById.size === 0) return directVespaPage;
+    return directVespaPage.map(ticket => {
+      const live = liveDirectRowsById.get(ticket.id);
+      if (!live) return ticket;
+      return {
+        ...ticket,
+        statusV2: live.statusV2,
+        stageName: live.stageName,
+        boardId: live.boardId,
+        priority: live.priority,
+        assignedTo: live.assignedTo,
+      };
+    });
+  }, [shouldUseDirectVespaRows, directVespaPage, liveDirectRowsById]);
+
+  const effectivePage = shouldUseDirectVespaRows ? overlaidDirectVespaPage : page;
   const effectivePageDetailsType = shouldUseDirectVespaRows
     ? directVespaPage === null
       ? 'unknown'

--- a/apps/dashboard/src/services/searchService.ts
+++ b/apps/dashboard/src/services/searchService.ts
@@ -18,6 +18,22 @@ export function sanitizeSearchQuery(query: string): string {
   ); // Enforce max length
 }
 
+export interface VespaTagSearchResponse {
+  success: boolean;
+  data?: {
+    tags: string[];
+    total: number;
+  };
+  error?: string;
+}
+
+export interface VespaTagSearchFilters {
+  query?: string | undefined;
+  projectId?: string | undefined;
+  boardIds?: string[] | undefined;
+  limit?: number | undefined;
+}
+
 export class SearchService {
   private vespaBaseUrl = '/vespaSearch';
 
@@ -291,6 +307,55 @@ export class SearchService {
     }
 
     return params;
+  }
+
+  /**
+   * Search for ticket tags via Vespa grouping
+   */
+  async searchTags(
+    filters: VespaTagSearchFilters,
+    signal?: AbortSignal,
+  ): Promise<{ tags: string[]; total: number }> {
+    try {
+      const params: Record<string, string> = {
+        type: 'ticket_tags',
+      };
+
+      if (filters.query) {
+        params['q'] = sanitizeSearchQuery(filters.query);
+      }
+
+      if (filters.projectId) {
+        params['projectId'] = filters.projectId;
+      }
+
+      if (filters.boardIds && filters.boardIds.length > 0) {
+        params['board'] = filters.boardIds.join(',');
+      }
+
+      if (filters.limit !== undefined) {
+        params['limit'] = filters.limit.toString();
+      }
+
+      const response = await apiInstance.get<VespaTagSearchResponse>(this.vespaBaseUrl, {
+        params,
+        ...(signal ? { signal } : {}),
+      });
+
+      if (!response.data.success || !response.data.data) {
+        throw new Error(response.data.error || 'Vespa tag search request failed');
+      }
+
+      return {
+        tags: response.data.data.tags,
+        total: response.data.data.total,
+      };
+    } catch (error) {
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error('Vespa tag search request failed');
+    }
   }
 }
 

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -3595,13 +3595,47 @@ export const queries = defineQueries({
   getAllTicketEntityMappings: defineQuery(() => {
     return zql.ticket_entity_mappings;
   }),
-  // Query for project tags by project ID
+  // Query for project tags by project ID (paginated with bidirectional cursor)
   projectTagsByProjectId: defineQuery(
-    z.object({ projectId: z.string() }),
-    ({ args: { projectId } }) => {
-      return zql.project_tags
+    z.object({
+      projectId: z.string(),
+      limit: z.number().optional(),
+      start: z.object({ name: z.string(), id: z.string() }).nullish(),
+      direction: z.enum(['forward', 'backward']).optional(),
+    }),
+    ({ args: { projectId, limit = 100, start, direction = 'forward' } }) => {
+      const isBackward = direction === 'backward';
+      let q = zql.project_tags
         .where('projectId', projectId)
-        .orderBy('name', 'asc');
+        .orderBy('name', isBackward ? 'desc' : 'asc')
+        .orderBy('id', isBackward ? 'desc' : 'asc');
+      if (start) {
+        q = q.start({ name: start.name, id: start.id }, { inclusive: false });
+      }
+      return q.limit(limit);
+    },
+  ),
+  // Query for project tags by multiple project IDs (paginated with bidirectional cursor)
+  projectTagsByProjectIds: defineQuery(
+    z.object({
+      projectIds: z.array(z.string()),
+      limit: z.number().optional(),
+      start: z.object({ name: z.string(), id: z.string() }).nullish(),
+      direction: z.enum(['forward', 'backward']).optional(),
+    }),
+    ({ args: { projectIds, limit = 100, start, direction = 'forward' } }) => {
+      if (projectIds.length === 0) {
+        return zql.project_tags.where('id', 'nonexistent').limit(0);
+      }
+      const isBackward = direction === 'backward';
+      let q = zql.project_tags
+        .where('projectId', 'IN', projectIds)
+        .orderBy('name', isBackward ? 'desc' : 'asc')
+        .orderBy('id', isBackward ? 'desc' : 'asc');
+      if (start) {
+        q = q.start({ name: start.name, id: start.id }, { inclusive: false });
+      }
+      return q.limit(limit);
     },
   ),
   // Conversation labels (Gmail-style) — the channel/desk's label catalog for the sidebar.


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
