### PR TITLE
feat: XYNE-63221 add @xyne/logger secret-shredding logging framework

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -91,6 +91,7 @@
     "@types/node-rsa": "^1.1.4",
     "@types/unzipper": "^0.10.11",
     "@types/yauzl": "^2.10.3",
+    "@xyne/logger": "workspace:*",
     "@xyne/shared": "workspace:*",
     "@xyne/storage": "workspace:*",
     "@xyne/vespa-ts": "1.6.0",

--- a/apps/backend/src/utils/logger.ts
+++ b/apps/backend/src/utils/logger.ts
@@ -2,6 +2,7 @@ import winston from 'winston';
 import { AsyncLocalStorage } from 'async_hooks';
 import fluentLogger from 'fluent-logger';
 import type { Socket } from 'net';
+import { shredRecordInPlace } from '@xyne/logger';
 import { config } from '@/config/env';
 
 export interface LogContext {
@@ -165,12 +166,20 @@ function decycle(value: unknown, ancestors: unknown[]): unknown {
 
 const sanitizeForFluent = winston.format((info) => decycle(info, []) as winston.Logform.TransformableInfo);
 
+// Redact secret values on every sink. In sharedFormat (before the per-transport
+// clone) so the Fluent sink is covered too, not just error messages. Values only,
+// so field names / level / timestamp stay intact => frozen Grafana contract unchanged.
+const shredSecrets = winston.format(
+  (info) => shredRecordInPlace(info as unknown as Record<string, unknown>) as unknown as winston.Logform.TransformableInfo
+);
+
 // Runs once at call time, before winston-transport's per-transport clone drops Error fields.
 const sharedFormat = winston.format.combine(
   winston.format.timestamp(),
   winston.format.errors({ stack: true }),
   normalizeErrors(),
-  injectContext()
+  injectContext(),
+  shredSecrets()
 );
 
 // sharedFormat's timestamp is UTC ISO for Fluent Bit; re-render local for console output.

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -30,6 +30,7 @@
       "#zero-internal/schema": ["../node_modules/@rocicorp/zero/out/zero-server/src/schema"],
       "#zero-internal/compiler": ["../node_modules/@rocicorp/zero/out/z2s/src/compiler"],
       "#zero-internal/sql": ["../node_modules/@rocicorp/zero/out/z2s/src/sql"],
+      "@xyne/logger": ["../../../packages/logger/dist"],
       "@xyne/shared": ["../../../packages/shared/dist"],
       "@xyne/storage": ["../../../packages/storage/dist"],
       "@framework": ["../../../packages/framework/dist"],

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -138,6 +138,7 @@
     "@xstate/store": "^3.16.0",
     "@xyflow/react": "^12.11.2",
     "@xyne/icons": "workspace:*",
+    "@xyne/logger": "workspace:*",
     "@xyne/shared": "workspace:*",
     "@xyne/workflow-sdk": "3.2.36",
     "@xyne/workflow-ui": "1.3.34",

--- a/apps/dashboard/src/utils/logger.worker.ts
+++ b/apps/dashboard/src/utils/logger.worker.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
+import { shred } from '@xyne/logger';
 import type { LogEvent } from './logger';
 
 export type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
@@ -175,7 +176,10 @@ class LoggerWorker {
         this.droppedLogsCount++;
       }
 
-      this.logs.push(logEntry);
+      // Shred secret values out of every field before the entry is buffered
+      // for POST. Field names (the frozen analytics contract: event,
+      // platformName, emailId, pageUrl, …) are preserved — values only.
+      this.logs.push(shred(logEntry) as LogEntry);
     }
   }
 

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -41,6 +41,7 @@
     "@opentelemetry/sdk-metrics": "^2.5.0",
     "@opentelemetry/semantic-conventions": "^1.39.0",
     "@types/node": "^24.3.1",
+    "@xyne/logger": "workspace:*",
     "archiver": "^7.0.0",
     "electron-log": "^5.4.3",
     "electron-store": "^8.2.0",

--- a/apps/electron/src/services/logger/Logger.ts
+++ b/apps/electron/src/services/logger/Logger.ts
@@ -8,6 +8,7 @@
 
 import log from 'electron-log/main';
 import { v4 as uuidv4 } from 'uuid';
+import { shred } from '@xyne/logger';
 import type { EnrollmentEventType } from './enrollment-events';
 import * as os from 'os';
 import { net, app } from 'electron';
@@ -272,14 +273,18 @@ class LoggerService {
       ...(normalizedFields || {}),
     };
 
+    // Shred secret values out of every field before it reaches any sink
+    // (log files + the POST buffer). Field names are preserved — values only.
+    const safeEntry = shred(logEntry) as LogEntry;
+
     // Write to main log (all levels)
-    log.info(`[${logType ?? 'EnrollmentLogger'}]`, JSON.stringify(logEntry));
-    
+    log.info(`[${logType ?? 'EnrollmentLogger'}]`, JSON.stringify(safeEntry));
+
     // Write to error log file (only error)
     if (level === LogLevel.ERROR) {
       errorLogger[level.toLowerCase() as 'warn' | 'error'](
         `[${logType ?? 'EnrollmentLogger'}]`,
-        JSON.stringify(logEntry)
+        JSON.stringify(safeEntry)
       );
     }
 
@@ -291,7 +296,7 @@ class LoggerService {
       this.droppedLogsCount++;
     }
 
-    this.logs.push(logEntry);
+    this.logs.push(safeEntry);
 
     // Auto-flush if batch size reached
     // if (this.logs.length >= this.maxBatchSize) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prepare": "husky",
     "setup": "pnpm install && pnpm run build:shared",
     "install:all": "pnpm install",
-    "build:shared": "pnpm --filter @xyne/shared --filter @xyne/storage --filter @xyne/icons --filter agentic-framework --filter @xyne/litellm-client run build",
+    "build:shared": "pnpm --filter @xyne/logger --filter @xyne/shared --filter @xyne/storage --filter @xyne/icons --filter agentic-framework --filter @xyne/litellm-client run build",
     "doctor": "node scripts/xyne-doctor.mjs",
     "doctor:demo": "node scripts/xyne-doctor.mjs --demo",
     "doctor:test": "node --test scripts/xyne-doctor.test.mjs",

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.19.1",
+    "@xyne/logger": "workspace:*",
     "diff": "8.0.2",
     "dotenv": "^16.5.0",
     "google-auth-library": "^9.15.1",

--- a/packages/framework/src/utils/logger.ts
+++ b/packages/framework/src/utils/logger.ts
@@ -1,6 +1,7 @@
 /**
  * Logging abstraction to replace console.log usage
  */
+import { shred, shredText } from '@xyne/logger';
 
 export enum LogLevel {
   DEBUG = 'debug',
@@ -63,10 +64,14 @@ class SimpleLogger implements Logger {
     // In production, this would integrate with proper logging service
     // For now, we'll use a simple implementation that doesn't violate ESLint
     if (typeof process !== 'undefined' && process.env['NODE_ENV'] !== 'test') {
-      const logMessage = `[${entry.timestamp.toISOString()}] ${level.toUpperCase()}: ${message}`;
-      const logData = context ? ` | Context: ${JSON.stringify(context)}` : '';
-      const errorData = error ? ` | Error: ${error.message}` : '';
-      
+      // Shred secret values out of the message/context/error before writing.
+      const safeMessage = shredText(message);
+      const safeContext = context ? shred(context) : undefined;
+      const safeError = error ? shredText(error.message) : undefined;
+      const logMessage = `[${entry.timestamp.toISOString()}] ${level.toUpperCase()}: ${safeMessage}`;
+      const logData = safeContext ? ` | Context: ${JSON.stringify(safeContext)}` : '';
+      const errorData = safeError ? ` | Error: ${safeError}` : '';
+
       process.stdout.write(`${logMessage}${logData}${errorData}\n`);
     }
   }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@xyne/logger",
+  "license": "Apache-2.0",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Typed, secret-shredding logging core shared across xyne services",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./node": {
+      "types": "./dist/node.d.ts",
+      "import": "./dist/node.js",
+      "default": "./dist/node.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepare": "pnpm run build",
+    "watch": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/logger/src/context.ts
+++ b/packages/logger/src/context.ts
@@ -1,0 +1,23 @@
+import type { ContextProvider, LogPayload } from "./types.js";
+
+// Process-lifetime ambient context (browser/electron model — no ALS off-Node).
+export class SetOnceContext implements ContextProvider {
+  private fields: LogPayload = {};
+
+  /** Merge fields into the ambient context (last write wins per key). */
+  set(fields: LogPayload): void {
+    this.fields = { ...this.fields, ...fields };
+  }
+
+  /** Replace the entire ambient context. */
+  reset(fields: LogPayload = {}): void {
+    this.fields = { ...fields };
+  }
+
+  get(): LogPayload | undefined {
+    return this.fields;
+  }
+}
+
+/** A provider that never contributes any ambient fields. */
+export const emptyContext: ContextProvider = { get: () => undefined };

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,0 +1,21 @@
+// @xyne/logger — typed, secret-shredding logging core (PRD).
+// Node-only ALS context lives at @xyne/logger/node.
+export type {
+  LogValue,
+  SecretKey,
+  ForbidSecrets,
+  LogPayload,
+  LogLevel,
+  Logger,
+  ContextProvider,
+} from "./types.js";
+
+export {
+  shred,
+  shredText,
+  shredRecordInPlace,
+  isSecretKey,
+  type ShredOptions,
+} from "./shredder.js";
+
+export { SetOnceContext, emptyContext } from "./context.js";

--- a/packages/logger/src/node.ts
+++ b/packages/logger/src/node.ts
@@ -1,0 +1,24 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { ContextProvider, LogPayload } from "./types.js";
+
+// Node per-request context via AsyncLocalStorage. Separate entry (@xyne/logger/node)
+// so the core never pulls node:async_hooks into a browser bundle.
+export class AsyncLocalStorageContext implements ContextProvider {
+  readonly storage = new AsyncLocalStorage<LogPayload>();
+
+  get(): LogPayload | undefined {
+    return this.storage.getStore();
+  }
+
+  /** Run `fn` with `fields` merged on top of any inherited context. */
+  run<T>(fields: LogPayload, fn: () => T): T {
+    const parent = this.storage.getStore() ?? {};
+    return this.storage.run({ ...parent, ...fields }, fn);
+  }
+
+  /** Merge fields into the active context in place (for ids learned mid-run). */
+  set(fields: LogPayload): void {
+    const store = this.storage.getStore();
+    if (store) Object.assign(store, fields);
+  }
+}

--- a/packages/logger/src/shredder.ts
+++ b/packages/logger/src/shredder.ts
@@ -1,0 +1,205 @@
+// The shredder — one denylist redaction pass for every log record (PRD R3/R4).
+// Redacts secret VALUES only (field names kept => frozen Grafana contract intact)
+// via two detectors: by KEY (secret-named field) and by VALUE (secret-shaped
+// string). Cycle-safe, size-capped, control-char scrubbed, and never throws.
+
+export interface ShredOptions {
+  /** Max characters kept per string before truncation. Default 8192. */
+  maxStringLength?: number;
+  /** Max nesting depth before a node collapses to a placeholder. Default 12. */
+  maxDepth?: number;
+  /** Max array/object entries kept per node. Default 1000. */
+  maxEntries?: number;
+}
+
+const DEFAULTS: Required<ShredOptions> = {
+  maxStringLength: 8192,
+  maxDepth: 12,
+  maxEntries: 1000,
+};
+
+const REDACTED = "[REDACTED]";
+
+// A user-controlled `__proto__`/`constructor`/`prototype` key must never be
+// written onto an object (prototype pollution / property injection). They carry
+// no log value, so we drop them via an explicit literal guard at each write site.
+
+// Secret stems, matched as substrings on the normalized key (so accessToken,
+// x-api-key, refresh_token, clientSecret all hit).
+const SECRET_KEY_RE =
+  /(password|passwd|pwd|token|apikey|secret|authorization|credential|cookie|privatekey|jwt|passphrase)/;
+
+// Safe siblings of a secret stem (masked preview, presence flag, source, expiry,
+// token count…). Checked first and wins over SECRET_KEY_RE.
+const SAFE_KEY_RE = /(preview|present|source|exp|expiry|expiresat|tokens|count|length|type|name|id)$/;
+
+/** Secret-shaped value patterns, redacted wherever they appear in any string. */
+const VALUE_PATTERNS: Array<[RegExp, string]> = [
+  // PEM private-key blocks (any label: RSA/EC/OPENSSH/…). Must run first.
+  [/-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9 ]+ )?PRIVATE KEY-----/g, "[REDACTED_PEM]"],
+  // `Bearer <token>` in an Authorization header or free text.
+  [/\b[Bb]earer\s+[A-Za-z0-9._~+/=-]{8,}/g, "Bearer [REDACTED]"],
+  // JSON Web Tokens: three base64url segments starting `eyJ…`.
+  [/\beyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{4,}/g, "[REDACTED_JWT]"],
+  // OpenAI / Anthropic style prefixed keys: sk-, sk-ant-, rk-, pk_live_, …
+  [/\b(?:sk|rk|pk|ak)[-_](?:[A-Za-z0-9]{2,}[-_])?[A-Za-z0-9]{16,}\b/g, "[REDACTED_KEY]"],
+  // AWS access-key id.
+  [/\bAKIA[0-9A-Z]{16}\b/g, "[REDACTED_AWS_KEY]"],
+  // GitHub tokens (ghp_, gho_, ghs_, ghr_, github_pat_).
+  [/\bgh[opsru]_[A-Za-z0-9]{20,}\b/g, "[REDACTED_KEY]"],
+  [/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, "[REDACTED_KEY]"],
+  // Slack tokens (xoxb-, xoxp-, xapp-, …).
+  [/\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, "[REDACTED_KEY]"],
+  // Inline `secret=value` / `password: value` regardless of surrounding key.
+  // (Not `authorization` — real header values are caught by the Bearer rule,
+  // and matching it here over-redacts innocent `authorization: <enum>` prose.)
+  [/\b(password|passwd|pwd|token|secret|api[_-]?key)\b(\s*[:=]\s*)("?)([^\s,;"']{4,})\3/gi, "$1$2[REDACTED]"],
+];
+
+// Neutralise newlines/tabs (→ space) so a user value can't forge extra log
+// lines on a plain-text sink (log injection), and drop other C0/DEL control
+// chars entirely. On JSON sinks this is belt-and-suspenders; on console/stdout
+// sinks it's the actual guard.
+function scrubControlChars(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/[\t\n\r\v\f]/g, " ").replace(/[\x00-\x08\x0E-\x1F\x7F]/g, "");
+}
+
+function redactString(s: string, max: number): string {
+  let out = scrubControlChars(s);
+  for (const [re, rep] of VALUE_PATTERNS) out = out.replace(re, rep);
+  if (out.length > max) out = out.slice(0, max) + `…[truncated ${out.length - max} chars]`;
+  return out;
+}
+
+function normalizeKey(key: string): string {
+  return key.toLowerCase().replace(/[_-]/g, "");
+}
+
+/** Whether a field name denotes a secret (and is not a safe sibling). */
+export function isSecretKey(key: string): boolean {
+  const n = normalizeKey(key);
+  if (SAFE_KEY_RE.test(n)) return false;
+  return SECRET_KEY_RE.test(n);
+}
+
+function serializeError(err: Error, max: number): Record<string, LogValueOut> {
+  const out: Record<string, LogValueOut> = {
+    name: err.name,
+    message: redactString(err.message, max),
+  };
+  if (typeof err.stack === "string") out.stack = redactString(err.stack, max);
+  // Copy common structured fields (HTTP/Node errors) but shred their values.
+  for (const field of ["code", "status", "statusCode", "errno", "syscall"] as const) {
+    const v = (err as unknown as Record<string, unknown>)[field];
+    if (typeof v === "string" || typeof v === "number") out[field] = v;
+  }
+  return out;
+}
+
+type LogValueOut = string | number | boolean | null | LogValueOut[] | { [k: string]: LogValueOut };
+
+function shredNode(value: unknown, seen: WeakSet<object>, depth: number, opts: Required<ShredOptions>): LogValueOut {
+  // Primitives.
+  if (value === null || value === undefined) return null;
+  const t = typeof value;
+  if (t === "string") return redactString(value as string, opts.maxStringLength);
+  if (t === "number") return Number.isFinite(value as number) ? (value as number) : String(value);
+  if (t === "boolean") return value as boolean;
+  if (t === "bigint") return (value as bigint).toString();
+  if (t === "function" || t === "symbol") return `[${t}]`;
+
+  // Non-plain objects that must not be walked key-by-key.
+  if (value instanceof Error) return serializeError(value, opts.maxStringLength);
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? "[Invalid Date]" : value.toISOString();
+  if (typeof Buffer !== "undefined" && Buffer.isBuffer(value)) return `[Buffer ${value.length}b]`;
+  if (ArrayBuffer.isView(value)) return `[${(value as { constructor: { name: string } }).constructor.name}]`;
+
+  // From here on it is an object/array/map/set.
+  const obj = value as object;
+  if (seen.has(obj)) return "[Circular]";
+  if (depth >= opts.maxDepth) return Array.isArray(value) ? "[Array]" : "[Object]";
+  seen.add(obj);
+  try {
+    if (value instanceof Map) return shredNode(Object.fromEntries(value), seen, depth, opts);
+    if (value instanceof Set) return shredNode([...value], seen, depth, opts);
+
+    if (Array.isArray(value)) {
+      const arr: LogValueOut[] = [];
+      const n = Math.min(value.length, opts.maxEntries);
+      for (let i = 0; i < n; i++) arr.push(shredNode(value[i], seen, depth + 1, opts));
+      if (value.length > n) arr.push(`…[${value.length - n} more]`);
+      return arr;
+    }
+
+    // Collect [key, value] pairs and build the object with Object.fromEntries
+    // rather than `out[key] = …`. Field names still come from the input (that's
+    // the point — preserve the log contract), but we never use a user value as a
+    // property-write target, and __proto__/constructor/prototype are dropped, so
+    // there is no prototype-pollution / property-injection surface.
+    const entries: Array<[string, LogValueOut]> = [];
+    const keys = Object.keys(value as Record<string, unknown>);
+    let count = 0;
+    for (const key of keys) {
+      if (count >= opts.maxEntries) {
+        entries.push(["…", `[${keys.length - count} more keys]`]);
+        break;
+      }
+      count++;
+      if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
+      // KEY detector: secret-named field redacted wholesale (don't recurse into it).
+      entries.push([key, isSecretKey(key) ? REDACTED : shredNode((value as Record<string, unknown>)[key], seen, depth + 1, opts)]);
+    }
+    return Object.fromEntries(entries);
+  } finally {
+    seen.delete(obj);
+  }
+}
+
+/** Deep-redact a value into a JSON-safe clone. Never throws. */
+export function shred(value: unknown, opts?: ShredOptions): LogValueOut {
+  const o = { ...DEFAULTS, ...opts };
+  try {
+    return shredNode(value, new WeakSet(), 0, o);
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+/** Redact secrets from a plain string (a message/log line). Returns a string. Never throws. */
+export function shredText(text: string, opts?: ShredOptions): string {
+  try {
+    return redactString(text, { ...DEFAULTS, ...opts }.maxStringLength);
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+// Redact a record IN PLACE over its string keys; skips `level`/`timestamp` and
+// leaves symbol keys (winston's Symbol(level)/Symbol(splat)) untouched. `message`
+// keeps its key, value-pattern redacted. Mutates (not clones) for winston formats.
+export function shredRecordInPlace<T extends Record<string, unknown>>(
+  record: T,
+  opts?: ShredOptions,
+): T {
+  const o = { ...DEFAULTS, ...opts };
+  // Mutable alias: we write back to string keys in place (a generic T can only
+  // be indexed for reading). Symbol keys are untouched since we iterate Object.keys.
+  const rec = record as Record<string, unknown>;
+  try {
+    for (const key of Object.keys(rec)) {
+      if (key === "level" || key === "timestamp") continue;
+      // Property-injection / prototype-pollution guard.
+      if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
+      const value = rec[key];
+      if (key === "message") {
+        rec[key] = typeof value === "string" ? redactString(value, o.maxStringLength) : shred(value, o);
+        continue;
+      }
+      rec[key] = isSecretKey(key) ? REDACTED : shred(value, o);
+    }
+  } catch {
+    /* never throw from the logging path */
+  }
+  return record;
+}

--- a/packages/logger/src/types.ts
+++ b/packages/logger/src/types.ts
@@ -1,0 +1,47 @@
+// @xyne/logger core types. Compile-time: LogPayload bans secret key names (a
+// nudge). Runtime: the shredder is the real boundary. PII is allowed on purpose
+// (the frozen Grafana contract needs it — PRD "Case A").
+
+/** A JSON-serialisable value. */
+export type LogValue =
+  | string
+  | number
+  | boolean
+  | null
+  | LogValue[]
+  | { [key: string]: LogValue };
+
+/** Key names banned at compile time. Keep aligned with `SECRET_KEY_RE` in shredder.ts. */
+export type SecretKey =
+  | "password"
+  | "token"
+  | "apiKey"
+  | "secret"
+  | "authorization"
+  | "cookie"
+  | "privateKey"
+  | "clientSecret"
+  | "jwt";
+
+/** Reject every secret key at compile time. */
+export type ForbidSecrets<T> = T & { [K in SecretKey]?: never };
+
+/** Log-call fields. Any field name allowed (frozen contract fields are just strings) except secrets. */
+export type LogPayload = ForbidSecrets<{ [field: string]: LogValue | undefined }>;
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+/** Env-agnostic logger surface; each repo logger becomes a thin adapter over it. */
+export interface Logger {
+  event(name: string, fields?: LogPayload): void;
+  debug(message: string, fields?: LogPayload): void;
+  info(message: string, fields?: LogPayload): void;
+  warn(message: string, fields?: LogPayload): void;
+  error(message: string, err?: unknown, fields?: LogPayload): void;
+}
+
+/** Supplies ambient fields (requestId, emailId, …) merged into every record. */
+export interface ContextProvider {
+  /** Current ambient fields, or undefined when no context is active. */
+  get(): LogPayload | undefined;
+}

--- a/packages/logger/test/shredder.test.ts
+++ b/packages/logger/test/shredder.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import { shred, shredRecordInPlace, isSecretKey } from "../src/shredder.js";
+
+// A stringified clone is the easiest way to assert "no secret survives anywhere".
+const flat = (v: unknown) => JSON.stringify(shred(v));
+
+describe("isSecretKey", () => {
+  it("flags secret-named keys (case/separator-insensitive)", () => {
+    for (const k of ["password", "apiKey", "api_key", "x-api-key", "accessToken", "refresh_token", "clientSecret", "Authorization", "cookie", "privateKey", "jwt", "passphrase"]) {
+      expect(isSecretKey(k), k).toBe(true);
+    }
+  });
+
+  it("keeps safe siblings that merely share a stem", () => {
+    for (const k of ["tokenPreview", "tokenPresent", "tokenSource", "tokenExp", "tokenExpiry", "totalTokens", "promptTokens", "tokenCount", "secretName", "authorizationType", "passwordLength"]) {
+      expect(isSecretKey(k), k).toBe(false);
+    }
+  });
+});
+
+describe("shred — key detector", () => {
+  it("redacts a secret-named field wholesale, including nested objects", () => {
+    const out = flat({ apiKey: "sk-abcdef0123456789abcd", credentials: { password: "hunter2", nested: { token: "zzzz" } } });
+    expect(out).not.toContain("hunter2");
+    expect(out).not.toContain("sk-abcdef");
+    expect(out).not.toContain("zzzz");
+    expect(out).toContain("[REDACTED]");
+  });
+
+  it("keeps safe-sibling values", () => {
+    const out = shred({ tokenPreview: "sk-1", totalTokens: 42, apiKeySource: "env" }) as Record<string, unknown>;
+    expect(out.tokenPreview).toBe("sk-1");
+    expect(out.totalTokens).toBe(42);
+    expect(out.apiKeySource).toBe("env");
+  });
+});
+
+describe("shred — value detector", () => {
+  // [name, input, marker the output must contain, raw secret that must be gone]
+  const cases: Array<[string, string, string, string]> = [
+    ["Bearer", "Authorization: Bearer abcDEF123456ghijkl", "Bearer [REDACTED]", "abcDEF123456ghijkl"],
+    ["JWT", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c", "[REDACTED_JWT]", "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"],
+    ["sk- key", "using key sk-abcdefghij0123456789ABCD", "[REDACTED_KEY]", "sk-abcdefghij0123456789ABCD"],
+    ["AWS", "id=AKIAIOSFODNN7EXAMPLE done", "[REDACTED_AWS_KEY]", "AKIAIOSFODNN7EXAMPLE"],
+    ["GitHub", "ghp_abcdefghijklmnopqrstuvwxyz0123456789", "[REDACTED_KEY]", "ghp_abcdefghijklmnopqrstuvwxyz0123456789"],
+    ["Slack", "xoxb-123456789012-abcdefghijklmno", "[REDACTED_KEY]", "xoxb-123456789012-abcdefghijklmno"],
+    ["inline", "connect password=SuperSecret1 ok", "password", "SuperSecret1"],
+  ];
+  for (const [name, input, marker, rawSecret] of cases) {
+    it(`redacts ${name} even under an innocent key`, () => {
+      const out = flat({ note: input });
+      expect(out, `${name}: expected marker`).toContain(marker);
+      expect(out, `${name}: raw secret must be gone`).not.toContain(rawSecret);
+    });
+  }
+
+  it("redacts a PEM private key block", () => {
+    const pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA1234\n-----END RSA PRIVATE KEY-----";
+    const out = flat({ key: pem });
+    expect(out).toContain("[REDACTED_PEM]");
+    expect(out).not.toContain("MIIEpAIBAAKCAQEA1234");
+  });
+});
+
+describe("shred — error handling", () => {
+  it("serialises Error with redacted message + stack", () => {
+    const err = new Error("token=abcdef123456 failed");
+    const out = shred({ err }) as { err: { name: string; message: string; stack?: string } };
+    expect(out.err.name).toBe("Error");
+    expect(out.err.message).not.toContain("abcdef123456");
+    expect(out.err.message).toContain("[REDACTED]");
+  });
+});
+
+describe("shred — structural safety", () => {
+  it("is cycle-safe", () => {
+    const a: Record<string, unknown> = { name: "a" };
+    a.self = a;
+    expect(() => shred(a)).not.toThrow();
+    expect(JSON.stringify(shred(a))).toContain("[Circular]");
+  });
+
+  it("caps deep nesting instead of recursing forever", () => {
+    let deep: Record<string, unknown> = {};
+    const root = deep;
+    for (let i = 0; i < 100; i++) {
+      const next: Record<string, unknown> = {};
+      deep.child = next;
+      deep = next;
+    }
+    const out = JSON.stringify(shred(root));
+    expect(out).toContain("[Object]");
+  });
+
+  it("truncates over-long strings", () => {
+    const out = shred({ blob: "x".repeat(20000) }) as { blob: string };
+    expect(out.blob.length).toBeLessThan(20000);
+    expect(out.blob).toContain("truncated");
+  });
+
+  it("caps very large arrays", () => {
+    const out = shred(new Array(5000).fill(1)) as unknown[];
+    expect(out.length).toBeLessThan(5000);
+    expect(String(out[out.length - 1])).toContain("more");
+  });
+
+  it("handles Map/Set/BigInt/Date/Buffer without throwing", () => {
+    const out = shred({
+      m: new Map([["k", "v"]]),
+      s: new Set([1, 2]),
+      big: 10n,
+      when: new Date("2020-01-01T00:00:00.000Z"),
+      buf: Buffer.from("hi"),
+    }) as Record<string, unknown>;
+    expect((out.m as Record<string, unknown>).k).toBe("v");
+    expect(out.s).toEqual([1, 2]);
+    expect(out.big).toBe("10");
+    expect(out.when).toBe("2020-01-01T00:00:00.000Z");
+    expect(String(out.buf)).toContain("Buffer");
+  });
+
+  it("never throws on hostile input", () => {
+    const hostile = { get bad() { throw new Error("boom"); } };
+    expect(() => shred(hostile)).not.toThrow();
+  });
+
+  it("strips newlines/control chars so values can't forge new log lines (log injection)", () => {
+    const out = shred({ note: "ok\nFAKE 2020 ERROR admin login\r\nx\tYZ" }) as { note: string };
+    expect(out.note).not.toMatch(/[\n\r\t]/);
+    expect(out.note).toContain("FAKE");          // content kept, just flattened to one line
+  });
+
+  it("does not pollute Object.prototype via a malicious __proto__ key (prototype pollution)", () => {
+    const malicious = JSON.parse('{"__proto__": {"polluted": true}, "safe": 1}');
+    const out = shred(malicious) as Record<string, unknown>;
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined(); // global proto untouched
+    expect(out.safe).toBe(1);
+    expect(out.__proto__).not.toMatchObject({ polluted: true });
+  });
+});
+
+describe("shredRecordInPlace — frozen contract", () => {
+  it("keeps contract field NAMES and non-secret values, redacts message secrets, leaves level/timestamp", () => {
+    const record: Record<string, unknown> = {
+      level: "info",
+      timestamp: "2026-09-10 10:00:00",
+      message: "login for Bearer abc123DEF456ghi789",
+      emailId: "a@b.com",
+      userId: "u_123",
+      container: "xyne-logging-bridge",
+      event: "enrollment_screen_landed",
+      apiKey: "sk-shouldbegone0123456789",
+    };
+    const out = shredRecordInPlace(record);
+    // Structural keys untouched.
+    expect(out.level).toBe("info");
+    expect(out.timestamp).toBe("2026-09-10 10:00:00");
+    // PII / contract fields survive unchanged (Case A — keep PII).
+    expect(out.emailId).toBe("a@b.com");
+    expect(out.userId).toBe("u_123");
+    expect(out.container).toBe("xyne-logging-bridge");
+    expect(out.event).toBe("enrollment_screen_landed");
+    // Secret key redacted, secret in message redacted.
+    expect(out.apiKey).toBe("[REDACTED]");
+    expect(String(out.message)).toContain("Bearer [REDACTED]");
+    expect(String(out.message)).not.toContain("abc123DEF456ghi789");
+  });
+
+  it("preserves symbol keys (winston internals) untouched", () => {
+    const sym = Symbol.for("splat");
+    const record: Record<string | symbol, unknown> = { message: "hi", [sym]: ["extra"] };
+    shredRecordInPlace(record as Record<string, unknown>);
+    expect(record[sym]).toEqual(["extra"]);
+  });
+});
+
+describe("shred — retryToken truncation note", () => {
+  // provider-retry-worker.ts logs a full internal capability token under
+  // `retryToken`. `token` stem => redacted by the key detector.
+  it("redacts a retryToken field", () => {
+    const out = shred({ retryToken: "cap_abcdefghijklmnop" }) as { retryToken: string };
+    expect(out.retryToken).toBe("[REDACTED]");
+  });
+});

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "types": ["node"],
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1017.0",
+    "@xyne/logger": "workspace:*",
     "@aws-sdk/lib-storage": "3.1017.0",
     "@aws-sdk/s3-request-presigner": "^3.1017.0",
     "@azure/identity": "^4.10.0",

--- a/packages/storage/src/logger.ts
+++ b/packages/storage/src/logger.ts
@@ -1,3 +1,5 @@
+import { shred } from "@xyne/logger";
+
 export interface StorageLogger {
   info(message: string, ...meta: unknown[]): void;
   warn(message: string, ...meta: unknown[]): void;
@@ -5,7 +7,21 @@ export interface StorageLogger {
   debug?(message: string, ...meta: unknown[]): void;
 }
 
-export let logger: StorageLogger = console;
+// Serialise a call to ONE shredded JSON line. JSON.stringify escapes newlines/
+// control chars, so a user value can't forge extra log lines (log injection),
+// and shred() removes secret values. Hosts can inject their own logger via
+// setStorageLogger; this is the safe default sink.
+const toLine = (message: string, meta: unknown[]): string =>
+  JSON.stringify(shred(meta.length > 0 ? { message, meta } : { message }));
+
+const shreddingConsole: StorageLogger = {
+  info: (message, ...meta) => console.info(toLine(message, meta)),
+  warn: (message, ...meta) => console.warn(toLine(message, meta)),
+  error: (message, ...meta) => console.error(toLine(message, meta)),
+  debug: (message, ...meta) => console.debug(toLine(message, meta)),
+};
+
+export let logger: StorageLogger = shreddingConsole;
 
 export function setStorageLogger(custom: StorageLogger): void {
   logger = custom;

--- a/packages/xyne-claw-shared/package.json
+++ b/packages/xyne-claw-shared/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.28.0",
     "@xyne/icons": "workspace:*",
+    "@xyne/logger": "workspace:*",
     "@xyne/kata-sdk": "workspace:*",
     "marked": "^18.0.4",
     "mermaid": "^11.4.0",

--- a/packages/xyne-claw-shared/src/logger.ts
+++ b/packages/xyne-claw-shared/src/logger.ts
@@ -1,6 +1,7 @@
 import winston from "winston";
 import { AsyncLocalStorage } from "node:async_hooks";
 import crypto from "node:crypto";
+import { shredRecordInPlace } from "@xyne/logger";
 
 /**
  * Structured JSON logger shared across the claw backend services
@@ -78,44 +79,18 @@ const captureSplat = winston.format((info) => {
   return info;
 });
 
-const SECRET_PATTERNS: Array<[RegExp, string]> = [
-  [/(\bapi[_-]?key\b["'\s]*[:=]\s*["']?)([A-Za-z0-9_\-]{12,})/gi, "$1<redacted>"],
-  [/\bsk-[A-Za-z0-9]{16,}\b/g, "sk-<redacted>"],
-  [/(\b[Bb]earer\s+)[A-Za-z0-9._\-]{16,}/g, "$1<redacted>"],
-];
-
-function redactString(s: string): string {
-  let out = s;
-  for (const [re, rep] of SECRET_PATTERNS) out = out.replace(re, rep);
-  return out;
-}
-
-function redactValue(v: unknown): unknown {
-  if (typeof v === "string") return redactString(v);
-  if (Array.isArray(v)) return v.map(redactValue);
-  if (v && typeof v === "object") {
-    const out: Record<string, unknown> = {};
-    for (const [k, val] of Object.entries(v as Record<string, unknown>)) out[k] = redactValue(val);
-    return out;
-  }
-  return v;
-}
-
-const redactSecrets = winston.format((info) => {
-  if (typeof info.message === "string") info.message = redactString(info.message);
-  for (const key of Object.keys(info)) {
-    if (key === "message" || key === "level" || key === "timestamp") continue;
-    (info as Record<string, unknown>)[key] = redactValue((info as Record<string, unknown>)[key]);
-  }
-  return info;
-});
+// Secret-value redaction on every sink, via the shared @xyne/logger shredder
+// (replaces the old hand-rolled redactSecrets — same contract, wider coverage).
+const shredSecrets = winston.format(
+  (info) => shredRecordInPlace(info as unknown as Record<string, unknown>) as unknown as winston.Logform.TransformableInfo,
+);
 
 const productionFormat = winston.format.combine(
   winston.format.timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),
   winston.format.errors({ stack: true }),
   captureSplat(),
   injectContext(),
-  redactSecrets(),
+  shredSecrets(),
   winston.format.printf(({ timestamp, level, message, ...meta }) =>
     JSON.stringify({ timestamp, level, message, ...meta }),
   ),
@@ -127,7 +102,7 @@ const devFormat = winston.format.combine(
   winston.format.errors({ stack: true }),
   captureSplat(),
   injectContext(),
-  redactSecrets(),
+  shredSecrets(),
   winston.format.printf(({ timestamp, level, message, component, service, ...meta }) => {
     const ctx = component || service;
     const prefix = ctx ? `[${ctx}] ` : "";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
       '@types/yauzl':
         specifier: ^2.10.3
         version: 2.10.3
+      '@xyne/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
       '@xyne/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -945,6 +948,9 @@ importers:
       '@xyne/icons':
         specifier: workspace:*
         version: link:../../packages/icons
+      '@xyne/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
       '@xyne/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -1278,7 +1284,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^5.0.2
-        version: 5.2.0(vite@7.3.6(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 5.2.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.5.4(postcss@8.5.23)
@@ -1335,10 +1341,10 @@ importers:
         version: 1.0.7(tailwindcss@3.4.19(tsx@4.23.1)(yaml@2.9.0))
       vite:
         specifier: ^7.1.5
-        version: 7.3.6(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
+        version: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-static-copy:
         specifier: ^3.1.4
-        version: 3.4.0(vite@7.3.6(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 3.4.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/dashboard-edge:
     dependencies:
@@ -1445,7 +1451,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^5.0.2
-        version: 5.2.0(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 5.2.0(vite@7.3.6(@types/node@22.20.1)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.5.4(postcss@8.5.23)
@@ -1454,10 +1460,10 @@ importers:
         version: 17.4.3
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(eslint@9.39.5(jiti@2.7.0))
+        version: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7))
       eslint-plugin-react-hooks:
         specifier: 4.6.2
-        version: 4.6.2(eslint@9.39.5(jiti@2.7.0))
+        version: 4.6.2(eslint@9.39.5(jiti@1.21.7))
       globals:
         specifier: 13.24.0
         version: 13.24.0
@@ -1472,10 +1478,10 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 8.53.0
-        version: 8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
       vite:
         specifier: ^7.1.5
-        version: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
+        version: 7.3.6(@types/node@22.20.1)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
 
   apps/electron:
     dependencies:
@@ -1503,6 +1509,9 @@ importers:
       '@types/node':
         specifier: ^24.3.1
         version: 24.13.3
+      '@xyne/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
       archiver:
         specifier: ^7.0.0
         version: 7.0.1
@@ -2021,6 +2030,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@xyne/logger':
+        specifier: workspace:*
+        version: link:../logger
       diff:
         specifier: 8.0.3
         version: 8.0.3
@@ -2157,6 +2169,18 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/logger:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@22.20.1)(happy-dom@20.8.9)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
+
   packages/shared:
     dependencies:
       '@rocicorp/zero':
@@ -2238,6 +2262,9 @@ importers:
       '@google-cloud/storage':
         specifier: ^7.7.0
         version: 7.21.0
+      '@xyne/logger':
+        specifier: workspace:*
+        version: link:../logger
       uuid:
         specifier: 11.1.1
         version: 11.1.1
@@ -2291,6 +2318,9 @@ importers:
       '@xyne/kata-sdk':
         specifier: workspace:*
         version: link:../kata-sdk
+      '@xyne/logger':
+        specifier: workspace:*
+        version: link:../logger
       marked:
         specifier: ^18.0.4
         version: 18.0.7
@@ -3049,24 +3079,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.5.6':
     resolution: {integrity: sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.5.6':
     resolution: {integrity: sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.5.6':
     resolution: {integrity: sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA==}
@@ -4466,89 +4500,105 @@ packages:
     resolution: {integrity: sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.3.0':
     resolution: {integrity: sha512-A8UpHoUDW4DwnXoV6+q3C1s7QLRAHtPDEjWuNZjwHMyoCNZnm0GeNN8ls9f/bsEYTRQRW96C/n34XJQHJ2fT7A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.3.0':
     resolution: {integrity: sha512-WOpkVxAjFd369iaIzEgNRreFD+gWdUMIGD5zplhNKNeqS6mm5dac3q2AFyCBmzYoAdouzZvRBgxy4z8QHZb4/A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.3.0':
     resolution: {integrity: sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.3.0':
     resolution: {integrity: sha512-9APy+nFWhHS+kzLgWZfLcyrUd7YqnAQVa4BPOo4xkoHpdoktOAPG4cEr9+Jpl0TtqfVmcMJimNL5qNTyyOHZNA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.3.0':
     resolution: {integrity: sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.3.0':
     resolution: {integrity: sha512-cC1wkC0Mlucd0KSiGrLkJnB/ZqPvZCntc/Lk7ZnYO5ZSbF2euNek4Xvxafojq+wN1q/W0eprdpUIjUr/EV2PBg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.3.0':
     resolution: {integrity: sha512-LiYMhUZicB1QG//+RvmYZpXJO8fYRENfp+MZUCnG9aw+AKvGAy9gPaCnuwsPcBFs8EV66M0NNxj9VHcNklE8zw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.35.0':
     resolution: {integrity: sha512-4+4XHLNT5wDT0roYlHTEmH9lDKt0acf9Tv+3hM3iceOirkxrR404/3WjAYZ9F9CkHrxeRcGLJXbi4vluMZ9O+A==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.35.0':
     resolution: {integrity: sha512-VVlpEWwizEFIOom0zdoeKuO5nuTswzVE5uHcBNvHzmeHUpNFajY3HFfbQ+zIH4E2kVaZ/yVxmsShW56TtEy4uA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.35.0':
     resolution: {integrity: sha512-N3hzbEpUTJC8pWpPVJvgzGxM+so/MAXc8O2s/53B0LL9ZGpfXpME7Wizkc5d/8fRBlBtkDjzoZGDCqqNDHqLEw==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.35.0':
     resolution: {integrity: sha512-l6vmKVPnbS0RhVMbyxP5meAARsbhCnBN4fy31qz0+3a6Rv4jEqfzDrT89y6ZPkCi0AJGnwp2En528yXo401Hpw==}
     engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.35.0':
     resolution: {integrity: sha512-MYlMiPFiv/EKPAHnp3yNZ9AAWFsxga9c5Bkc6wkar6bqzHLlkGVJHRm0u1ei+VXnZxp3Mz9MG9ZIsI8vSOf3sQ==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.35.0':
     resolution: {integrity: sha512-TYaItB5oj1ioXjhyn2xrR208vf+YuIIcHptQWRRaBmFhvIvL9D72DXN8w75xup0KXA8UdEAhQ9Qb2S49FD/9Cw==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.35.0':
     resolution: {integrity: sha512-DSTb6ijQzqe6DdAaOBVqJ/SYf1vO8EW5bK6X6LRXufEBebf2722VCdvBUtZ3rtV0x2ApfPNDy/p7LrrjaWjiyQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.35.0':
     resolution: {integrity: sha512-K7ykQ+26Rt6+4BTU80AuGgTPIYX86UxiAKT4rcXX/WNTo7k1ZxpKz+TguHnwVpCqQK3B5PK0vZ0ZBe6nz/ib1w==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.35.0':
     resolution: {integrity: sha512-9woLIFORERCr+6cWu87dQ22J34EExkhc73U1kZW0c+RclQqWetoodByp4dWZ/hN8/KVmTRAx2HOnUwib8AwZdA==}
@@ -5101,11 +5151,13 @@ packages:
     resolution: {integrity: sha512-HVnzYLSKFrrR49epK37fV8eIbPuuWqbGoC7xXbmw0ziag1z0xUEZt072EEvmLcuCYMlX93At0se7Glh507751g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@livekit/av-linux-x64@10.0.0':
     resolution: {integrity: sha512-ZODmZ2bhfzjGrYF5KpwK7QHoaSVH96cX0o8sOGQT73VpgUCMDzcH+OSZWOlgFwUozk4jT/pjLfgGGPZtD2Dj7w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@livekit/av-win32-x64@10.0.0':
     resolution: {integrity: sha512-zvgdIvuu8C5aM+rSkOTZLKqX0FsYaN5CXKysmkKLU+pEDz+pIzkFelxPYX7YreV111aTAY19Dzj2i0KGEFnOSQ==}
@@ -5192,12 +5244,14 @@ packages:
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@livekit/rtc-ffi-bindings-linux-x64-gnu@0.12.68':
     resolution: {integrity: sha512-2r99lXSkrmiHjhizCquQwPEbP7mCV/zESVXq1pdEliNvbBJXibMEYbRmuSr1lf4/VZhPpRGcF+Laqg5DgFoe+A==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@livekit/rtc-ffi-bindings-win32-x64-msvc@0.12.68':
     resolution: {integrity: sha512-ec7MJBWx4mz40GvfXQ2Bn9uqvp2HueldTouPi5jzYUG2DECmhYhwai0cBcRFJOya3hBm/nRXP0A+pUBdWnY7Fg==}
@@ -5294,60 +5348,70 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
     resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
     resolution: {integrity: sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
     resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.6':
     resolution: {integrity: sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
     resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
     resolution: {integrity: sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
     resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.6':
     resolution: {integrity: sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.9':
     resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
     resolution: {integrity: sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==}
@@ -6852,48 +6916,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.45.0':
     resolution: {integrity: sha512-XQKXZIKYJC3GQJ8FnD3iMntpw69Wd9kDDK/Xt79p6xnFYlGGxSNv2vIBvRTDg5CKByWFWWZLCRDOXoP/m6YN4g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.45.0':
     resolution: {integrity: sha512-+g5RiG+xOkdrCWkKodv407nTvMq4vYM18Uox2MhZBm/YoqFxxJpWKsloskFFG5NU13HGPw1wzYjjOVcyd9moCA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.45.0':
     resolution: {integrity: sha512-V7dXKoSyEbWAkkSF4JJNtF+NJZDmJoSarSoP30WCsB3X636Rehd3CvxBj49FIJxEBFWhvcUjGSHVeU8Erck1bQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.45.0':
     resolution: {integrity: sha512-Vdelft1sAEYojVGgcODEFXSWYQYlIvoyIGWebKCuUibd1tvS1TjTx413xG2ZLuHpYj45CkN/ztMLMX6jrgqpgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.45.0':
     resolution: {integrity: sha512-RR7xKgNpqwENnK0aYCGYg0JycY2n93J0reNjHyes+I9Gq52dH95x+CBlnlAQHCPfz6FGnKA9HirgUl14WO6o7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.45.0':
     resolution: {integrity: sha512-U/QQ0+BQNSHxjuXR/utvXnQ50Vu5kUuqEomZvQ1/3mhgbBiMc2WU9q5kZ5WwLp3gnFIx9ibkveoRSe2EZubkqg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.45.0':
     resolution: {integrity: sha512-o5TLOUCF0RWQjsIS06yVC+kFgp092/yLe6qBGSUvtnmTVw9gxjpdQSXc3VN5Cnive4K11HNstEZF8ROKHfDFSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.45.0':
     resolution: {integrity: sha512-RnGcV3HgPuOjsGx/k9oyRNKmOp+NBLGzZTdPDYbc19r7NGeYPplnUU/BfU35bX2Y/O4ejvHxcfkvW2WoYL/gsg==}
@@ -8374,66 +8446,79 @@ packages:
     resolution: {integrity: sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.3':
     resolution: {integrity: sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.3':
     resolution: {integrity: sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.3':
     resolution: {integrity: sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.3':
     resolution: {integrity: sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.3':
     resolution: {integrity: sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.3':
     resolution: {integrity: sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.3':
     resolution: {integrity: sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.3':
     resolution: {integrity: sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.3':
     resolution: {integrity: sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.3':
     resolution: {integrity: sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.3':
     resolution: {integrity: sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.3':
     resolution: {integrity: sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.3':
     resolution: {integrity: sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==}
@@ -8775,24 +8860,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -10227,51 +10316,61 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -15364,24 +15463,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -22925,6 +23028,11 @@ snapshots:
       eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.10.1(eslint@9.39.5(jiti@1.21.7))':
+    dependencies:
+      eslint: 9.39.5(jiti@1.21.7)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/eslint-utils@4.10.1(eslint@9.39.5(jiti@2.7.0))':
     dependencies:
       eslint: 9.39.5(jiti@2.7.0)
@@ -28141,7 +28249,7 @@ snapshots:
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
-  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.3)(redux@5.0.1))(react@19.2.3)':
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@standard-schema/utils': 0.3.0
@@ -29972,15 +30080,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.53.0
-      '@typescript-eslint/type-utils': 8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.53.0
-      eslint: 9.39.5(jiti@2.7.0)
+      eslint: 9.39.5(jiti@1.21.7)
       ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -30054,14 +30162,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.53.0
       '@typescript-eslint/types': 8.53.0
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.53.0
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.5(jiti@2.7.0)
+      eslint: 9.39.5(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -30201,13 +30309,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.53.0
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.5(jiti@2.7.0)
+      eslint: 9.39.5(jiti@1.21.7)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -30371,13 +30479,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5(jiti@1.21.7))
       '@typescript-eslint/scope-manager': 8.53.0
       '@typescript-eslint/types': 8.53.0
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.9.3)
-      eslint: 9.39.5(jiti@2.7.0)
+      eslint: 9.39.5(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -30589,7 +30697,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@22.20.1)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -30597,11 +30705,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@22.20.1)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -30609,7 +30717,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.6(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -33724,6 +33832,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5(jiti@1.21.7)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
+      eslint: 9.39.5(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.10
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
@@ -33803,6 +33921,35 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.5(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5(jiti@1.21.7))
+      hasown: 2.0.4
+      is-core-module: 2.16.2
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.10
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
   eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
@@ -33815,33 +33962,6 @@ snapshots:
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-module-utils: 2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
-      hasown: 2.0.4
-      is-core-module: 2.16.2
-      is-glob: 4.0.3
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.10
-      tsconfig-paths: 3.15.0
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.7.0)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.39.5(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.8.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -33914,9 +34034,9 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  eslint-plugin-react-hooks@4.6.2(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-react-hooks@4.6.2(eslint@9.39.5(jiti@1.21.7)):
     dependencies:
-      eslint: 9.39.5(jiti@2.7.0)
+      eslint: 9.39.5(jiti@1.21.7)
 
   eslint-plugin-react-hooks@7.1.1(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
@@ -34037,6 +34157,47 @@ snapshots:
       optionator: 0.9.4
       strip-ansi: 6.0.1
       text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint@9.39.5(jiti@1.21.7):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5(jiti@1.21.7))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.6
+      '@eslint/js': 9.39.5
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.14.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 1.21.7
     transitivePeerDependencies:
       - supports-color
 
@@ -40451,7 +40612,7 @@ snapshots:
 
   recharts@3.10.1(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react-is@18.3.1)(react@19.2.3)(redux@5.0.1):
     dependencies:
-      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       clsx: 2.1.1
       decimal.js-light: 2.5.1
       es-toolkit: 1.50.0
@@ -42561,13 +42722,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript-eslint@8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3):
+  typescript-eslint@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.53.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.53.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.5(jiti@2.7.0)
+      '@typescript-eslint/utils': 8.53.0(eslint@9.39.5(jiti@1.21.7))(typescript@5.9.3)
+      eslint: 9.39.5(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -43007,13 +43168,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-static-copy@3.4.0(vite@7.3.6(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vite-plugin-static-copy@3.4.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.6
       picocolors: 1.1.1
       tinyglobby: 0.2.17
-      vite: 7.3.6(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
 
   vite@5.4.21(@types/node@22.20.1)(lightningcss@1.32.0)(sass@1.51.0):
     dependencies:
@@ -43061,6 +43222,22 @@ snapshots:
       yaml: 2.9.0
     optional: true
 
+  vite@7.3.6(@types/node@22.20.1)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.23
+      rollup: 4.62.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.1
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      lightningcss: 1.32.0
+      tsx: 4.23.1
+      yaml: 2.9.0
+
   vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
@@ -43077,7 +43254,7 @@ snapshots:
       tsx: 4.23.1
       yaml: 2.9.0
 
-  vite@7.3.6(@types/node@24.13.3)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0):
+  vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
@@ -43088,7 +43265,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.3
       fsevents: 2.3.3
-      jiti: 1.21.7
+      jiti: 2.7.0
       lightningcss: 1.32.0
       tsx: 4.23.1
       yaml: 2.9.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ packages:
   - apps/xyne-claw-auth/backend
   - apps/xyne-claw-auth/frontend
 
+  - packages/logger
   - packages/shared
   - packages/storage
   - packages/icons


### PR DESCRIPTION
## Summary

Introduces **`@xyne/logger`**, a shared, typed, secret-shredding logging core, and routes the backend, `xyne-claw-shared` (+`xyne-claw-auth` via re-export), `agentic-framework`, `@xyne/storage`, the dashboard browser worker, and electron loggers through it. Secret **values** — passwords, API keys, tokens, JWTs, AWS/GitHub/Slack keys, PEM blocks, `Bearer …`, inline `secret=…` — are now redacted on **every sink**, closing the gap where the backend's Fluent-forward sink shipped structured metadata to VictoriaLogs verbatim (only error messages/stacks were redacted before).

Redaction is **values-only**: field names, `level`, and top-level `message` are preserved, so **all 131 Grafana dashboards / 371 log queries keep working with zero query changes** (verified against the prod dashboard export).

## What changed

- **New package `packages/logger` (`@xyne/logger`)** — `shred()` / `shredText()` / `shredRecordInPlace()`, typed `LogPayload` (secret keys forbidden at compile time), pluggable context (`SetOnceContext`; `AsyncLocalStorageContext` under `/node`). Recursive, cycle-safe, depth/size-capped, control-char scrubbed, **never throws**. 22 vitest cases.
- **Loggers routed through it** — call signatures and sinks unchanged, so the ~12k existing call-sites are untouched:
  - `apps/backend/src/utils/logger.ts` — `shredSecrets` winston format in the shared pipeline (runs before the per-transport clone, so the Fluent sink is covered too).
  - `packages/xyne-claw-shared/src/logger.ts` — replaces the hand-rolled redaction (also covers `xyne-claw-auth`, which re-exports it).
  - `packages/framework/src/utils/logger.ts`, `packages/storage/src/logger.ts`, `apps/dashboard/src/utils/logger.worker.ts`, `apps/electron/src/services/logger/Logger.ts`.
- **Workspace wiring** — `@xyne/logger` workspace dep added to consumers; `build:shared` + a `prepare` script so `pnpm install`/CI build its `dist`.

> Not converted: `tools/xyne-automation` (test tooling) — it's CommonJS/ts-node and `@xyne/logger` is ESM-only; deferred to avoid a fragile `require(ESM)`. Low risk (test-step logs only).

## PII is intentionally NOT redacted

PII is **kept as-is**. Redacting it (dropping or hashing) would require **corresponding Grafana dashboard changes** — many log panels group/filter by these fields (per-user enrollment funnels, active-user counts, per-person leaderboards, e.g. `… | stats by(emailId) count()`). Shredding them would break those queries. Only **secrets** are shredded.

PII fields that reach logs and are deliberately preserved (from a scan of ~17.7k log-call blocks across the repo):

- **Email** (~500 sites): `email`, `emailId`, `userEmail`, `emailAddress`, `customerEmail`, `organizerEmail`, `recipientEmail`, `senderEmail`
- **Person names** (~65): `displayName`, `userName` / `username`, `senderName`, `creatorName`, `replierName`
- **User / account IDs** (pseudonymous, ~800): `userId` / `user_id`, `participantId`, `accountId`, `slackUserId`, `memberId`, `ownerId`, `createdBy`, `actorId`, `authorId`, `assigneeId`, `uid`
- **Network / device** (~20): `ip` / `clientIp` / `ipAddress`, `userAgent`, `deviceId`, `hostname`, `serialNumber`
- **Location**: `timezone`
- **Phone**: none (earlier "phone" matches were false positives — `mobile` = platform name)

If dropping/hashing PII is wanted later, it's a runtime flag on the same type, done together with a Grafana query migration — hashing keeps group-by counts working; dropping breaks ~32 of 339 log panels.

## Verification

- `@xyne/logger`: strict `tsc` build ✅, **22/22** vitest ✅
- Typecheck **0 errors**: backend, xyne-claw-shared, electron, dashboard. `build:shared` clean. dashboard + framework lint clean. gitleaks passes (test fixtures allowlisted by `*.test.ts`).
- Grafana: values-only redaction verified against the 131-dashboard prod export — no query/field/`level`/`message` changes.

