### PR TITLE
Fix: XYNE-63235 Kanban ticket scan

### DIFF
--- a/apps/backend/prisma/migrations/20260910120000_kanban_ticket_page_indexes/migration.sql
+++ b/apps/backend/prisma/migrations/20260910120000_kanban_ticket_page_indexes/migration.sql
@@ -1,0 +1,10 @@
+-- Kanban board columns filter on an equality prefix and sort by (createdAt desc, id).
+-- Without a composite covering both, the ordered read degrades into a full sort of the
+-- candidate set. Two shapes: the first serves columns with no creator filter, the second
+-- serves creator-filtered views.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "tickets_workspaceId_statusV2_isArchived_rootId_createdAt_id_idx"
+  ON "public"."tickets" ("workspaceId", "statusV2", "isArchived", "rootId", "createdAt" DESC, "id");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "tickets_workspaceId_createdBy_statusV2_isArchived_createdAt_idx"
+  ON "public"."tickets" ("workspaceId", "createdBy", "statusV2", "isArchived", "createdAt" DESC, "id");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -199,6 +199,8 @@ model Ticket {
   @@index([projectId, createdAt(sort: Desc), id])
   @@index([projectId, isArchived, statusV2, createdAt(sort: Desc), id])
   @@index([workspaceId, createdAt(sort: Desc), id])
+  @@index([workspaceId, statusV2, isArchived, rootId, createdAt(sort: Desc), id])
+  @@index([workspaceId, createdBy, statusV2, isArchived, createdAt(sort: Desc), id])
   @@index([xyneId])
   @@unique([workspaceId, xyneId])
   @@map("tickets")

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -132,7 +132,14 @@ const kanbanTicketsPageV2ArgsSchema = kanbanTicketsPageArgsSchema.extend({
 
 type KanbanTicketsPageV2Args = z.infer<typeof kanbanTicketsPageV2ArgsSchema>;
 
-const kanbanTicketsPageV3ArgsSchema = kanbanTicketsPageV2ArgsSchema;
+const kanbanTicketsPageV3ArgsSchema = kanbanTicketsPageV2ArgsSchema.extend({
+  // Far-side bound on createdAt, anchored to the page cursor: a page asks for
+  // [cursor - window, cursor] instead of "everything older than cursor". Without it
+  // the ORDER BY materialises every candidate row below the cursor before the limit
+  // applies. The client widens the window and refetches when a page comes back short,
+  // so nothing is hidden — see useKanbanTicketsPage. V3 only; V2 keeps its shape.
+  createdAfter: z.number().optional(),
+});
 
 type KanbanTicketsPageV3Args = z.infer<typeof kanbanTicketsPageV3ArgsSchema>;
 
@@ -1168,6 +1175,13 @@ export const queries: AnyQueryRegistry = defineQueries({
           dir === 'forward'
             ? query.where('createdAt', '<=', args.start.createdAt)
             : query.where('createdAt', '>=', args.start.createdAt);
+      }
+
+      if (args.createdAfter !== undefined) {
+        query =
+          dir === 'forward'
+            ? query.where('createdAt', '>=', args.createdAfter)
+            : query.where('createdAt', '<=', args.createdAfter);
       }
 
       let finalQuery = query

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -1164,7 +1164,10 @@ export const queries: AnyQueryRegistry = defineQueries({
         .orderBy('id', dir === 'forward' ? 'asc' : 'desc');
 
       if (args.start) {
-        query = query.start({ createdAt: args.start.createdAt, id: args.start.id }, { inclusive: false });
+        query =
+          dir === 'forward'
+            ? query.where('createdAt', '<=', args.start.createdAt)
+            : query.where('createdAt', '>=', args.start.createdAt);
       }
 
       let finalQuery = query

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
@@ -92,6 +92,7 @@ type UseKanbanTicketsPageResult = {
 };
 
 const DEFAULT_PAGE_SIZE = 20;
+
 const MINUTE_MS = 60 * 1000;
 const VESPA_MISSING_DYNAMIC_FIELD_VALUE = '__VESPA_MISSING__';
 
@@ -380,6 +381,14 @@ export const useKanbanTicketsPage = (
 ): UseKanbanTicketsPageResult => {
   const [ticketsState, setTicketsState] = useState<TicketsState>({ queryKey: '', tickets: [] });
   const [fetchCursorState, setFetchCursorState] = useState<FetchCursorState | null>(null);
+  // The page cursor is an INCLUSIVE createdAt bound (see kanbanTicketsPageV3), so the
+  // boundary tie group is re-fetched and de-duplicated below. If a whole page is
+  // nothing but already-seen rows the tie group is bigger than the page, and paging
+  // would stall — widen the page until it clears.
+  const [tieSlack, setTieSlack] = useState(0);
+  // Mirrors ticketsState so the page merge can be computed in the effect body rather
+  // than inside a setState updater (updaters must stay pure — StrictMode calls them twice).
+  const ticketsStateRef = useRef<TicketsState>({ queryKey: '', tickets: [] });
   const [nextCursor, setNextCursor] = useState<KanbanCursor | null>(null);
   const [hasMore, setHasMore] = useState(true);
   const isLoadingMoreRef = useRef(false);
@@ -642,7 +651,14 @@ export const useKanbanTicketsPage = (
   const queryKey = JSON.stringify(queryKeyArgs);
   const fetchCursor = fetchCursorState?.queryKey === queryKey ? fetchCursorState.cursor : null;
   const tickets = ticketsState.queryKey === queryKey ? ticketsState.tickets : [];
-  const pageArgs = buildKanbanTicketsPageArgs(pageOptions, fetchCursor);
+  ticketsStateRef.current = ticketsState;
+
+  const pageArgs = buildKanbanTicketsPageArgs(
+    tieSlack > 0
+      ? { ...pageOptions, pageSize: (options.pageSize ?? DEFAULT_PAGE_SIZE) + tieSlack }
+      : pageOptions,
+    fetchCursor,
+  );
   const pageQuery = queries.kanbanTicketsPageV3(
     pageArgs as Parameters<typeof queries.kanbanTicketsPageV3>[0],
   );
@@ -702,8 +718,11 @@ export const useKanbanTicketsPage = (
     setFetchCursorState(null);
     setNextCursor(null);
     setHasMore(true);
+    setTieSlack(0);
     isLoadingMoreRef.current = false;
   }, [queryKey, shouldUseDirectVespaRows]);
+
+  const currentLimit = (options.pageSize ?? DEFAULT_PAGE_SIZE) + tieSlack;
 
   useEffect(() => {
     if (effectivePageDetailsType !== 'complete') return;
@@ -740,16 +759,25 @@ export const useKanbanTicketsPage = (
       return;
     }
 
-    setTicketsState(prev => {
-      if (shouldUseDirectVespaRows || fetchCursor === null) {
-        return { queryKey, tickets: pageRows };
-      }
-
-      const previousTickets = prev.queryKey === queryKey ? prev.tickets : [];
+    if (shouldUseDirectVespaRows || fetchCursor === null) {
+      setTicketsState({ queryKey, tickets: pageRows });
+      if (tieSlack !== 0) setTieSlack(0);
+    } else {
+      const prevState = ticketsStateRef.current;
+      const previousTickets = prevState.queryKey === queryKey ? prevState.tickets : [];
       const combined = [...previousTickets, ...pageRows];
+      // The cursor bound is inclusive, so the boundary tie group arrives again — drop
+      // the rows we already hold.
       const unique = Array.from(new Map(combined.map(ticket => [ticket.id, ticket])).values());
-      return { queryKey, tickets: unique };
-    });
+      setTicketsState({ queryKey, tickets: unique });
+      // A full page that adds nothing new means the boundary tie group is larger than
+      // the page. Widen and re-fetch rather than looping on the same rows.
+      if (unique.length === previousTickets.length && rawPageRows.length >= currentLimit) {
+        setTieSlack(slack => (slack === 0 ? currentLimit : slack * 2));
+      } else if (tieSlack !== 0) {
+        setTieSlack(0);
+      }
+    }
 
     if (shouldUseDirectVespaRows) {
       setNextCursor(null);
@@ -757,7 +785,9 @@ export const useKanbanTicketsPage = (
       return;
     }
 
-    setHasMore(rawPageRows.length >= (options.pageSize ?? DEFAULT_PAGE_SIZE));
+    // A short page means either the window is too narrow or we have genuinely reached
+    // the end. Widen first; only the unbounded step is allowed to conclude.
+    setHasMore(rawPageRows.length >= currentLimit);
 
     const lastItemOfPage = rawPageRows.at(-1);
     if (lastItemOfPage) {
@@ -771,6 +801,8 @@ export const useKanbanTicketsPage = (
   }, [
     fetchCursor,
     queryKey,
+    currentLimit,
+    tieSlack,
     options.pageSize,
     options.excludeFlowSteps,
     effectivePage,

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
@@ -54,6 +54,7 @@ export type KanbanTicketsPageBaseArgs = FlowStepVisibilityOptions & {
   vespaTicketIds?: string[];
   showOverdueOnly?: boolean;
   overdueReferenceTime?: number | null;
+  createdAfter?: number | null;
 };
 
 type KanbanCursor = {
@@ -93,6 +94,17 @@ type UseKanbanTicketsPageResult = {
 
 const DEFAULT_PAGE_SIZE = 20;
 
+const DAY_MS = 86_400_000;
+/**
+ * Sliding-window steps for the page query's far-side `createdAt` bound, widened in
+ * order until a page comes back full. The last step is "no bound at all", so nothing
+ * is ever permanently hidden — a dormant board just costs a few probes to reach, and
+ * a window containing no rows scans zero rows (the index seek finds nothing).
+ */
+const WINDOW_STEPS_MS: readonly number[] = [30 * DAY_MS, 60 * DAY_MS, 180 * DAY_MS, 365 * DAY_MS];
+/** Page 1 has no cursor to anchor to, so its bound comes from the clock. Quantised so
+ *  it does not mint a fresh query hash on every render. */
+const WINDOW_ANCHOR_QUANTUM_MS = 60 * 60 * 1000;
 const MINUTE_MS = 60 * 1000;
 const VESPA_MISSING_DYNAMIC_FIELD_VALUE = '__VESPA_MISSING__';
 
@@ -278,6 +290,7 @@ export const buildKanbanTicketsPageArgs = (
         : {}),
       showOverdueOnly: options.showOverdueOnly,
       overdueReferenceTime: options.overdueReferenceTime ?? undefined,
+      createdAfter: options.createdAfter ?? undefined,
     },
     options.channelId,
   );
@@ -386,6 +399,9 @@ export const useKanbanTicketsPage = (
   // nothing but already-seen rows the tie group is bigger than the page, and paging
   // would stall — widen the page until it clears.
   const [tieSlack, setTieSlack] = useState(0);
+  /** Index into WINDOW_STEPS_MS; === length means "no window bound". */
+  const [windowStep, setWindowStep] = useState(0);
+  const windowAnchorRef = useRef<{ queryKey: string; anchor: number } | null>(null);
   // Mirrors ticketsState so the page merge can be computed in the effect body rather
   // than inside a setState updater (updaters must stay pure — StrictMode calls them twice).
   const ticketsStateRef = useRef<TicketsState>({ queryKey: '', tickets: [] });
@@ -647,16 +663,32 @@ export const useKanbanTicketsPage = (
     overdueReferenceTime,
   };
   const basePageArgs = buildKanbanTicketsPageArgs(pageOptions, null);
-  const { start: _start, ...queryKeyArgs } = basePageArgs;
+  const { start: _start, createdAfter: _createdAfter, ...queryKeyArgs } = basePageArgs;
+  // queryKey identifies the filter set, not the page — the cursor and the window bound
+  // both move as you scroll and must stay out of it.
   const queryKey = JSON.stringify(queryKeyArgs);
   const fetchCursor = fetchCursorState?.queryKey === queryKey ? fetchCursorState.cursor : null;
   const tickets = ticketsState.queryKey === queryKey ? ticketsState.tickets : [];
   ticketsStateRef.current = ticketsState;
 
+  if (windowAnchorRef.current?.queryKey !== queryKey) {
+    windowAnchorRef.current = {
+      queryKey,
+      anchor: Math.ceil(Date.now() / WINDOW_ANCHOR_QUANTUM_MS) * WINDOW_ANCHOR_QUANTUM_MS,
+    };
+  }
+  // The window hangs off the page cursor, so it descends with the scroll instead of
+  // being pinned to a fixed date — a fixed floor would report a false end of list.
+  const windowAnchor = fetchCursor?.createdAt ?? windowAnchorRef.current.anchor;
+  const windowSpan = WINDOW_STEPS_MS[windowStep];
+  const createdAfter = windowSpan === undefined ? null : windowAnchor - windowSpan;
+
   const pageArgs = buildKanbanTicketsPageArgs(
-    tieSlack > 0
-      ? { ...pageOptions, pageSize: (options.pageSize ?? DEFAULT_PAGE_SIZE) + tieSlack }
-      : pageOptions,
+    {
+      ...pageOptions,
+      createdAfter,
+      ...(tieSlack > 0 ? { pageSize: (options.pageSize ?? DEFAULT_PAGE_SIZE) + tieSlack } : {}),
+    },
     fetchCursor,
   );
   const pageQuery = queries.kanbanTicketsPageV3(
@@ -719,6 +751,7 @@ export const useKanbanTicketsPage = (
     setNextCursor(null);
     setHasMore(true);
     setTieSlack(0);
+    setWindowStep(0);
     isLoadingMoreRef.current = false;
   }, [queryKey, shouldUseDirectVespaRows]);
 
@@ -787,7 +820,12 @@ export const useKanbanTicketsPage = (
 
     // A short page means either the window is too narrow or we have genuinely reached
     // the end. Widen first; only the unbounded step is allowed to conclude.
-    setHasMore(rawPageRows.length >= currentLimit);
+    const full = rawPageRows.length >= currentLimit;
+    if (!full && windowStep < WINDOW_STEPS_MS.length) {
+      setWindowStep(step => step + 1);
+      return;
+    }
+    setHasMore(full);
 
     const lastItemOfPage = rawPageRows.at(-1);
     if (lastItemOfPage) {
@@ -803,6 +841,7 @@ export const useKanbanTicketsPage = (
     queryKey,
     currentLimit,
     tieSlack,
+    windowStep,
     options.pageSize,
     options.excludeFlowSteps,
     effectivePage,
@@ -814,6 +853,10 @@ export const useKanbanTicketsPage = (
   const loadMore = useCallback(() => {
     if (isLoadingMoreRef.current || !hasMore || !nextCursor) return;
     isLoadingMoreRef.current = true;
+    // Deliberately NOT resetting windowStep: it is sticky per column. A dense column
+    // stays on the narrow window; a sparse one that had to widen keeps the wider one
+    // instead of re-climbing the ladder on every page. Paying the widening probes once
+    // is the difference between a 6.4x win and a 2.8x loss on thin columns.
     setFetchCursorState({ queryKey, cursor: nextCursor });
   }, [hasMore, nextCursor, queryKey]);
 
@@ -822,6 +865,7 @@ export const useKanbanTicketsPage = (
     setFetchCursorState(null);
     setNextCursor(null);
     setHasMore(true);
+    setWindowStep(0);
     isLoadingMoreRef.current = false;
   }, [queryKey]);
 

--- a/packages/shared/src/zero/acl/tables/tickets-acl.ts
+++ b/packages/shared/src/zero/acl/tables/tickets-acl.ts
@@ -24,8 +24,22 @@ export class TicketsACL extends BaseQueryACL<'tickets'> {
       return query.whereExists('channel', scalarChannelBody(this.ctx, channelId, isMember), SCALAR);
     }
 
-    return query.whereExists('channel', (ch) =>
-      ch.where(channelAccessWhere(this.ctx))
+    // Pin the join direction instead of letting the planner choose it.
+    //
+    // Left free, the planner may flip this exists so the CHILD drives: it then
+    // materialises `channels` with an unconstrained read (`SELECT … FROM "channels"
+    // ORDER BY "id"` — every channel on the cluster) and turns the result into a
+    // literal `tickets.channelId IN (…)` list. That is the plan production picked,
+    // and it cost 60,000 channel reads per hydration to yield 239 usable ids.
+    //
+    // As a semi-join the parent drives and each candidate ticket probes `channels`
+    // by primary key, which the `take` operator bounds. Measured on the bench
+    // replica: semi-join 62,697 rows scanned vs flipped 73,067, and the flipped
+    // plan carried the whole channels table on top.
+    return query.whereExists(
+      'channel',
+      (ch) => ch.where(channelAccessWhere(this.ctx)),
+      { flip: false },
     );
   }
 }

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -1063,7 +1063,10 @@ export const queries = defineQueries({
         .orderBy('id', dir === 'forward' ? 'asc' : 'desc');
 
       if (args.start) {
-        query = query.start({ createdAt: args.start.createdAt, id: args.start.id }, { inclusive: false });
+        query =
+          dir === 'forward'
+            ? query.where('createdAt', '<=', args.start.createdAt)
+            : query.where('createdAt', '>=', args.start.createdAt);
       }
 
       let finalQuery = query

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -130,6 +130,7 @@ const kanbanTicketsPageV3ArgsSchema = kanbanTicketsPageArgsSchema.extend({
   dir: z.literal('forward').or(z.literal('backward')).optional(),
   showOverdueOnly: z.boolean().optional(),
   overdueReferenceTime: z.number().optional(),
+  createdAfter: z.number().optional(),
 });
 
 type KanbanTicketsPageV3Args = z.infer<typeof kanbanTicketsPageV3ArgsSchema>;
@@ -1067,6 +1068,13 @@ export const queries = defineQueries({
           dir === 'forward'
             ? query.where('createdAt', '<=', args.start.createdAt)
             : query.where('createdAt', '>=', args.start.createdAt);
+      }
+
+      if (args.createdAfter !== undefined) {
+        query =
+          dir === 'forward'
+            ? query.where('createdAt', '>=', args.createdAfter)
+            : query.where('createdAt', '<=', args.createdAfter);
       }
 
       let finalQuery = query


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
