### PR TITLE
feat: XYNE-63239 desk views

### DIFF
--- a/apps/backend/src/zero/acl/tables/saved-user-configuration-values-acl.ts
+++ b/apps/backend/src/zero/acl/tables/saved-user-configuration-values-acl.ts
@@ -24,19 +24,23 @@ interface TicketFilterFieldDescriptor {
  * Column type (string vs number) is derived from col.type at runtime — not hardcoded.
  */
 const TICKET_FILTER_SCHEMA: Record<string, TicketFilterFieldDescriptor> = {
-  boards:           { col: ticketCols.boardId,         enumValues: null },
-  assignee:         { col: ticketCols.assignedTo,      enumValues: null },
-  createdBy:        { col: ticketCols.createdBy,       enumValues: null },
-  userGroups:       { col: ticketCols.userGroupId,     enumValues: null },
-  tags:             { col: tagCols.name,               enumValues: null },
-  stages:           { col: ticketCols.stageName,       enumValues: null },
-  ticketTypes:      { col: ticketCols.ticketType,      enumValues: null },
-  sourceChannels:   { col: ticketCols.channelId,       enumValues: null },
-  dueDateStart:     { col: ticketCols.eta,             enumValues: null },
-  dueDateEnd:       { col: ticketCols.eta,             enumValues: null },
-  createdDateStart: { col: ticketCols.createdAt,       enumValues: null },
-  createdDateEnd:   { col: ticketCols.createdAt,       enumValues: null },
-  priority:         { col: ticketCols.priority,        enumValues: new Set(Object.values(TicketPriority)) },
+  boards:              { col: ticketCols.boardId,      enumValues: null },
+  assignee:            { col: ticketCols.assignedTo,   enumValues: null },
+  createdBy:           { col: ticketCols.createdBy,    enumValues: null },
+  userGroups:          { col: ticketCols.userGroupId,  enumValues: null },
+  tags:                { col: tagCols.name,            enumValues: null },
+  stages:              { col: ticketCols.stageName,    enumValues: null },
+  ticketTypes:         { col: ticketCols.ticketType,   enumValues: null },
+  sourceChannels:      { col: ticketCols.channelId,    enumValues: null },
+  dueDateStart:        { col: ticketCols.eta,          enumValues: null },
+  dueDateEnd:          { col: ticketCols.eta,          enumValues: null },
+  createdDateStart:    { col: ticketCols.createdAt,    enumValues: null },
+  createdDateEnd:      { col: ticketCols.createdAt,    enumValues: null },
+  priority:            { col: ticketCols.priority,     enumValues: new Set(Object.values(TicketPriority)) },
+  // Desk-specific real-column fields
+  aiCategory:          { col: ticketCols.aiCategory,   enumValues: null },
+  lastEmailAtStart:    { col: ticketCols.lastEmailAt,  enumValues: null },
+  lastEmailAtEnd:      { col: ticketCols.lastEmailAt,  enumValues: null },
 };
 
 function validateTicketValue(fieldName: string, fieldValue: string): void {
@@ -50,6 +54,18 @@ function validateTicketValue(fieldName: string, fieldValue: string): void {
 
   // Virtual UI-state field (the groupBy column name), not a real column.
   if (fieldName === '__groupBy') return;
+
+  // Desk-only virtual fields — not real DB columns so not in TICKET_FILTER_SCHEMA.
+  if (fieldName === 'generatedTags') return; // free-form "category:tag" string
+  if (fieldName === 'conversationLabelId') return; // UUID string, existence validated at query time
+  if (fieldName === 'assigned') return; // boolean-as-string, existence validated at query time
+  if (fieldName === 'hasSubTickets') return; // boolean-as-string
+  if (fieldName === 'hasAiDraft') {
+    if (fieldValue !== 'true' && fieldValue !== 'false') {
+      throw new MutationACLError(`hasAiDraft must be "true" or "false"`, 'saved_user_configuration_values');
+    }
+    return;
+  }
 
   if (fieldName === 'roleAssignments') {
     const [roleId, userIdsCsv] = fieldValue.split('|');
@@ -101,8 +117,9 @@ function validateTicketValue(fieldName: string, fieldValue: string): void {
  *   - "<fieldId>.start"   — lower bound for DATE range filters
  *   - "<fieldId>.end"     — upper bound for DATE range filters
  *
- * The fieldId is looked up in form_fields to confirm it exists and to validate
- * the fieldValue against the actual field type.
+ * The fieldId may be either a form_fields.id (legacy rows) or a global_fields.id
+ * (new-style rows where resolveDisplayFormFields uses globalFieldId as the key).
+ * Both paths are checked so both work identically.
  */
 async function validateFormEntityValue(
   fieldName: string,
@@ -123,23 +140,40 @@ async function validateFormEntityValue(
     isDateBound = true;
   }
 
+  // Try form_fields.id first (legacy), then global_fields.id (new-style).
+  // resolveDisplayFormFields uses row.globalFieldId as the field key for new rows,
+  // so the stored fieldId in dynamicFields is a global_fields.id, not a form_fields.id.
   const formField = await tx.run(zql.form_fields.where('id', fieldId).one());
-  if (!formField) {
-    throw new MutationACLError(
-      `Unknown dynamic field id "${fieldId}"`,
-      table,
-    );
+  let resolvedFieldType: string | null | undefined;
+  let resolvedFieldOptions: string | null | undefined;
+  let resolvedFieldEnum: string | null | undefined;
+  if (formField) {
+    resolvedFieldType = formField.fieldType;
+    resolvedFieldOptions = formField.fieldOptions;
+    // form_fields.fieldEnum is json() in the schema, cast to string for parseFieldOptionValues
+    resolvedFieldEnum = formField.fieldEnum as string | null | undefined;
+  } else {
+    const globalField = await tx.run(zql.global_fields.where('id', fieldId).one());
+    if (!globalField) {
+      throw new MutationACLError(
+        `Unknown dynamic field id "${fieldId}"`,
+        table,
+      );
+    }
+    resolvedFieldType = globalField.fieldType;
+    resolvedFieldOptions = globalField.fieldOptions;
+    resolvedFieldEnum = globalField.fieldEnum;
   }
 
   // Non-date fields must NOT use the .start / .end suffix
-  if (isDateBound && formField.fieldType !== FormFieldType.DATE) {
+  if (isDateBound && resolvedFieldType !== FormFieldType.DATE) {
     throw new MutationACLError(
       `Non-DATE field "${fieldId}" must not use ".start" or ".end" suffix`,
       table,
     );
   }
 
-  switch (formField.fieldType) {
+  switch (resolvedFieldType) {
     case FormFieldType.DATE:
       if (!isDateBound) {
         throw new MutationACLError(
@@ -175,7 +209,7 @@ async function validateFormEntityValue(
 
     case FormFieldType.SINGLE_SELECT:
     case FormFieldType.MULTI_SELECT: {
-      const options = parseFieldOptionValues(formField.fieldOptions ?? formField.fieldEnum);
+      const options = parseFieldOptionValues(resolvedFieldOptions ?? resolvedFieldEnum);
       if (options.length > 0 && !options.includes(fieldValue)) {
         throw new MutationACLError(
           `Invalid value "${fieldValue}" for field "${fieldId}"`,
@@ -197,6 +231,7 @@ async function validateFormEntityValue(
     }
 
     case FormFieldType.STRING:
+    default:
       // Any non-empty string is valid — already checked above
       break;
   }

--- a/apps/backend/src/zero/acl/tables/saved-user-configurations-acl.ts
+++ b/apps/backend/src/zero/acl/tables/saved-user-configurations-acl.ts
@@ -1,8 +1,22 @@
 import type { DeleteID, InsertValue, Transaction, UpdateValue } from '@rocicorp/zero';
-import { ChannelRole, SavedConfigVisibility, Schema } from '@xyne/shared';
+import { ChannelRole, SavedConfigContextType, SavedConfigVisibility, Schema } from '@xyne/shared';
 import { BaseACL } from '../core/base-acl';
 import { MutationACLError, type TableSchema, type QueryContext } from '../core/types';
 import { zql } from '../../queries';
+
+async function isChannelAdmin(
+  tx: Transaction<Schema>,
+  userId: string,
+  channelId: string,
+): Promise<boolean> {
+  const p = await tx.run(
+    zql.channel_participants
+      .where('userId', userId)
+      .where('channelId', channelId)
+      .where('role', ChannelRole.ADMIN),
+  );
+  return p.length > 0;
+}
 
 /**
  * Checks if a user can create or promote a saved view to PUBLIC visibility.
@@ -62,7 +76,9 @@ export class SavedUserConfigurationsACL extends BaseACL<'saved_user_configuratio
     }
 
     if (args.visibility === SavedConfigVisibility.PUBLIC) {
-      const allowed = await canMakePublicView(tx, this.ctx.userID, args.contextId);
+      const allowed = args.contextType === SavedConfigContextType.DESK_TICKET
+        ? await isChannelAdmin(tx, this.ctx.userID, args.contextId)
+        : await canMakePublicView(tx, this.ctx.userID, args.contextId);
       if (!allowed) {
         throw new MutationACLError(
           'Saved view insert failed: you do not have permission to create a public view',
@@ -97,7 +113,9 @@ export class SavedUserConfigurationsACL extends BaseACL<'saved_user_configuratio
       args.visibility === SavedConfigVisibility.PUBLIC &&
       config.visibility !== SavedConfigVisibility.PUBLIC
     ) {
-      const allowed = await canMakePublicView(tx, this.ctx.userID, config.contextId);
+      const allowed = config.contextType === SavedConfigContextType.DESK_TICKET
+        ? await isChannelAdmin(tx, this.ctx.userID, config.contextId)
+        : await canMakePublicView(tx, this.ctx.userID, config.contextId);
       if (!allowed) {
         throw new MutationACLError(
           'Saved view update failed: you do not have permission to make this view public',

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -14942,14 +14942,20 @@ export function createMutators(
           tx,
           args: { id, name, contextType, contextId, visibility, timestamp, values },
         }) => {
-          // Check for duplicate name (case-insensitive) per user per contextId
+          // Check for duplicate name (case-insensitive) per user per contextType+contextId
           const allUserConfigs = await tx.run(
             zql.saved_user_configurations
               .where('userId', authData.sub)
+              .where('contextType', contextType)
               .where('contextId', contextId)
           );
+          const isDeskContext = contextType === SavedConfigContextType.DESK_TICKET;
           if (allUserConfigs.some(c => c.name.toLowerCase() === name.toLowerCase())) {
-            throw new Error('A saved view with this name already exists for this board');
+            throw new Error(
+              isDeskContext
+                ? 'A saved view with this name already exists for this channel'
+                : 'A saved view with this name already exists for this board',
+            );
           }
 
           await tx.mutate.saved_user_configurations.insert({
@@ -15010,10 +15016,16 @@ export function createMutators(
             const allUserConfigs = await tx.run(
               zql.saved_user_configurations
                 .where('userId', authData.sub)
+                .where('contextType', config.contextType)
                 .where('contextId', config.contextId)
             );
             if (allUserConfigs.some(c => c.id !== configId && c.name.toLowerCase() === name.toLowerCase())) {
-              throw new Error('A saved view with this name already exists for this board');
+              const isDesk = config.contextType === SavedConfigContextType.DESK_TICKET;
+              throw new Error(
+                isDesk
+                  ? 'A saved view with this name already exists for this channel'
+                  : 'A saved view with this name already exists for this board',
+              );
             }
           }
 

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -36,6 +36,7 @@ import {
   ActivityClassification, LinkVisibility,
   NudgeState,
   SavedConfigContextType,
+  SavedConfigVisibility,
   Status,
   ProjectType,
   TicketPriority,
@@ -5291,9 +5292,24 @@ dmChannelsLatestMessagesPaginated: defineQuery(
   savedConfigsByUser: defineQuery(z.object({ userId: z.string() }), ({ args: { userId } }) => {
     return zql.saved_user_configurations
       .where('userId', userId)
+      .where('contextType', SavedConfigContextType.BOARD)
       .related('values')
       .orderBy('createdAt', 'desc');
   }),
+
+  savedDeskTicketConfigsByChannel: defineQuery(
+    z.object({ channelId: z.string() }),
+    ({ args: { channelId }, ctx }) => {
+      return zql.saved_user_configurations
+        .where('contextType', SavedConfigContextType.DESK_TICKET)
+        .where('contextId', channelId)
+        .where(({ cmp, or }) =>
+          or(cmp('userId', '=', ctx.userID), cmp('visibility', '=', SavedConfigVisibility.PUBLIC)),
+        )
+        .related('values')
+        .orderBy('createdAt', 'desc');
+    },
+  ),
 
   savedConfigsSharedWithUser: defineQuery(
     z.object({ userId: z.string() }),

--- a/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/DynamicFieldSubmenu/DynamicFieldSubmenu.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/DynamicFieldSubmenu/DynamicFieldSubmenu.tsx
@@ -80,19 +80,12 @@ export const DynamicFieldSubmenu = ({
   // Render SINGLE_SELECT or MULTI_SELECT
   if (fieldType === FormFieldType.SINGLE_SELECT || fieldType === FormFieldType.MULTI_SELECT) {
     const handleToggle = (option: string): void => {
-      if (fieldType === FormFieldType.SINGLE_SELECT) {
-        // Single select: replace value or clear if clicking selected
-        onChange(selectedValues.includes(option) ? [] : [option]);
-      } else {
-        // Multi select: toggle in array
-        const isSelected = selectedValues.includes(option);
-        onChange(
-          isSelected ? selectedValues.filter(v => v !== option) : [...selectedValues, option],
-        );
-      }
+      const isSelected = selectedValues.includes(option);
+      onChange(isSelected ? selectedValues.filter(v => v !== option) : [...selectedValues, option]);
     };
 
-    const isMultiSelect = fieldType === FormFieldType.MULTI_SELECT;
+    const isMultiSelect =
+      fieldType === FormFieldType.SINGLE_SELECT || fieldType === FormFieldType.MULTI_SELECT;
     const allVisibleSelected =
       filteredOptions.length > 0 && filteredOptions.every(o => selectedValues.includes(o));
 

--- a/apps/dashboard/src/components/xyne-desk/DeskSavedViewsControls.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSavedViewsControls.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type ReactElement } from 'react';
+import { useState, useEffect, useRef, type ReactElement, type CSSProperties } from 'react';
 import * as Popover from '@radix-ui/react-popover';
 import { toast } from 'sonner';
 import { SavedConfigVisibility } from '@xyne/shared';
@@ -8,11 +8,17 @@ import {
   LockClose as Lock,
   DeleteDustbin01 as Trash,
   AlertTriangle,
+  ArrowRight,
+  ChevronDown,
+  ChevronUp,
 } from '@xyne/icons';
 import { cn } from '../../utils/classNames';
 import { Switch } from '../ui/Switch';
 import Dialog from '../ui/Dialog';
+import { valuesToFilters } from '../../utils/savedViewSerialization';
 import type { DeskTicketSavedView } from '../../hooks/useDeskTicketSavedViews';
+import type { TicketFilters } from '../Tickets/TicketFilters/types';
+import type { ResolvedDisplayFormField } from '../../utils/board/resolveDisplayFormFields';
 
 interface DeskSavedViewsControlsProps {
   savedViews: DeskTicketSavedView[];
@@ -24,8 +30,133 @@ interface DeskSavedViewsControlsProps {
   onSave: (name: string, visibility: SavedConfigVisibility) => Promise<string | undefined>;
   onUpdate: (viewId: string) => Promise<void>;
   onDelete: (viewId: string) => Promise<void>;
-  hasActiveFilters: boolean;
+  currentFilters: TicketFilters;
+  dynamicFieldDefs?: ResolvedDisplayFormField[];
   trackCategory?: string;
+}
+
+interface FilterRow {
+  label: string;
+  values: string[];
+}
+
+function buildFilterRows(
+  values: DeskTicketSavedView['values'],
+  fieldDefs?: ResolvedDisplayFormField[],
+): FilterRow[] {
+  if (!values || values.length === 0) return [];
+  const f = valuesToFilters(values);
+  const rows: FilterRow[] = [];
+  if (f.priority?.length) rows.push({ label: 'Priority', values: f.priority });
+  if (f.stages?.length) rows.push({ label: 'Stage', values: f.stages });
+  if (f.assignee?.length)
+    rows.push({ label: 'Assignee', values: [`${f.assignee.length} selected`] });
+  if (f.assigned !== undefined)
+    rows.push({ label: 'Assigned', values: [f.assigned ? 'Yes' : 'No'] });
+  if (f.aiCategory?.length) rows.push({ label: 'AI Category', values: f.aiCategory });
+  if (f.hasAiDraft !== undefined)
+    rows.push({ label: 'Has AI Draft', values: [f.hasAiDraft ? 'Yes' : 'No'] });
+  if (f.hasSubTickets !== undefined)
+    rows.push({ label: 'Has Sub-tickets', values: [f.hasSubTickets ? 'Yes' : 'No'] });
+  if (f.generatedTags?.length)
+    rows.push({
+      label: 'Tags',
+      values: f.generatedTags.map(t => {
+        const [cat, tag] = t.split(':');
+        return tag ? `${cat}: ${tag}` : t;
+      }),
+    });
+  if (f.conversationLabelId) rows.push({ label: 'Label', values: ['Set'] });
+  if (f.lastEmailAtStart !== undefined || f.lastEmailAtEnd !== undefined)
+    rows.push({ label: 'Last Email', values: ['Date range'] });
+  if (f.dueDateStart !== undefined || f.dueDateEnd !== undefined)
+    rows.push({ label: 'Due Date', values: ['Date range'] });
+  if (f.createdDateStart !== undefined || f.createdDateEnd !== undefined)
+    rows.push({ label: 'Created', values: ['Date range'] });
+  if (f.dynamicFields) {
+    for (const [fieldId, val] of Object.entries(f.dynamicFields)) {
+      const def = fieldDefs?.find(d => d.id === fieldId);
+      const label = def?.fieldName ?? `Custom: ${fieldId.slice(0, 8)}`;
+      if (Array.isArray(val)) {
+        rows.push({ label, values: val });
+      } else {
+        rows.push({ label, values: ['Date range'] });
+      }
+    }
+  }
+  return rows;
+}
+
+function FilterPreviewCard({
+  view,
+  style,
+  fieldDefs,
+}: {
+  view: DeskTicketSavedView;
+  style: CSSProperties;
+  fieldDefs?: ResolvedDisplayFormField[];
+}): ReactElement {
+  const rows = buildFilterRows(view.values, fieldDefs);
+  const isPublic = view.visibility === (SavedConfigVisibility.PUBLIC as string);
+
+  return (
+    <div
+      style={style}
+      className='absolute z-[80] w-52 bg-popover border border-border rounded-xl shadow-xl py-3 pointer-events-none'
+    >
+      {/* Header */}
+      <div className='flex items-center gap-1.5 px-3 pb-2 border-b border-border'>
+        {isPublic ? (
+          <Globe size={11} className='shrink-0 text-muted-foreground' />
+        ) : (
+          <Lock size={11} className='shrink-0 text-muted-foreground' />
+        )}
+        <span className='text-xs font-semibold text-foreground truncate'>{view.name}</span>
+      </div>
+      {/* Filter rows */}
+      <div className='flex flex-col gap-1.5 px-3 pt-2'>
+        {rows.length === 0 ? (
+          <p className='text-xs text-muted-foreground'>No filters</p>
+        ) : (
+          rows.map(row => (
+            <div key={row.label} className='flex flex-col gap-0.5'>
+              <span className='text-[10px] font-medium text-muted-foreground uppercase tracking-wide'>
+                {row.label}
+              </span>
+              <div className='flex flex-wrap gap-1'>
+                {row.values.map(v => (
+                  <span
+                    key={v}
+                    className='text-xs px-1.5 py-0.5 rounded-md bg-muted text-foreground'
+                  >
+                    {v}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Recursively sort object keys so JSON.stringify gives a stable result regardless of insertion order. */
+function sortKeysDeep(val: unknown): unknown {
+  if (Array.isArray(val)) return val.map(sortKeysDeep);
+  if (val !== null && typeof val === 'object') {
+    return Object.fromEntries(
+      Object.keys(val as Record<string, unknown>)
+        .sort()
+        .map(k => [k, sortKeysDeep((val as Record<string, unknown>)[k])]),
+    );
+  }
+  return val;
+}
+
+/** Stable signature for dirty-state comparison — handles nested objects like dynamicFields. */
+function filtersSignature(filters: TicketFilters): string {
+  return JSON.stringify(sortKeysDeep(filters));
 }
 
 export function DeskSavedViewsControls({
@@ -38,26 +169,67 @@ export function DeskSavedViewsControls({
   onSave,
   onUpdate,
   onDelete,
-  hasActiveFilters,
+  currentFilters,
+  dynamicFieldDefs,
   trackCategory = 'Support',
 }: DeskSavedViewsControlsProps): ReactElement {
-  const [showViewsPopover, setShowViewsPopover] = useState(false);
-  const [showSavePopover, setShowSavePopover] = useState(false);
+  const [open, setOpen] = useState(false);
   const [saveViewName, setSaveViewName] = useState('');
   const [isPublic, setIsPublic] = useState(false);
   const [saveError, setSaveError] = useState('');
   const [saveLoading, setSaveLoading] = useState(false);
-  const [viewToDelete, setViewToDelete] = useState<DeskTicketSavedView | null>(null);
   const [updateLoading, setUpdateLoading] = useState(false);
+  const [showUpdateConfirm, setShowUpdateConfirm] = useState(false);
+  const [showSaveForm, setShowSaveForm] = useState(false);
+  const [viewToDelete, setViewToDelete] = useState<DeskTicketSavedView | null>(null);
+  const [showViewsList, setShowViewsList] = useState(true);
+  const [hoverPos, setHoverPos] = useState<{ viewId: string; top: number } | null>(null);
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   const activeView = savedViews.find(v => v.id === activeViewId) ?? null;
+  const isOwnActiveView = activeView?.userId === currentUserId;
 
-  // When all filters are cleared, deactivate the active view so "Save view" reappears
+  // Dirty: current filters differ from what the active view has stored
+  const isDirty = (() => {
+    if (!activeView?.values) return false;
+    const viewFilters = valuesToFilters(activeView.values);
+    return filtersSignature(currentFilters) !== filtersSignature(viewFilters);
+  })();
+
+  // Reset inner state when popover closes
   useEffect(() => {
-    if (!hasActiveFilters && activeViewId) {
-      onActiveViewChange(null);
+    if (!open) {
+      setSaveViewName('');
+      setIsPublic(false);
+      setSaveError('');
+      setShowUpdateConfirm(false);
+      setShowSaveForm(false);
+      setShowViewsList(true);
+      // Clear stale hover so it doesn't show on next open without moving the cursor
+      if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
+      setHoverPos(null);
     }
-  }, [hasActiveFilters, activeViewId, onActiveViewChange]);
+  }, [open]);
+
+  const hasFilters = Object.keys(currentFilters).some(k => {
+    const v = currentFilters[k as keyof TicketFilters];
+    if (Array.isArray(v)) return v.length > 0;
+    if (typeof v === 'object' && v !== null) return Object.keys(v).length > 0;
+    return v !== undefined && v !== null;
+  });
+
+  // Auto-collapse views list when a banner/form or the "save filters" entry takes focus
+  const hasBanner = (activeView !== null && isDirty) || showSaveForm || (!activeView && hasFilters);
+  useEffect(() => {
+    if (hasBanner) setShowViewsList(false);
+  }, [hasBanner]);
+
+  const handleApply = (view: DeskTicketSavedView): void => {
+    onApply(view);
+    onActiveViewChange(view.id);
+    setOpen(false);
+  };
 
   const handleSave = async (): Promise<void> => {
     const name = saveViewName.trim();
@@ -73,9 +245,7 @@ export function DeskSavedViewsControls({
         onActiveViewChange(id);
         toast.success(`View "${name}" saved`);
       }
-      setSaveViewName('');
-      setIsPublic(false);
-      setShowSavePopover(false);
+      setOpen(false);
     } catch (e) {
       setSaveError(e instanceof Error ? e.message : 'Failed to save view');
     } finally {
@@ -89,17 +259,13 @@ export function DeskSavedViewsControls({
     try {
       await onUpdate(activeViewId);
       toast.success(`View "${activeView?.name ?? ''}" updated`);
+      setShowUpdateConfirm(false);
+      setOpen(false);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Failed to update view');
     } finally {
       setUpdateLoading(false);
     }
-  };
-
-  const handleApply = (view: DeskTicketSavedView): void => {
-    onApply(view);
-    onActiveViewChange(view.id);
-    setShowViewsPopover(false);
   };
 
   const handleDeleteConfirm = async (): Promise<void> => {
@@ -115,197 +281,331 @@ export function DeskSavedViewsControls({
     }
   };
 
+  const handleHoverEnter = (id: string, el: HTMLElement): void => {
+    if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
+    hoverTimerRef.current = setTimeout(() => {
+      if (!contentRef.current) return;
+      const rowRect = el.getBoundingClientRect();
+      const containerRect = contentRef.current.getBoundingClientRect();
+      setHoverPos({ viewId: id, top: rowRect.top - containerRect.top });
+    }, 200);
+  };
+
+  const handleHoverLeave = (): void => {
+    if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
+    setHoverPos(null);
+  };
+
   return (
     <div className='flex items-center gap-2'>
-      {/* Update button — shown when an own view is active and filters exist */}
-      {activeViewId && activeView && activeView.userId === currentUserId && hasActiveFilters ? (
-        <button
-          onClick={() => void handleUpdate()}
-          disabled={updateLoading}
-          className='flex items-center gap-1.5 px-2.5 h-8 text-sm rounded-lg border border-primary bg-primary/10 text-primary hover:bg-primary/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
-          data-track-category={trackCategory}
-          data-track-name='UpdateDeskView'
-        >
-          {updateLoading ? 'Updating…' : `Update "${activeView.name}"`}
-        </button>
-      ) : (
-        /* Save view — bright when filters active, disabled when not */
-        <Popover.Root
-          open={showSavePopover}
-          onOpenChange={open => {
-            setShowSavePopover(open);
-            if (!open) {
-              setSaveViewName('');
-              setIsPublic(false);
-              setSaveError('');
-            }
-          }}
-        >
-          <Popover.Trigger asChild>
-            <button
-              disabled={!hasActiveFilters}
-              className={cn(
-                'flex items-center gap-1.5 px-2.5 h-8 text-sm rounded-lg border transition-colors',
-                hasActiveFilters
-                  ? 'border-primary bg-primary/10 text-primary hover:bg-primary/20'
-                  : 'border-border text-muted-foreground cursor-not-allowed opacity-50',
-              )}
-              data-track-category={trackCategory}
-              data-track-name='OpenDeskSaveViewPopover'
-            >
-              Save view
-            </button>
-          </Popover.Trigger>
-          <Popover.Content
-            side='bottom'
-            align='end'
-            sideOffset={6}
-            className='z-[60] w-72 bg-popover border border-border rounded-xl shadow-lg p-4 flex flex-col gap-3'
+      {/* Active view pill */}
+      {activeView && (
+        <div className='flex items-center gap-1.5 px-2 h-8 rounded-lg border-2 border-border bg-muted text-foreground text-sm font-medium max-w-[220px]'>
+          {activeView.visibility === (SavedConfigVisibility.PUBLIC as string) ? (
+            <Globe size={11} className='shrink-0 text-muted-foreground' />
+          ) : (
+            <Lock size={11} className='shrink-0 text-muted-foreground' />
+          )}
+          <span className='truncate'>{activeView.name}</span>
+          <span className='shrink-0 text-[11px] text-muted-foreground font-normal'>
+            (
+            {activeView.visibility === (SavedConfigVisibility.PUBLIC as string)
+              ? 'Public'
+              : 'Private'}
+            )
+          </span>
+          <button
+            onClick={() => onActiveViewChange(null)}
+            className='flex-shrink-0 ml-0.5 rounded hover:bg-foreground/10 p-0.5 transition-colors text-muted-foreground hover:text-foreground'
+            title='Exit view'
+            data-track-category={trackCategory}
+            data-track-name='ExitDeskView'
           >
-            <p className='text-sm font-medium text-foreground'>Save current filters as a view</p>
-            <input
-              type='text'
-              placeholder='Give this view a name…'
-              value={saveViewName}
-              onChange={e => {
-                setSaveViewName(e.target.value);
-                setSaveError('');
-              }}
-              onKeyDown={e => {
-                if (e.key === 'Enter' && saveViewName.trim()) void handleSave();
-              }}
-              autoFocus
-              data-track-category={trackCategory}
-              data-track-name='DeskSaveViewNameInput'
-              className='w-full text-sm border-0 border-b border-border focus:outline-none pb-1 placeholder-muted-foreground'
-            />
-            {saveError && <p className='text-xs text-destructive'>{saveError}</p>}
-            {isChannelAdmin && (
-              <div className='flex items-start gap-2'>
-                <Switch
-                  checked={isPublic}
-                  onCheckedChange={setIsPublic}
-                  label='Share with team'
-                  id='desk-save-view-public-toggle'
-                />
-                <p className='text-xs text-muted-foreground mt-0.5'>
-                  {isPublic ? 'Visible to everyone in this channel' : 'Only visible to you'}
-                </p>
-              </div>
-            )}
-            <div className='flex items-center justify-end gap-2'>
-              <button
-                onClick={() => setShowSavePopover(false)}
-                data-track-category={trackCategory}
-                data-track-name='CancelDeskSaveView'
-                className='text-sm font-medium text-muted-foreground px-2 h-8 hover:text-foreground'
-              >
-                Cancel
-              </button>
-              <button
-                onClick={() => void handleSave()}
-                disabled={!saveViewName.trim() || saveLoading}
-                data-track-category={trackCategory}
-                data-track-name='ConfirmDeskSaveView'
-                className='text-sm font-semibold px-4 h-8 rounded-[8px] bg-primary text-white disabled:opacity-50 disabled:cursor-not-allowed'
-              >
-                {saveLoading ? 'Saving…' : 'Save view'}
-              </button>
-            </div>
-          </Popover.Content>
-        </Popover.Root>
+            ×
+          </button>
+        </div>
       )}
 
-      {/* Views list popover */}
-      <Popover.Root open={showViewsPopover} onOpenChange={setShowViewsPopover}>
+      {/* Main Views popover */}
+      <Popover.Root open={open} onOpenChange={setOpen}>
         <Popover.Trigger asChild>
           <button
             className={cn(
               'flex items-center gap-1.5 px-2.5 h-8 text-sm rounded-lg border border-border transition-colors',
-              showViewsPopover
+              open || activeView
                 ? 'bg-muted text-foreground'
-                : 'text-muted-foreground hover:text-foreground hover:bg-muted',
+                : hasFilters
+                  ? 'bg-muted text-foreground font-medium border-foreground/20'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-muted',
             )}
             data-track-category={trackCategory}
             data-track-name='OpenDeskViewsPopover'
           >
             <Bookmark size={14} />
             <span>Views{savedViews.length > 0 ? ` (${savedViews.length})` : ''}</span>
+            {(isDirty || (!activeView && hasFilters)) && (
+              <span className='w-1.5 h-1.5 rounded-full bg-blue-500' />
+            )}
           </button>
         </Popover.Trigger>
+
         <Popover.Content
           side='bottom'
           align='end'
           sideOffset={6}
-          className='z-[60] w-72 bg-popover border border-border rounded-xl shadow-lg py-2 flex flex-col'
+          ref={contentRef}
+          className='z-[60] w-80 bg-popover border border-border rounded-xl shadow-lg flex flex-col relative'
         >
-          {savedViews.length === 0 ? (
-            <p className='text-sm text-muted-foreground px-3 py-2'>No saved views yet</p>
-          ) : (
-            <div className='flex flex-col'>
-              {/* Legend */}
-              <div className='flex items-center gap-3 px-3 pb-2 border-b border-border mb-1'>
-                <span className='flex items-center gap-1 text-xs text-muted-foreground'>
-                  <Globe size={11} />
-                  Team
-                </span>
-                <span className='flex items-center gap-1 text-xs text-muted-foreground'>
-                  <Lock size={11} />
-                  Private
-                </span>
-              </div>
-              {savedViews.map(view => {
-                const isOwn = view.userId === currentUserId;
-                const isPublicView = view.visibility === (SavedConfigVisibility.PUBLIC as string);
-                return (
-                  <button
-                    key={view.id}
-                    type='button'
-                    className={cn(
-                      'flex items-center justify-between px-3 py-2 cursor-pointer hover:bg-muted w-full text-left',
-                      activeViewId === view.id && 'bg-accent',
-                    )}
-                    onClick={() => handleApply(view)}
-                    onKeyDown={e => {
-                      if (e.key === 'Enter' || e.key === ' ') handleApply(view);
-                    }}
-                    data-track-category={trackCategory}
-                    data-track-name='ApplyDeskSavedView'
-                  >
-                    <div className='flex items-center gap-2 min-w-0'>
-                      {isPublicView ? (
-                        <Globe size={13} className='shrink-0 text-primary' />
-                      ) : (
-                        <Lock size={13} className='shrink-0 text-muted-foreground' />
-                      )}
-                      <div className='flex flex-col min-w-0'>
-                        <span className='text-sm truncate'>{view.name}</span>
-                        <span className='text-xs text-muted-foreground'>
-                          {isPublicView ? 'Shared with team' : 'Only you'}
-                          {!isOwn && ' · by others'}
-                        </span>
-                      </div>
-                    </div>
-                    {/* Delete — always visible, only for own views */}
-                    {isOwn && (
-                      <button
-                        onClick={e => {
-                          e.stopPropagation();
-                          setViewToDelete(view);
-                        }}
-                        className='ml-2 p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors shrink-0'
-                        title='Delete view'
-                        data-track-category={trackCategory}
-                        data-track-name='OpenDeleteDeskViewDialog'
-                      >
-                        <Trash size={13} />
-                      </button>
-                    )}
-                  </button>
-                );
-              })}
+          {/* Dirty-state banner — non-owner edited a public view */}
+          {activeView && !isOwnActiveView && isDirty && !showSaveForm && (
+            <div className='px-4 pt-4 pb-3 border-b border-border bg-muted/60'>
+              <p className='text-xs text-muted-foreground mb-2'>
+                You&apos;ve modified{' '}
+                <span className='font-medium text-foreground'>&quot;{activeView.name}&quot;</span> —
+                save a copy?
+              </p>
+              <button
+                onClick={() => setShowSaveForm(true)}
+                data-track-category={trackCategory}
+                data-track-name='StartSaveAsFromPublicDeskView'
+                className='text-xs font-semibold px-3 h-7 rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors'
+              >
+                Save as new view
+              </button>
             </div>
           )}
+
+          {/* Dirty-state banner — own view + filters changed */}
+          {activeView && isOwnActiveView && isDirty && !showSaveForm && (
+            <div className='px-4 pt-4 pb-3 border-b border-border bg-muted/60'>
+              <p className='text-xs text-muted-foreground mb-2'>
+                Unsaved changes to{' '}
+                <span className='font-medium text-foreground'>&quot;{activeView.name}&quot;</span>
+              </p>
+              {showUpdateConfirm ? (
+                <div className='flex flex-col gap-2'>
+                  <p className='text-xs text-muted-foreground'>
+                    Save your filter changes back to this view?
+                  </p>
+                  <div className='flex items-center gap-2'>
+                    <button
+                      onClick={() => void handleUpdate()}
+                      disabled={updateLoading}
+                      data-track-category={trackCategory}
+                      data-track-name='ConfirmUpdateDeskView'
+                      className='text-xs font-semibold px-3 h-7 rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80 disabled:opacity-50 transition-colors'
+                    >
+                      {updateLoading ? 'Saving…' : 'Yes, update'}
+                    </button>
+                    <button
+                      onClick={() => setShowUpdateConfirm(false)}
+                      data-track-category={trackCategory}
+                      data-track-name='CancelUpdateDeskView'
+                      className='text-xs font-medium px-2 h-7 text-muted-foreground hover:text-foreground transition-colors'
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className='flex items-center gap-2'>
+                  <button
+                    onClick={() => setShowUpdateConfirm(true)}
+                    data-track-category={trackCategory}
+                    data-track-name='StartUpdateDeskView'
+                    className='text-xs font-medium px-3 h-7 rounded-md border border-border bg-background hover:bg-muted transition-colors'
+                  >
+                    Update view
+                  </button>
+                  <button
+                    onClick={() => setShowSaveForm(true)}
+                    data-track-category={trackCategory}
+                    data-track-name='StartSaveNewDeskView'
+                    className='text-xs font-medium px-3 h-7 rounded-md border border-border bg-background hover:bg-muted transition-colors'
+                  >
+                    Save as new
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Save new view form — only when explicitly opened */}
+          {showSaveForm && !showUpdateConfirm && (
+            <div className='px-4 pt-4 pb-3 border-b border-border flex flex-col gap-2'>
+              <span className='text-[13px] font-medium text-foreground'>Save as new view</span>
+              <input
+                autoFocus
+                type='text'
+                placeholder='e.g. Open urgent bugs'
+                value={saveViewName}
+                onChange={e => {
+                  setSaveViewName(e.target.value);
+                  setSaveError('');
+                }}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && saveViewName.trim()) void handleSave();
+                }}
+                data-track-category={trackCategory}
+                data-track-name='DeskSaveViewNameInput'
+                className='h-8 px-2 rounded-md border border-input bg-background text-[13px] text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50'
+              />
+              {saveError && <p className='text-xs text-destructive'>{saveError}</p>}
+              {isChannelAdmin && (
+                <Switch
+                  checked={isPublic}
+                  onCheckedChange={setIsPublic}
+                  label={isPublic ? 'Visible to everyone in this channel' : 'Only visible to you'}
+                  id='desk-save-view-public-toggle'
+                />
+              )}
+              <div className='flex justify-end gap-2 pt-1'>
+                <button
+                  onClick={() => {
+                    setShowSaveForm(false);
+                    setSaveViewName('');
+                    setSaveError('');
+                  }}
+                  data-track-category={trackCategory}
+                  data-track-name='CancelDeskSaveView'
+                  className='text-[13px] font-medium text-muted-foreground px-2 h-7 hover:text-foreground'
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={() => void handleSave()}
+                  disabled={!saveViewName.trim() || saveLoading}
+                  data-track-category={trackCategory}
+                  data-track-name='ConfirmDeskSaveView'
+                  className='text-[13px] font-semibold px-4 h-7 rounded-md bg-secondary text-secondary-foreground disabled:opacity-40 disabled:cursor-not-allowed hover:bg-secondary/80 transition-colors'
+                >
+                  {saveLoading ? 'Saving…' : 'Save'}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Save view entry point — no active view + filters exist */}
+          {!activeView && !showSaveForm && hasFilters && (
+            <div className='px-3 py-2.5 border-b border-border'>
+              <button
+                type='button'
+                onClick={() => setShowSaveForm(true)}
+                data-track-category={trackCategory}
+                data-track-name='OpenDeskSaveViewForm'
+                className='w-full flex items-center justify-between gap-2 px-3 h-9 rounded-lg border border-dashed border-border bg-muted/40 hover:bg-muted hover:border-border/80 transition-colors group'
+              >
+                <div className='flex items-center gap-2'>
+                  <Bookmark size={13} className='text-muted-foreground shrink-0' />
+                  <span className='text-[13px] font-medium text-foreground'>
+                    Save current filters as a view
+                  </span>
+                </div>
+                <ArrowRight
+                  size={13}
+                  className='text-muted-foreground shrink-0 group-hover:translate-x-0.5 transition-transform'
+                />
+              </button>
+            </div>
+          )}
+
+          {/* Views list header — always visible, acts as collapse toggle when a banner/form is active */}
+          {savedViews.length > 0 && (
+            <button
+              type='button'
+              onClick={() => setShowViewsList(v => !v)}
+              data-track-category={trackCategory}
+              data-track-name='ToggleDeskViewsList'
+              className='flex items-center justify-between w-full px-4 py-2 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors border-b border-border'
+            >
+              <span>Saved views ({savedViews.length})</span>
+              {showViewsList ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+            </button>
+          )}
+
+          {/* Views list */}
+          {savedViews.length === 0 ? (
+            <p className='text-sm text-muted-foreground px-4 py-3'>No saved views yet</p>
+          ) : (
+            showViewsList && (
+              <div className='flex flex-col py-1 max-h-56 overflow-y-auto overflow-x-visible'>
+                {savedViews.map(view => {
+                  const isOwn = view.userId === currentUserId;
+                  const isPublicView = view.visibility === (SavedConfigVisibility.PUBLIC as string);
+                  const isActive = view.id === activeViewId;
+
+                  return (
+                    <div
+                      key={view.id}
+                      role='button'
+                      tabIndex={0}
+                      className={cn(
+                        'group flex items-center w-full cursor-pointer px-4 py-2 hover:bg-muted transition-colors',
+                        isActive && 'bg-accent',
+                      )}
+                      onClick={() => handleApply(view)}
+                      onMouseEnter={e => handleHoverEnter(view.id, e.currentTarget)}
+                      onMouseLeave={handleHoverLeave}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' || e.key === ' ') handleApply(view);
+                      }}
+                      data-track-category={trackCategory}
+                      data-track-name='ApplyDeskSavedView'
+                    >
+                      <div className='flex items-center gap-1.5 min-w-0 flex-1'>
+                        {isPublicView ? (
+                          <Globe size={12} className='shrink-0 text-muted-foreground' />
+                        ) : (
+                          <Lock size={12} className='shrink-0 text-muted-foreground' />
+                        )}
+                        <span
+                          className={cn(
+                            'text-sm truncate',
+                            isActive ? 'font-medium text-foreground' : 'text-muted-foreground',
+                          )}
+                        >
+                          {view.name}
+                        </span>
+                        {!isOwn && (
+                          <span className='text-xs text-muted-foreground shrink-0'>· others</span>
+                        )}
+                      </div>
+                      {isOwn && (
+                        <button
+                          type='button'
+                          onClick={e => {
+                            e.stopPropagation();
+                            setViewToDelete(view);
+                          }}
+                          className='ml-2 p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors shrink-0 opacity-0 group-hover:opacity-100'
+                          title='Delete view'
+                          data-track-category={trackCategory}
+                          data-track-name='OpenDeleteDeskViewDialog'
+                          tabIndex={-1}
+                        >
+                          <Trash size={12} />
+                        </button>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )
+          )}
+
+          {/* Floating filter preview card — shown to the left of the popover on row hover */}
+          {hoverPos &&
+            (() => {
+              const view = savedViews.find(v => v.id === hoverPos.viewId);
+              if (!view) return null;
+              return (
+                <FilterPreviewCard
+                  view={view}
+                  style={{ right: 'calc(100% + 8px)', top: hoverPos.top }}
+                  {...(dynamicFieldDefs ? { fieldDefs: dynamicFieldDefs } : {})}
+                />
+              );
+            })()}
         </Popover.Content>
       </Popover.Root>
 
@@ -321,7 +621,6 @@ export function DeskSavedViewsControls({
       >
         {viewToDelete && (
           <div className='flex flex-col'>
-            {/* Header */}
             <div className='flex items-start gap-4 px-6 pt-6 pb-5'>
               <div className='flex-shrink-0 flex items-center justify-center w-10 h-10 rounded-full bg-destructive/10'>
                 <AlertTriangle size={20} className='text-destructive' />
@@ -336,8 +635,6 @@ export function DeskSavedViewsControls({
                 </p>
               </div>
             </div>
-
-            {/* Team view warning */}
             {viewToDelete.visibility === (SavedConfigVisibility.PUBLIC as string) && (
               <div className='mx-6 mb-5 flex items-start gap-2.5 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3'>
                 <Globe size={14} className='mt-0.5 shrink-0 text-destructive' />
@@ -346,8 +643,6 @@ export function DeskSavedViewsControls({
                 </p>
               </div>
             )}
-
-            {/* Actions */}
             <div className='flex items-center justify-end gap-3 border-t border-border px-6 py-4'>
               <button
                 onClick={() => setViewToDelete(null)}

--- a/apps/dashboard/src/components/xyne-desk/DeskSavedViewsControls.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSavedViewsControls.tsx
@@ -1,0 +1,374 @@
+import { useState, useEffect, type ReactElement } from 'react';
+import * as Popover from '@radix-ui/react-popover';
+import { toast } from 'sonner';
+import { SavedConfigVisibility } from '@xyne/shared';
+import {
+  BookmarkDefault as Bookmark,
+  Globe,
+  LockClose as Lock,
+  DeleteDustbin01 as Trash,
+  AlertTriangle,
+} from '@xyne/icons';
+import { cn } from '../../utils/classNames';
+import { Switch } from '../ui/Switch';
+import Dialog from '../ui/Dialog';
+import type { DeskTicketSavedView } from '../../hooks/useDeskTicketSavedViews';
+
+interface DeskSavedViewsControlsProps {
+  savedViews: DeskTicketSavedView[];
+  activeViewId: string | null;
+  onActiveViewChange: (id: string | null) => void;
+  currentUserId: string;
+  isChannelAdmin: boolean;
+  onApply: (view: DeskTicketSavedView) => void;
+  onSave: (name: string, visibility: SavedConfigVisibility) => Promise<string | undefined>;
+  onUpdate: (viewId: string) => Promise<void>;
+  onDelete: (viewId: string) => Promise<void>;
+  hasActiveFilters: boolean;
+  trackCategory?: string;
+}
+
+export function DeskSavedViewsControls({
+  savedViews,
+  activeViewId,
+  onActiveViewChange,
+  currentUserId,
+  isChannelAdmin,
+  onApply,
+  onSave,
+  onUpdate,
+  onDelete,
+  hasActiveFilters,
+  trackCategory = 'Support',
+}: DeskSavedViewsControlsProps): ReactElement {
+  const [showViewsPopover, setShowViewsPopover] = useState(false);
+  const [showSavePopover, setShowSavePopover] = useState(false);
+  const [saveViewName, setSaveViewName] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
+  const [saveError, setSaveError] = useState('');
+  const [saveLoading, setSaveLoading] = useState(false);
+  const [viewToDelete, setViewToDelete] = useState<DeskTicketSavedView | null>(null);
+  const [updateLoading, setUpdateLoading] = useState(false);
+
+  const activeView = savedViews.find(v => v.id === activeViewId) ?? null;
+
+  // When all filters are cleared, deactivate the active view so "Save view" reappears
+  useEffect(() => {
+    if (!hasActiveFilters && activeViewId) {
+      onActiveViewChange(null);
+    }
+  }, [hasActiveFilters, activeViewId, onActiveViewChange]);
+
+  const handleSave = async (): Promise<void> => {
+    const name = saveViewName.trim();
+    if (!name) return;
+    setSaveLoading(true);
+    setSaveError('');
+    try {
+      const id = await onSave(
+        name,
+        isPublic ? SavedConfigVisibility.PUBLIC : SavedConfigVisibility.PRIVATE,
+      );
+      if (id) {
+        onActiveViewChange(id);
+        toast.success(`View "${name}" saved`);
+      }
+      setSaveViewName('');
+      setIsPublic(false);
+      setShowSavePopover(false);
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : 'Failed to save view');
+    } finally {
+      setSaveLoading(false);
+    }
+  };
+
+  const handleUpdate = async (): Promise<void> => {
+    if (!activeViewId) return;
+    setUpdateLoading(true);
+    try {
+      await onUpdate(activeViewId);
+      toast.success(`View "${activeView?.name ?? ''}" updated`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to update view');
+    } finally {
+      setUpdateLoading(false);
+    }
+  };
+
+  const handleApply = (view: DeskTicketSavedView): void => {
+    onApply(view);
+    onActiveViewChange(view.id);
+    setShowViewsPopover(false);
+  };
+
+  const handleDeleteConfirm = async (): Promise<void> => {
+    if (!viewToDelete) return;
+    try {
+      await onDelete(viewToDelete.id);
+      if (activeViewId === viewToDelete.id) onActiveViewChange(null);
+      toast.success(`View "${viewToDelete.name}" deleted`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to delete view');
+    } finally {
+      setViewToDelete(null);
+    }
+  };
+
+  return (
+    <div className='flex items-center gap-2'>
+      {/* Update button — shown when an own view is active and filters exist */}
+      {activeViewId && activeView && activeView.userId === currentUserId && hasActiveFilters ? (
+        <button
+          onClick={() => void handleUpdate()}
+          disabled={updateLoading}
+          className='flex items-center gap-1.5 px-2.5 h-8 text-sm rounded-lg border border-primary bg-primary/10 text-primary hover:bg-primary/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
+          data-track-category={trackCategory}
+          data-track-name='UpdateDeskView'
+        >
+          {updateLoading ? 'Updating…' : `Update "${activeView.name}"`}
+        </button>
+      ) : (
+        /* Save view — bright when filters active, disabled when not */
+        <Popover.Root
+          open={showSavePopover}
+          onOpenChange={open => {
+            setShowSavePopover(open);
+            if (!open) {
+              setSaveViewName('');
+              setIsPublic(false);
+              setSaveError('');
+            }
+          }}
+        >
+          <Popover.Trigger asChild>
+            <button
+              disabled={!hasActiveFilters}
+              className={cn(
+                'flex items-center gap-1.5 px-2.5 h-8 text-sm rounded-lg border transition-colors',
+                hasActiveFilters
+                  ? 'border-primary bg-primary/10 text-primary hover:bg-primary/20'
+                  : 'border-border text-muted-foreground cursor-not-allowed opacity-50',
+              )}
+              data-track-category={trackCategory}
+              data-track-name='OpenDeskSaveViewPopover'
+            >
+              Save view
+            </button>
+          </Popover.Trigger>
+          <Popover.Content
+            side='bottom'
+            align='end'
+            sideOffset={6}
+            className='z-[60] w-72 bg-popover border border-border rounded-xl shadow-lg p-4 flex flex-col gap-3'
+          >
+            <p className='text-sm font-medium text-foreground'>Save current filters as a view</p>
+            <input
+              type='text'
+              placeholder='Give this view a name…'
+              value={saveViewName}
+              onChange={e => {
+                setSaveViewName(e.target.value);
+                setSaveError('');
+              }}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && saveViewName.trim()) void handleSave();
+              }}
+              autoFocus
+              data-track-category={trackCategory}
+              data-track-name='DeskSaveViewNameInput'
+              className='w-full text-sm border-0 border-b border-border focus:outline-none pb-1 placeholder-muted-foreground'
+            />
+            {saveError && <p className='text-xs text-destructive'>{saveError}</p>}
+            {isChannelAdmin && (
+              <div className='flex items-start gap-2'>
+                <Switch
+                  checked={isPublic}
+                  onCheckedChange={setIsPublic}
+                  label='Share with team'
+                  id='desk-save-view-public-toggle'
+                />
+                <p className='text-xs text-muted-foreground mt-0.5'>
+                  {isPublic ? 'Visible to everyone in this channel' : 'Only visible to you'}
+                </p>
+              </div>
+            )}
+            <div className='flex items-center justify-end gap-2'>
+              <button
+                onClick={() => setShowSavePopover(false)}
+                data-track-category={trackCategory}
+                data-track-name='CancelDeskSaveView'
+                className='text-sm font-medium text-muted-foreground px-2 h-8 hover:text-foreground'
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => void handleSave()}
+                disabled={!saveViewName.trim() || saveLoading}
+                data-track-category={trackCategory}
+                data-track-name='ConfirmDeskSaveView'
+                className='text-sm font-semibold px-4 h-8 rounded-[8px] bg-primary text-white disabled:opacity-50 disabled:cursor-not-allowed'
+              >
+                {saveLoading ? 'Saving…' : 'Save view'}
+              </button>
+            </div>
+          </Popover.Content>
+        </Popover.Root>
+      )}
+
+      {/* Views list popover */}
+      <Popover.Root open={showViewsPopover} onOpenChange={setShowViewsPopover}>
+        <Popover.Trigger asChild>
+          <button
+            className={cn(
+              'flex items-center gap-1.5 px-2.5 h-8 text-sm rounded-lg border border-border transition-colors',
+              showViewsPopover
+                ? 'bg-muted text-foreground'
+                : 'text-muted-foreground hover:text-foreground hover:bg-muted',
+            )}
+            data-track-category={trackCategory}
+            data-track-name='OpenDeskViewsPopover'
+          >
+            <Bookmark size={14} />
+            <span>Views{savedViews.length > 0 ? ` (${savedViews.length})` : ''}</span>
+          </button>
+        </Popover.Trigger>
+        <Popover.Content
+          side='bottom'
+          align='end'
+          sideOffset={6}
+          className='z-[60] w-72 bg-popover border border-border rounded-xl shadow-lg py-2 flex flex-col'
+        >
+          {savedViews.length === 0 ? (
+            <p className='text-sm text-muted-foreground px-3 py-2'>No saved views yet</p>
+          ) : (
+            <div className='flex flex-col'>
+              {/* Legend */}
+              <div className='flex items-center gap-3 px-3 pb-2 border-b border-border mb-1'>
+                <span className='flex items-center gap-1 text-xs text-muted-foreground'>
+                  <Globe size={11} />
+                  Team
+                </span>
+                <span className='flex items-center gap-1 text-xs text-muted-foreground'>
+                  <Lock size={11} />
+                  Private
+                </span>
+              </div>
+              {savedViews.map(view => {
+                const isOwn = view.userId === currentUserId;
+                const isPublicView = view.visibility === (SavedConfigVisibility.PUBLIC as string);
+                return (
+                  <button
+                    key={view.id}
+                    type='button'
+                    className={cn(
+                      'flex items-center justify-between px-3 py-2 cursor-pointer hover:bg-muted w-full text-left',
+                      activeViewId === view.id && 'bg-accent',
+                    )}
+                    onClick={() => handleApply(view)}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter' || e.key === ' ') handleApply(view);
+                    }}
+                    data-track-category={trackCategory}
+                    data-track-name='ApplyDeskSavedView'
+                  >
+                    <div className='flex items-center gap-2 min-w-0'>
+                      {isPublicView ? (
+                        <Globe size={13} className='shrink-0 text-primary' />
+                      ) : (
+                        <Lock size={13} className='shrink-0 text-muted-foreground' />
+                      )}
+                      <div className='flex flex-col min-w-0'>
+                        <span className='text-sm truncate'>{view.name}</span>
+                        <span className='text-xs text-muted-foreground'>
+                          {isPublicView ? 'Shared with team' : 'Only you'}
+                          {!isOwn && ' · by others'}
+                        </span>
+                      </div>
+                    </div>
+                    {/* Delete — always visible, only for own views */}
+                    {isOwn && (
+                      <button
+                        onClick={e => {
+                          e.stopPropagation();
+                          setViewToDelete(view);
+                        }}
+                        className='ml-2 p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors shrink-0'
+                        title='Delete view'
+                        data-track-category={trackCategory}
+                        data-track-name='OpenDeleteDeskViewDialog'
+                      >
+                        <Trash size={13} />
+                      </button>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </Popover.Content>
+      </Popover.Root>
+
+      {/* Delete confirmation dialog */}
+      <Dialog
+        open={!!viewToDelete}
+        onOpenChange={open => {
+          if (!open) setViewToDelete(null);
+        }}
+        title='Delete saved view'
+        zIndexClassName='z-[70]'
+        className='max-w-sm'
+      >
+        {viewToDelete && (
+          <div className='flex flex-col'>
+            {/* Header */}
+            <div className='flex items-start gap-4 px-6 pt-6 pb-5'>
+              <div className='flex-shrink-0 flex items-center justify-center w-10 h-10 rounded-full bg-destructive/10'>
+                <AlertTriangle size={20} className='text-destructive' />
+              </div>
+              <div className='flex flex-col gap-1 min-w-0'>
+                <h3 className='text-base font-semibold text-foreground'>Delete saved view</h3>
+                <p className='text-sm text-muted-foreground'>
+                  <span className='font-medium text-foreground'>
+                    &quot;{viewToDelete.name}&quot;
+                  </span>{' '}
+                  will be permanently removed. This cannot be undone.
+                </p>
+              </div>
+            </div>
+
+            {/* Team view warning */}
+            {viewToDelete.visibility === (SavedConfigVisibility.PUBLIC as string) && (
+              <div className='mx-6 mb-5 flex items-start gap-2.5 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3'>
+                <Globe size={14} className='mt-0.5 shrink-0 text-destructive' />
+                <p className='text-sm text-destructive'>
+                  This is a shared team view. Deleting it removes it for everyone in this channel.
+                </p>
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className='flex items-center justify-end gap-3 border-t border-border px-6 py-4'>
+              <button
+                onClick={() => setViewToDelete(null)}
+                data-track-category={trackCategory}
+                data-track-name='CancelDeleteDeskView'
+                className='text-sm font-medium h-9 px-4 rounded-lg border border-border hover:bg-muted transition-colors'
+              >
+                Keep view
+              </button>
+              <button
+                onClick={() => void handleDeleteConfirm()}
+                data-track-category={trackCategory}
+                data-track-name='ConfirmDeleteDeskView'
+                className='text-sm font-semibold h-9 px-4 rounded-lg bg-destructive text-white hover:bg-destructive/90 transition-colors'
+              >
+                Delete view
+              </button>
+            </div>
+          </div>
+        )}
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/dashboard/src/hooks/useDeskTicketSavedViews.ts
+++ b/apps/dashboard/src/hooks/useDeskTicketSavedViews.ts
@@ -1,0 +1,97 @@
+import { useCallback } from 'react';
+import { SavedConfigContextType, SavedConfigVisibility } from '@xyne/shared';
+import { v4 as uuidv4 } from 'uuid';
+import { queries } from '../zero/queries';
+import { mutators } from '../zero/mutators';
+import { useZero } from './useZero';
+import { useCachedQuery } from './useCachedQuery';
+import { deskFiltersToValues, valuesToFilters } from '../utils/savedViewSerialization';
+import type { SavedConfigValueRow } from '../utils/savedViewSerialization';
+import type { TicketFilters } from '../components/Tickets/TicketFilters/types';
+
+export type DeskTicketSavedView = {
+  id: string;
+  name: string;
+  userId: string;
+  visibility: string;
+  contextId: string;
+  values?: readonly SavedConfigValueRow[];
+};
+
+export function useDeskTicketSavedViews(
+  channelId: string,
+  applyView?: (filters: TicketFilters) => void,
+) {
+  const zero = useZero();
+
+  const [savedViews] = useCachedQuery(queries.savedDeskTicketConfigsByChannel({ channelId }), {
+    enabled: !!channelId,
+  });
+
+  const saveView = useCallback(
+    async (
+      name: string,
+      filters: TicketFilters,
+      visibility: SavedConfigVisibility,
+    ): Promise<string | undefined> => {
+      if (!channelId) return undefined;
+      const id = uuidv4();
+      const values = deskFiltersToValues(filters);
+      const res = await zero.mutate(
+        mutators.savedUserConfiguration.create({
+          id,
+          name,
+          contextType: SavedConfigContextType.DESK_TICKET,
+          contextId: channelId,
+          channelId,
+          visibility,
+          timestamp: Date.now(),
+          values,
+        }),
+      ).server;
+      if (res.type === 'error') throw new Error(res.error?.message ?? 'Failed to save view');
+      return id;
+    },
+    [zero, channelId],
+  );
+
+  const updateView = useCallback(
+    async (configId: string, filters: TicketFilters): Promise<void> => {
+      const values = deskFiltersToValues(filters);
+      const res = await zero.mutate(
+        mutators.savedUserConfiguration.update({
+          configId,
+          timestamp: Date.now(),
+          values,
+        }),
+      ).server;
+      if (res.type === 'error') throw new Error(res.error?.message ?? 'Failed to update view');
+    },
+    [zero],
+  );
+
+  const deleteView = useCallback(
+    async (configId: string): Promise<void> => {
+      const res = await zero.mutate(mutators.savedUserConfiguration.delete({ configId })).server;
+      if (res.type === 'error') throw new Error(res.error?.message ?? 'Failed to delete view');
+    },
+    [zero],
+  );
+
+  const applySavedView = useCallback(
+    (view: DeskTicketSavedView): void => {
+      if (!applyView || !view.values) return;
+      const filters = valuesToFilters(view.values);
+      applyView(filters);
+    },
+    [applyView],
+  );
+
+  return {
+    savedViews: (savedViews ?? []) as DeskTicketSavedView[],
+    saveView,
+    updateView,
+    deleteView,
+    applySavedView,
+  };
+}

--- a/apps/dashboard/src/machines/ticketFiltersMachine.ts
+++ b/apps/dashboard/src/machines/ticketFiltersMachine.ts
@@ -14,6 +14,7 @@ interface StorageData {
   groupBy?: string;
   showOverdueOnly?: boolean;
   showSubStatus?: boolean;
+  activeViewId?: string;
 }
 
 export interface TicketFiltersContext {
@@ -37,6 +38,7 @@ export interface TicketFiltersContext {
   setSearchParams?: (
     params: URLSearchParams | ((prev: URLSearchParams) => URLSearchParams),
   ) => void;
+  activeViewId: string | null;
 }
 
 export type TicketFiltersEvent =
@@ -59,7 +61,8 @@ export type TicketFiltersEvent =
   | { type: 'SET_GROUP_BY'; groupBy: string }
   | { type: 'SET_OVERDUE_ONLY'; showOverdueOnly: boolean }
   | { type: 'SET_SUB_STATUS'; showSubStatus: boolean }
-  | { type: 'URL_CHANGED'; searchParams: URLSearchParams };
+  | { type: 'URL_CHANGED'; searchParams: URLSearchParams }
+  | { type: 'SET_ACTIVE_VIEW_ID'; activeViewId: string | null };
 
 /* -------------------------- UTILITY FUNCTIONS -------------------------- */
 
@@ -363,6 +366,9 @@ const loadFromStorage = (key: string): StorageData => {
       if (typeof parsed.showSubStatus === 'boolean') {
         result.showSubStatus = parsed.showSubStatus;
       }
+      if (parsed.activeViewId) {
+        result.activeViewId = parsed.activeViewId;
+      }
       return result;
     }
   } catch {
@@ -381,6 +387,7 @@ const saveToStorage = (
   groupBy?: string,
   showOverdueOnly?: boolean,
   showSubStatus?: boolean,
+  activeViewId?: string | null,
 ): void => {
   try {
     const data: StorageData = { filters };
@@ -395,6 +402,9 @@ const saveToStorage = (
     }
     if (showSubStatus) {
       data.showSubStatus = true;
+    }
+    if (activeViewId) {
+      data.activeViewId = activeViewId;
     }
     sessionStorage.setItem(key, JSON.stringify(data));
   } catch {
@@ -465,9 +475,11 @@ export const ticketFiltersMachine = setup({
       let groupBy = 'none';
       let showOverdueOnly = false;
       let showSubStatus = false;
+      let activeViewId: string | null = null;
 
       if (enabled) {
         const storageData = loadFromStorage(storageKey);
+        activeViewId = storageData.activeViewId ?? null;
 
         const boardFromUrl = urlFilters.boards?.length ? urlFilters.boards : undefined;
         const boardFromDb = event.selectedBoardIdFromDb ? [event.selectedBoardIdFromDb] : undefined;
@@ -520,6 +532,7 @@ export const ticketFiltersMachine = setup({
         urlFilters,
         currentSearchParams: event.searchParams,
         setSearchParams: event.setSearchParams,
+        activeViewId,
       };
 
       // Store optional properties only if they exist
@@ -553,6 +566,14 @@ export const ticketFiltersMachine = setup({
     updateFilters: assign(({ event, context }) => {
       if (event.type !== 'SET_FILTERS') return context;
       return { ...context, filters: event.filters };
+    }),
+
+    /**
+     * Update activeViewId in context
+     */
+    updateActiveViewId: assign(({ event, context }) => {
+      if (event.type !== 'SET_ACTIVE_VIEW_ID') return context;
+      return { ...context, activeViewId: event.activeViewId };
     }),
 
     /**
@@ -661,6 +682,7 @@ export const ticketFiltersMachine = setup({
         context.groupBy,
         context.showOverdueOnly,
         context.showSubStatus,
+        context.activeViewId,
       );
     },
 
@@ -733,6 +755,7 @@ export const ticketFiltersMachine = setup({
     enabled: true,
     storageKey: `${STORAGE_KEY_PREFIX}-default`,
     urlFilters: {},
+    activeViewId: null,
   },
   states: {
     /**
@@ -775,6 +798,9 @@ export const ticketFiltersMachine = setup({
         },
         URL_CHANGED: {
           actions: ['syncFromUrl', 'applyUrlFilters', 'saveToStorage'],
+        },
+        SET_ACTIVE_VIEW_ID: {
+          actions: ['updateActiveViewId', 'saveToStorage'],
         },
       },
     },

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -201,6 +201,7 @@ import { AutoLabelWizard } from '../../components/xyne-desk/AutoLabelWizard/Auto
 import { DeskReportPanel } from '../../components/xyne-desk/DeskReport';
 import { DeskSavedViewsControls } from '../../components/xyne-desk/DeskSavedViewsControls';
 import { useDeskTicketSavedViews } from '../../hooks/useDeskTicketSavedViews';
+import { valuesToFilters } from '../../utils/savedViewSerialization';
 import {
   useChannelIntegrationInfo,
   clearChannelConnectedEmailCache,
@@ -882,7 +883,13 @@ const SupportScreen = (): ReactElement => {
   // Desk ticket saved views
   const ticketViewsChannelId =
     selectedChannelId && selectedChannelId !== ALL_CHANNELS_ID ? selectedChannelId : '';
-  const [activeTicketViewId, setActiveTicketViewId] = useState<string | null>(null);
+  const activeTicketViewId = filtersState.context.activeViewId;
+  const setActiveTicketViewId = useCallback(
+    (id: string | null) => {
+      sendFilters({ type: 'SET_ACTIVE_VIEW_ID', activeViewId: id });
+    },
+    [sendFilters],
+  );
   const {
     savedViews: deskSavedViews,
     saveView: saveDeskView,
@@ -907,6 +914,26 @@ const SupportScreen = (): ReactElement => {
   const handleUpdateDeskView = async (viewId: string): Promise<void> => {
     await updateDeskView(viewId, filters);
   };
+
+  const isDeskViewDirty = useMemo(() => {
+    if (!activeTicketViewId) return false;
+    const activeView = deskSavedViews.find(v => v.id === activeTicketViewId);
+    if (!activeView?.values) return false;
+    const viewFilters = valuesToFilters(activeView.values);
+    const sortDeep = (v: unknown): unknown => {
+      if (Array.isArray(v)) return v.map(sortDeep);
+      if (v !== null && typeof v === 'object') {
+        const rec = v as Record<string, unknown>;
+        return Object.fromEntries(
+          Object.keys(rec)
+            .sort()
+            .map(k => [k, sortDeep(rec[k])]),
+        );
+      }
+      return v;
+    };
+    return JSON.stringify(sortDeep(filters)) !== JSON.stringify(sortDeep(viewFilters));
+  }, [activeTicketViewId, deskSavedViews, filters]);
 
   const {
     rowRef: filterRowRef,
@@ -3370,18 +3397,29 @@ const SupportScreen = (): ReactElement => {
                             )}
                           </Popover.Root>
 
-                          {hasAnyFilterActive && (
+                          {(isDeskViewDirty || (!activeTicketViewId && hasAnyFilterActive)) && (
                             <Button
                               variant='outline'
                               size='sm'
                               className='rounded-[10px] border-border hover:bg-muted text-muted-foreground'
-                              onClick={() => setFilters({})}
+                              onClick={() => {
+                                const activeView = deskSavedViews.find(
+                                  v => v.id === activeTicketViewId,
+                                );
+                                if (activeView) {
+                                  applyDeskSavedView(activeView);
+                                } else {
+                                  setFilters({});
+                                }
+                              }}
                               data-track-category='Support'
                               data-track-name='CLEAR_SUPPORT_FILTERS'
                             >
                               <div className='flex items-center gap-1.5'>
                                 <X className='w-3 h-3' />
-                                <span className='font-medium'>Clear</span>
+                                <span className='font-medium'>
+                                  {activeTicketViewId ? 'Reset view' : 'Clear'}
+                                </span>
                               </div>
                             </Button>
                           )}
@@ -3498,7 +3536,8 @@ const SupportScreen = (): ReactElement => {
                             onSave={handleSaveDeskView}
                             onUpdate={handleUpdateDeskView}
                             onDelete={deleteDeskView}
-                            hasActiveFilters={hasAnyFilterActive}
+                            currentFilters={filters}
+                            dynamicFieldDefs={deskDynamicFields}
                             trackCategory='Support'
                           />
                         )}

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -8,6 +8,7 @@ import {
   NotificationLevel,
   AutoDraftStatus,
   MailboxState,
+  SavedConfigVisibility,
 } from '@xyne/shared';
 import React, { ReactElement, useMemo, useState, useEffect, useCallback, useRef } from 'react';
 import { toast } from 'sonner';
@@ -198,6 +199,8 @@ import { DeskMetricsDashboard } from '../../components/xyne-desk/DeskMetrics';
 import { TopicsExplorer } from '../../components/xyne-desk/TopicsExplorer';
 import { AutoLabelWizard } from '../../components/xyne-desk/AutoLabelWizard/AutoLabelWizard';
 import { DeskReportPanel } from '../../components/xyne-desk/DeskReport';
+import { DeskSavedViewsControls } from '../../components/xyne-desk/DeskSavedViewsControls';
+import { useDeskTicketSavedViews } from '../../hooks/useDeskTicketSavedViews';
 import {
   useChannelIntegrationInfo,
   clearChannelConnectedEmailCache,
@@ -875,6 +878,35 @@ const SupportScreen = (): ReactElement => {
   const hasMoreFiltersActive = moreFiltersActiveCount > 0;
   const hasAnyFilterActive =
     hasAssigneeFilter || hasPriorityFilter || hasStagesFilter || hasMoreFiltersActive;
+
+  // Desk ticket saved views
+  const ticketViewsChannelId =
+    selectedChannelId && selectedChannelId !== ALL_CHANNELS_ID ? selectedChannelId : '';
+  const [activeTicketViewId, setActiveTicketViewId] = useState<string | null>(null);
+  const {
+    savedViews: deskSavedViews,
+    saveView: saveDeskView,
+    updateView: updateDeskView,
+    deleteView: deleteDeskView,
+    applySavedView: applyDeskSavedView,
+  } = useDeskTicketSavedViews(ticketViewsChannelId, setFilters);
+  const [myAdminParticipations] = useCachedQuery(queries.myChannelParticipations({}), {
+    enabled: !!ticketViewsChannelId,
+  });
+  const isTicketViewsChannelAdmin = (myAdminParticipations ?? []).some(
+    p => p.channelId === ticketViewsChannelId,
+  );
+
+  const handleSaveDeskView = async (
+    name: string,
+    visibility: SavedConfigVisibility,
+  ): Promise<string | undefined> => {
+    return saveDeskView(name, filters, visibility);
+  };
+
+  const handleUpdateDeskView = async (viewId: string): Promise<void> => {
+    await updateDeskView(viewId, filters);
+  };
 
   const {
     rowRef: filterRowRef,
@@ -3454,6 +3486,22 @@ const SupportScreen = (): ReactElement => {
                         </Popover.Root>
                       )}
                       <div ref={actionsRestRef} className='flex items-center gap-2'>
+                        {/* Desk saved views — only shown when a specific channel is selected */}
+                        {ticketViewsChannelId && (
+                          <DeskSavedViewsControls
+                            savedViews={deskSavedViews}
+                            activeViewId={activeTicketViewId}
+                            onActiveViewChange={setActiveTicketViewId}
+                            currentUserId={userID}
+                            isChannelAdmin={isTicketViewsChannelAdmin}
+                            onApply={view => applyDeskSavedView(view)}
+                            onSave={handleSaveDeskView}
+                            onUpdate={handleUpdateDeskView}
+                            onDelete={deleteDeskView}
+                            hasActiveFilters={hasAnyFilterActive}
+                            trackCategory='Support'
+                          />
+                        )}
                         {/* View Toggle */}
                         <div className='flex items-center border border-border rounded-lg overflow-hidden'>
                           <button

--- a/apps/dashboard/src/utils/savedViewSerialization.ts
+++ b/apps/dashboard/src/utils/savedViewSerialization.ts
@@ -1,7 +1,8 @@
 import { SavedConfigEntityName, TicketPriority } from '@xyne/shared';
+import { v4 as uuidv4 } from 'uuid';
 import type { TicketFilters } from '../components/Tickets/TicketFilters/types';
 
-type SavedConfigValueRow = {
+export type SavedConfigValueRow = {
   entityName: SavedConfigEntityName;
   fieldName: string;
   fieldValue: string;
@@ -84,9 +85,101 @@ export function valuesToFilters(values: ReadonlyArray<SavedConfigValueRow>): Tic
       case 'createdDateEnd':
         result.createdDateEnd = Number(fieldValue);
         break;
+      // Desk-specific fields
+      case 'aiCategory':
+        result.aiCategory = [...(result.aiCategory ?? []), fieldValue];
+        break;
+      case 'generatedTags':
+        result.generatedTags = [...(result.generatedTags ?? []), fieldValue];
+        break;
+      case 'assigned':
+        result.assigned = fieldValue === 'true';
+        break;
+      case 'hasAiDraft':
+        result.hasAiDraft = fieldValue === 'true';
+        break;
+      case 'hasSubTickets':
+        result.hasSubTickets = fieldValue === 'true';
+        break;
+      case 'conversationLabelId':
+        result.conversationLabelId = fieldValue;
+        break;
+      case 'lastEmailAtStart':
+        result.lastEmailAtStart = Number(fieldValue);
+        break;
+      case 'lastEmailAtEnd':
+        result.lastEmailAtEnd = Number(fieldValue);
+        break;
     }
   }
   return result;
+}
+
+type DeskValueRow = {
+  id: string;
+  entityName: SavedConfigEntityName;
+  fieldName: string;
+  fieldValue: string;
+};
+
+/** Serialize TicketFilters (including desk-specific fields) to saved-view value rows. */
+export function deskFiltersToValues(filters: TicketFilters): DeskValueRow[] {
+  const values: DeskValueRow[] = [];
+
+  const addTicket = (fieldName: string, fieldValue: string): void => {
+    values.push({ id: uuidv4(), entityName: SavedConfigEntityName.TICKET, fieldName, fieldValue });
+  };
+  const addForm = (fieldName: string, fieldValue: string): void => {
+    values.push({
+      id: uuidv4(),
+      entityName: SavedConfigEntityName.FORM_ENTITY_VALUE,
+      fieldName,
+      fieldValue,
+    });
+  };
+
+  // Standard ticket fields
+  filters.priority?.forEach(v => addTicket('priority', v));
+  filters.assignee?.forEach(v => addTicket('assignee', v));
+  filters.userGroups?.forEach(v => addTicket('userGroups', v));
+  filters.createdBy?.forEach(v => addTicket('createdBy', v));
+  filters.stages?.forEach(v => addTicket('stages', v));
+  filters.ticketTypes?.forEach(v => addTicket('ticketTypes', v));
+  filters.sourceChannels?.forEach(v => addTicket('sourceChannels', v));
+  filters.tags?.forEach(v => addTicket('tags', v));
+  if (filters.dueDateStart !== undefined) addTicket('dueDateStart', String(filters.dueDateStart));
+  if (filters.dueDateEnd !== undefined) addTicket('dueDateEnd', String(filters.dueDateEnd));
+  if (filters.createdDateStart !== undefined)
+    addTicket('createdDateStart', String(filters.createdDateStart));
+  if (filters.createdDateEnd !== undefined)
+    addTicket('createdDateEnd', String(filters.createdDateEnd));
+
+  // Desk-specific fields
+  filters.aiCategory?.forEach(v => addTicket('aiCategory', v));
+  filters.generatedTags?.forEach(v => addTicket('generatedTags', v));
+  if (filters.assigned !== undefined) addTicket('assigned', String(filters.assigned));
+  if (filters.hasAiDraft !== undefined) addTicket('hasAiDraft', String(filters.hasAiDraft));
+  if (filters.hasSubTickets !== undefined)
+    addTicket('hasSubTickets', String(filters.hasSubTickets));
+  if (filters.conversationLabelId) addTicket('conversationLabelId', filters.conversationLabelId);
+  if (filters.lastEmailAtStart !== undefined)
+    addTicket('lastEmailAtStart', String(filters.lastEmailAtStart));
+  if (filters.lastEmailAtEnd !== undefined)
+    addTicket('lastEmailAtEnd', String(filters.lastEmailAtEnd));
+
+  // Dynamic form fields
+  if (filters.dynamicFields) {
+    Object.entries(filters.dynamicFields).forEach(([fieldId, val]) => {
+      if (Array.isArray(val)) {
+        val.forEach(v => addForm(fieldId, v));
+      } else {
+        if (val.start !== undefined) addForm(`${fieldId}.start`, String(val.start));
+        if (val.end !== undefined) addForm(`${fieldId}.end`, String(val.end));
+      }
+    });
+  }
+
+  return values;
 }
 
 interface ShareableView {

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -10894,10 +10894,18 @@ export const mutators = defineMutators({
         args: { id, name, contextType, contextId, visibility, timestamp, values },
       }) => {
         const allUserConfigs = await tx.run(
-          zql.saved_user_configurations.where('userId', ctx.userID).where('contextId', contextId),
+          zql.saved_user_configurations
+            .where('userId', ctx.userID)
+            .where('contextType', contextType)
+            .where('contextId', contextId),
         );
+        const isDeskContext = contextType === SavedConfigContextType.DESK_TICKET;
         if (allUserConfigs.some(c => c.name.toLowerCase() === name.toLowerCase())) {
-          throw new Error('A saved view with this name already exists for this board');
+          throw new Error(
+            isDeskContext
+              ? 'A saved view with this name already exists for this channel'
+              : 'A saved view with this name already exists for this board',
+          );
         }
 
         await tx.mutate.saved_user_configurations.insert({
@@ -10957,6 +10965,7 @@ export const mutators = defineMutators({
           const allUserConfigs = await tx.run(
             zql.saved_user_configurations
               .where('userId', ctx.userID)
+              .where('contextType', config.contextType)
               .where('contextId', config.contextId),
           );
           if (
@@ -10964,7 +10973,12 @@ export const mutators = defineMutators({
               c => c.id !== configId && c.name.toLowerCase() === name.toLowerCase(),
             )
           ) {
-            throw new Error('A saved view with this name already exists for this board');
+            const isDesk = config.contextType === SavedConfigContextType.DESK_TICKET;
+            throw new Error(
+              isDesk
+                ? 'A saved view with this name already exists for this channel'
+                : 'A saved view with this name already exists for this board',
+            );
           }
         }
 

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -12,6 +12,7 @@ import {
   LookupType,
   ProjectType,
   SavedConfigContextType,
+  SavedConfigVisibility,
   ShareableEntityType,
   SummaryTemplateVisibility,
 } from './schema.js';
@@ -4442,9 +4443,24 @@ export const queries = defineQueries({
   savedConfigsByUser: defineQuery(z.object({ userId: z.string() }), ({ args: { userId } }) => {
     return zql.saved_user_configurations
       .where('userId', userId)
+      .where('contextType', SavedConfigContextType.BOARD)
       .related('values')
       .orderBy('createdAt', 'desc');
   }),
+
+  savedDeskTicketConfigsByChannel: defineQuery(
+    z.object({ channelId: z.string() }),
+    ({ args: { channelId }, ctx }) => {
+      return zql.saved_user_configurations
+        .where('contextType', SavedConfigContextType.DESK_TICKET)
+        .where('contextId', channelId)
+        .where(({ cmp, or }) =>
+          or(cmp('userId', '=', ctx.userID), cmp('visibility', '=', SavedConfigVisibility.PUBLIC)),
+        )
+        .related('values')
+        .orderBy('createdAt', 'desc');
+    },
+  ),
 
   savedConfigsSharedWithUser: defineQuery(
     z.object({ userId: z.string() }),

--- a/packages/shared/src/zero/types.ts
+++ b/packages/shared/src/zero/types.ts
@@ -981,6 +981,7 @@ export enum ProjectType {
 // @ts-ignore TS1294
 export enum SavedConfigContextType {
   BOARD = 'BOARD',
+  DESK_TICKET = 'DESK_TICKET',
 }
 
 // @ts-ignore TS1294


### PR DESCRIPTION

<img width="2560" height="1440" alt="Screenshot 2026-09-11 at 6 55 43 PM (2)" src="https://github.com/user-attachments/assets/51eaaf6c-110e-4a27-a0ec-df2d323d241c" />

<img width="2560" height="1440" alt="Screenshot 2026-09-11 at 6 56 03 PM (2)" src="https://github.com/user-attachments/assets/ab0c5d7c-707e-461e-b348-de518306df75" />

<img width="2560" height="1440" alt="Screenshot 2026-09-11 at 6 55 58 PM (2)" src="https://github.com/user-attachments/assets/b778e0d8-2ec2-4a66-8bd2-7048c553019d" />


Migration-Changes:
  - Added a comment for justification

Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
