### PR TITLE
feat: XYNE-61830 folders and folder conversations in the SDLC hub

### DIFF
--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -262,6 +262,8 @@ export const workflowTable = table("workflows")
     eventType: string(),
     automationSeriesId: string().optional(),
     scheduledAt: number().optional(),
+    folderId: string().optional(),
+    summary: string().optional(),
     createdAt: number(),
     updatedAt: number(),
   })
@@ -296,6 +298,8 @@ export const workflowExecutionStateTable = table("workflow_execution_states")
     context: string().optional(),
     output: string().optional(),
     currentStepIndex: number(),
+    pausePath: string().optional(),
+    pauseType: string().optional(),
   })
   .primaryKey("id");
 
@@ -1870,6 +1874,7 @@ export const canvasVersionTable = table("canvas_versions")
 export const canvasCommentThreadTable = table("canvas_comment_threads")
   .columns({
     id: string(),
+    workspaceId: string().optional(),
     canvasId: string(),
     blockId: string(),
     anchorText: string().optional(),
@@ -1886,6 +1891,7 @@ export const canvasCommentThreadTable = table("canvas_comment_threads")
 export const canvasCommentTable = table("canvas_comments")
   .columns({
     id: string(),
+    workspaceId: string().optional(),
     threadId: string(),
     canvasId: string(),
     body: string(),
@@ -2033,6 +2039,17 @@ export const sdlcArtifactTable = table("sdlc_artifacts")
     updatedAt: number(),
   })
   .primaryKey("artifactId");
+
+export const sdlcFolderTable = table("sdlc_folders")
+  .columns({
+    workspaceId: string(),
+    id: string(),
+    name: string(),
+    createdBy: string(),
+    createdAt: number(),
+    updatedAt: number(),
+  })
+  .primaryKey("id");
 
 export const sdlcTrackTable = table("sdlc_tracks")
   .columns({
@@ -2634,6 +2651,18 @@ export const savedUserConfigurationValueTable = table("saved_user_configuration_
     fieldValue: string(),
     createdAt: number(),
     updatedAt: number(),
+  })
+  .primaryKey("id");
+
+export const viewAccessTable = table("view_access")
+  .columns({
+    workspaceId: string(),
+    id: string(),
+    viewId: string(),
+    entityType: string(),
+    entityId: string(),
+    sharedBy: string(),
+    createdAt: number(),
   })
   .primaryKey("id");
 
@@ -4853,12 +4882,25 @@ export const savedUserConfigurationTableRelationships = relationships(savedUserC
     sourceField: ["id"],
     destField: ["configId"],
     destSchema: savedUserConfigurationValueTable,
+  }),
+  viewAccess: many({
+    sourceField: ["id"],
+    destField: ["viewId"],
+    destSchema: viewAccessTable,
   })
 }));
 
 export const savedUserConfigurationValueTableRelationships = relationships(savedUserConfigurationValueTable, ({ one }) => ({
   config: one({
     sourceField: ["configId"],
+    destField: ["id"],
+    destSchema: savedUserConfigurationTable,
+  })
+}));
+
+export const viewAccessTableRelationships = relationships(viewAccessTable, ({ one }) => ({
+  view: one({
+    sourceField: ["viewId"],
     destField: ["id"],
     destSchema: savedUserConfigurationTable,
   })
@@ -5163,6 +5205,7 @@ export const schema = createSchema(
       repoTable,
       sdlcEntityLinkTable,
       sdlcArtifactTable,
+      sdlcFolderTable,
       sdlcTrackTable,
       lookupValueTable,
       formTable,
@@ -5204,6 +5247,7 @@ export const schema = createSchema(
       appCommandTable,
       savedUserConfigurationTable,
       savedUserConfigurationValueTable,
+      viewAccessTable,
       delayedMessageTable,
       dataSourceTable,
       dataSourceTableTable,
@@ -5327,6 +5371,7 @@ export const schema = createSchema(
       appCommandTableRelationships,
       savedUserConfigurationTableRelationships,
       savedUserConfigurationValueTableRelationships,
+      viewAccessTableRelationships,
       dataSourceTableRelationships,
       dataSourceTableTableRelationships,
       dataSourceColumnTableRelationships,
@@ -5467,6 +5512,7 @@ export type VespaInsertionLogs = Row<typeof schema.tables.vespa_insertion_logs>;
 export type Repo = Row<typeof schema.tables.repos>;
 export type SdlcEntityLink = Row<typeof schema.tables.sdlc_entity_links>;
 export type SdlcArtifact = Row<typeof schema.tables.sdlc_artifacts>;
+export type SdlcFolder = Row<typeof schema.tables.sdlc_folders>;
 export type SdlcTrack = Row<typeof schema.tables.sdlc_tracks>;
 export type LookupValue = Row<typeof schema.tables.lookup_values>;
 export type Form = Row<typeof schema.tables.forms>;
@@ -5508,6 +5554,7 @@ export type AppIncomingWebhook = Row<typeof schema.tables.app_incoming_webhooks>
 export type AppCommand = Row<typeof schema.tables.app_commands>;
 export type SavedUserConfiguration = Row<typeof schema.tables.saved_user_configurations>;
 export type SavedUserConfigurationValue = Row<typeof schema.tables.saved_user_configuration_values>;
+export type ViewAccess = Row<typeof schema.tables.view_access>;
 export type DelayedMessage = Row<typeof schema.tables.delayed_messages>;
 export type DataSource = Row<typeof schema.tables.data_sources>;
 export type DataSourceTable = Row<typeof schema.tables.data_source_tables>;

--- a/apps/backend/prisma/migrations/20260909120000_sdlc_folders/migration.sql
+++ b/apps/backend/prisma/migrations/20260909120000_sdlc_folders/migration.sql
@@ -1,0 +1,13 @@
+
+CREATE TABLE "public"."sdlc_folders" (
+    "workspaceId" TEXT NOT NULL,
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "sdlc_folders_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "sdlc_folders_workspaceId_idx" ON "public"."sdlc_folders"("workspaceId");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -3375,6 +3375,30 @@ model SdlcArtifact {
 // SDLC track: a named workstream inside a hub. Which hub is the CHANNEL -> TRACK edge in
 // sdlc_entity_links; the track row itself carries no scope. Groups canvases and tickets
 // through TRACK -> * TRACK_ITEM edges in the same table.
+/// A user-made folder for grouping artifacts inside a track.
+///
+/// Carries a name and nothing else. Where a folder sits — at a track's root or
+/// inside another folder — is an edge in sdlc_entity_links, and that edge holds
+/// the hub, so no scope column belongs here: the same arrangement as SdlcTrack,
+/// which is placed by its CHANNEL -> TRACK edge. Keeping placement in one place
+/// also keeps nesting and the set of things a folder can hold open, rather than
+/// fixing either in columns.
+///
+/// Distinct from CanvasFolder, which classifies artifacts by type (PRDs, Tech
+/// Docs) and is not user-made.
+model SdlcFolder {
+  workspaceId String
+  id          String   @id @default(cuid())
+  name        String
+  createdBy   String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([workspaceId])
+  @@map("sdlc_folders")
+  @@schema("public")
+}
+
 model SdlcTrack {
   workspaceId String
   id          String   @id @default(cuid())

--- a/apps/backend/src/api/sdk/v1/exclusions.json
+++ b/apps/backend/src/api/sdk/v1/exclusions.json
@@ -182,10 +182,6 @@
       "reason": "deferred:sdlc — the software-development-lifecycle subsystem (repos, links, baselines, discussions) is an internal surface driven by its own services and Claw execution profiles. Exposing it is a product decision, not an oversight."
     },
     {
-      "name": "sdlcRelatedConversations",
-      "reason": "deferred:sdlc — the software-development-lifecycle subsystem (repos, links, baselines, discussions) is an internal surface driven by its own services and Claw execution profiles. Exposing it is a product decision, not an oversight."
-    },
-    {
       "name": "sdlcTicketsByChannel",
       "kind": "query",
       "reason": "deferred:sdlc — the software-development-lifecycle subsystem (repos, links, baselines, discussions) is an internal surface driven by its own services and Claw execution profiles. Exposing it is a product decision, not an oversight.",

--- a/apps/backend/src/database/acl/acl-factory.ts
+++ b/apps/backend/src/database/acl/acl-factory.ts
@@ -296,6 +296,8 @@ export class ACLFactory {
       return new BaseQueryACL(ctx, prisma)
     case 'sdlcTrack':
       return new BaseQueryACL(ctx, prisma)
+    case 'sdlcFolder':
+      return new BaseQueryACL(ctx, prisma)
     case 'role':
       return new RolesACL(ctx, prisma)
     case 'savedUserConfiguration':

--- a/apps/backend/src/sdlc/SdlcHubService.ts
+++ b/apps/backend/src/sdlc/SdlcHubService.ts
@@ -1,7 +1,9 @@
 import { createHash, randomUUID } from 'crypto';
 import { Prisma, PrismaClient } from '@prisma/client';
 import {
+  SDLC_CONTAINMENT_RELATION,
   SDLC_MEMBERSHIP_RELATION,
+  SDLC_TRACK_FLAT_RELATION,
   SDLC_STRUCTURAL_RELATIONS,
   SDLC_TRACK_MEMBERSHIP_RELATION,
   CanvasVisibility,
@@ -908,6 +910,8 @@ export class SdlcHubService implements SdlcHub {
             },
           });
           if (input.kind !== 'BASELINE' && input.trackId) {
+            // Containment: a new artifact lands at the track's root, so the
+            // parent on the source side is the track itself.
             await tx.sdlcEntityLink.create({
               data: {
                 workspaceId: actor.workspaceId,
@@ -916,7 +920,22 @@ export class SdlcHubService implements SdlcHub {
                 sourceId: input.trackId,
                 targetType: 'CANVAS',
                 targetId: canvas.id,
-                relationType: 'TRACK_ITEM',
+                relationType: SDLC_CONTAINMENT_RELATION,
+                createdBy: actor.userId,
+              },
+            });
+            // And the flat edge, which keeps pointing at the track wherever the
+            // artifact is later filed. Written with the artifact so the two
+            // cannot drift apart.
+            await tx.sdlcEntityLink.create({
+              data: {
+                workspaceId: actor.workspaceId,
+                channelId: repo.channelId,
+                sourceType: 'TRACK',
+                sourceId: input.trackId,
+                targetType: 'CANVAS',
+                targetId: canvas.id,
+                relationType: SDLC_TRACK_FLAT_RELATION,
                 createdBy: actor.userId,
               },
             });

--- a/apps/backend/src/sdlc/SdlcHubService.ts
+++ b/apps/backend/src/sdlc/SdlcHubService.ts
@@ -1536,13 +1536,17 @@ export class SdlcHubService implements SdlcHub {
       // Propagate the source artifact's track onto the ticket so the ticket shows
       // under the same track (same TRACK_ITEM entity link we use for PRDs/Tech Docs).
       if (input.targetType === 'TICKET' && input.sourceType === 'CANVAS') {
+        // The flat edge, not containment: once an artifact is filed into a
+        // folder its containment edge is FOLDER -> CANVAS, and a TRACK source
+        // finds nothing — the ticket would be created and silently left off the
+        // track's list. Same lookup, same reason, as entityLinkService.
         const trackLink = await this.prisma.sdlcEntityLink.findFirst({
           where: {
             channelId: repo.channelId,
             sourceType: 'TRACK',
             targetType: 'CANVAS',
             targetId: input.sourceId,
-            relationType: 'TRACK_ITEM',
+            relationType: SDLC_TRACK_FLAT_RELATION,
           },
           select: { sourceId: true },
         });

--- a/apps/backend/src/sdlc/SdlcHubService.ts
+++ b/apps/backend/src/sdlc/SdlcHubService.ts
@@ -910,8 +910,6 @@ export class SdlcHubService implements SdlcHub {
             },
           });
           if (input.kind !== 'BASELINE' && input.trackId) {
-            // Containment: a new artifact lands at the track's root, so the
-            // parent on the source side is the track itself.
             await tx.sdlcEntityLink.create({
               data: {
                 workspaceId: actor.workspaceId,
@@ -924,9 +922,6 @@ export class SdlcHubService implements SdlcHub {
                 createdBy: actor.userId,
               },
             });
-            // And the flat edge, which keeps pointing at the track wherever the
-            // artifact is later filed. Written with the artifact so the two
-            // cannot drift apart.
             await tx.sdlcEntityLink.create({
               data: {
                 workspaceId: actor.workspaceId,
@@ -1536,10 +1531,6 @@ export class SdlcHubService implements SdlcHub {
       // Propagate the source artifact's track onto the ticket so the ticket shows
       // under the same track (same TRACK_ITEM entity link we use for PRDs/Tech Docs).
       if (input.targetType === 'TICKET' && input.sourceType === 'CANVAS') {
-        // The flat edge, not containment: once an artifact is filed into a
-        // folder its containment edge is FOLDER -> CANVAS, and a TRACK source
-        // finds nothing — the ticket would be created and silently left off the
-        // track's list. Same lookup, same reason, as entityLinkService.
         const trackLink = await this.prisma.sdlcEntityLink.findFirst({
           where: {
             channelId: repo.channelId,

--- a/apps/backend/src/sdlc/entityLinkService.ts
+++ b/apps/backend/src/sdlc/entityLinkService.ts
@@ -1,5 +1,5 @@
 import { Prisma, type PrismaClient } from '@prisma/client';
-import type { EntityLinkOwner } from '@xyne/shared';
+import { SDLC_TRACK_FLAT_RELATION, type EntityLinkOwner } from '@xyne/shared';
 import { logger } from '@/utils/logger';
 import { isCanvasInChannel, isTrackInChannel } from './sdlcChannelMembership';
 
@@ -31,14 +31,40 @@ export async function ensureLink(
   return { created: result.count > 0 };
 }
 
+/**
+ * The track a folder sits in. Read off the flat edge rather than walked up the
+ * containment chain: every folder gets one when it is created, so this is a
+ * single lookup at any depth.
+ */
+export async function resolveFolderTrackId(
+  db: Db,
+  folderId: string
+): Promise<string | null> {
+  const edge = await db.sdlcEntityLink.findFirst({
+    where: {
+      sourceType: 'TRACK',
+      targetType: 'FOLDER',
+      targetId: folderId,
+      relationType: SDLC_TRACK_FLAT_RELATION,
+    },
+    select: { sourceId: true },
+  });
+  return edge?.sourceId ?? null;
+}
+
 export async function validateOwnerInChannel(
   db: Db,
   owner: EntityLinkOwner,
   channelId: string
 ): Promise<boolean> {
-  return owner.sourceType === 'TRACK'
-    ? isTrackInChannel(db, owner.sourceId, channelId)
-    : isCanvasInChannel(db, owner.sourceId, channelId);
+  if (owner.sourceType === 'TRACK') {
+    return isTrackInChannel(db, owner.sourceId, channelId);
+  }
+  if (owner.sourceType === 'FOLDER') {
+    const trackId = await resolveFolderTrackId(db, owner.sourceId);
+    return trackId ? isTrackInChannel(db, trackId, channelId) : false;
+  }
+  return isCanvasInChannel(db, owner.sourceId, channelId);
 }
 
 export async function resolveInheritedOwner(
@@ -53,7 +79,10 @@ export async function resolveInheritedOwner(
     },
     select: { sourceType: true, sourceId: true },
   });
-  return link && (link.sourceType === 'CANVAS' || link.sourceType === 'TRACK')
+  return link &&
+    (link.sourceType === 'CANVAS' ||
+      link.sourceType === 'TRACK' ||
+      link.sourceType === 'FOLDER')
     ? { sourceType: link.sourceType, sourceId: link.sourceId }
     : null;
 }
@@ -120,13 +149,16 @@ export async function linkCreatedEntities(
         },
         actor
       );
+      // The flat edge, not containment: once an artifact is filed into a folder
+      // its containment edge is FOLDER -> CANVAS, and looking for a TRACK source
+      // would find nothing and silently drop the ticket's track.
       const trackEdge = await db.sdlcEntityLink.findFirst({
         where: {
           channelId,
           sourceType: 'TRACK',
           targetType: 'CANVAS',
           targetId: owner.sourceId,
-          relationType: 'TRACK_ITEM',
+          relationType: SDLC_TRACK_FLAT_RELATION,
         },
         select: { sourceId: true },
       });
@@ -145,18 +177,40 @@ export async function linkCreatedEntities(
         );
       }
     } else {
-      await ensureLink(
-        db,
-        {
-          channelId,
-          sourceType: 'TRACK',
-          sourceId: owner.sourceId,
-          targetType: 'TICKET',
-          targetId: ticketId,
-          relationType: 'TRACK_ITEM',
-        },
-        actor
-      );
+      if (owner.sourceType === 'FOLDER') {
+        await ensureLink(
+          db,
+          {
+            channelId,
+            sourceType: 'FOLDER',
+            sourceId: owner.sourceId,
+            targetType: 'TICKET',
+            targetId: ticketId,
+            relationType: 'TICKET',
+          },
+          actor
+        );
+      }
+      // Tickets are listed per track wherever they were raised, so a folder's
+      // resolve to the track the folder lives in.
+      const trackId =
+        owner.sourceType === 'FOLDER'
+          ? await resolveFolderTrackId(db, owner.sourceId)
+          : owner.sourceId;
+      if (trackId) {
+        await ensureLink(
+          db,
+          {
+            channelId,
+            sourceType: 'TRACK',
+            sourceId: trackId,
+            targetType: 'TICKET',
+            targetId: ticketId,
+            relationType: 'TRACK_ITEM',
+          },
+          actor
+        );
+      }
     }
   }
 }

--- a/apps/backend/src/sdlc/entityLinkService.ts
+++ b/apps/backend/src/sdlc/entityLinkService.ts
@@ -31,11 +31,6 @@ export async function ensureLink(
   return { created: result.count > 0 };
 }
 
-/**
- * The track a folder sits in. Read off the flat edge rather than walked up the
- * containment chain: every folder gets one when it is created, so this is a
- * single lookup at any depth.
- */
 export async function resolveFolderTrackId(
   db: Db,
   folderId: string
@@ -149,9 +144,6 @@ export async function linkCreatedEntities(
         },
         actor
       );
-      // The flat edge, not containment: once an artifact is filed into a folder
-      // its containment edge is FOLDER -> CANVAS, and looking for a TRACK source
-      // would find nothing and silently drop the ticket's track.
       const trackEdge = await db.sdlcEntityLink.findFirst({
         where: {
           channelId,
@@ -191,8 +183,6 @@ export async function linkCreatedEntities(
           actor
         );
       }
-      // Tickets are listed per track wherever they were raised, so a folder's
-      // resolve to the track the folder lives in.
       const trackId =
         owner.sourceType === 'FOLDER'
           ? await resolveFolderTrackId(db, owner.sourceId)

--- a/apps/backend/src/sdlc/sdlcNavTarget.ts
+++ b/apps/backend/src/sdlc/sdlcNavTarget.ts
@@ -2,7 +2,7 @@ import { ChannelType } from '@xyne/shared';
 import { sdlcSectionForCanvas, type SdlcNavTarget, type SdlcSection } from '@xyne/shared/sdlc';
 import { db } from '@/database/client';
 import { runAsSystem } from '@/database/tenant/context';
-import { resolveInheritedOwner } from './entityLinkService';
+import { resolveFolderTrackId, resolveInheritedOwner } from './entityLinkService';
 
 export interface SdlcNavIds {
   channelId?: string | null;
@@ -123,6 +123,12 @@ async function conversationLocation(conversationId: string): Promise<SdlcLocatio
   }
   if (owner.sourceType === 'TRACK') {
     return { section: 'tracks', trackId: owner.sourceId, discussionId: conversationId };
+  }
+  if (owner.sourceType === 'FOLDER') {
+    // A folder has no route of its own, and its conversations roll up to the
+    // track it lives in — which is where the reader will find this one.
+    const trackId = await resolveFolderTrackId(db, owner.sourceId);
+    return trackId ? { section: 'tracks', trackId, discussionId: conversationId } : null;
   }
   const canvas = await canvasLocation(owner.sourceId);
   return canvas ? { ...canvas, discussionId: conversationId } : null;

--- a/apps/backend/src/sdlc/sdlcNavTarget.ts
+++ b/apps/backend/src/sdlc/sdlcNavTarget.ts
@@ -125,8 +125,6 @@ async function conversationLocation(conversationId: string): Promise<SdlcLocatio
     return { section: 'tracks', trackId: owner.sourceId, discussionId: conversationId };
   }
   if (owner.sourceType === 'FOLDER') {
-    // A folder has no route of its own, and its conversations roll up to the
-    // track it lives in — which is where the reader will find this one.
     const trackId = await resolveFolderTrackId(db, owner.sourceId);
     return trackId ? { section: 'tracks', trackId, discussionId: conversationId } : null;
   }

--- a/apps/backend/src/zero/acl/core/acl-factory.ts
+++ b/apps/backend/src/zero/acl/core/acl-factory.ts
@@ -118,6 +118,7 @@ import { ReleaseChangesACL } from '../tables/release-changes-acl';
 import { ReleaseEventsACL } from '../tables/release-events-acl';
 import { ReposACL } from '../tables/repos-acl';
 import { SdlcEntityLinksACL } from '../tables/sdlc-entity-links-acl';
+import { SdlcFoldersACL } from '../tables/sdlc-folders-acl';
 import { SdlcTracksACL } from '../tables/sdlc-tracks-acl';
 import { StageApproversACL } from '../tables/stage-approvers-acl';
 import { StageTransitionsACL } from '../tables/stage-transitions-acl';
@@ -421,6 +422,8 @@ export class ACLFactory {
       case 'sdlc_artifacts':
         // Server-written provenance table: no client mutations (BaseACL denies all).
         return new BaseACL<any>(ctx);
+      case 'sdlc_folders':
+        return new SdlcFoldersACL(ctx);
       case 'sdlc_tracks':
         return new SdlcTracksACL(ctx);
       case 'stage_approvers':

--- a/apps/backend/src/zero/acl/tables/sdlc-folders-acl.ts
+++ b/apps/backend/src/zero/acl/tables/sdlc-folders-acl.ts
@@ -5,12 +5,6 @@ import { MutationACLError, type TableSchema } from '../core/types';
 import { assertWorkspaceMatch } from '../core/workspace-match';
 import { zql } from '../../queries';
 
-/**
- * A folder row carries only a name; where it sits and which hub it belongs to
- * are its containment edge, which sdlc_entity_links guards. So membership is
- * checked by the folder mutators that write the edge, and this ACL is left with
- * the tenant boundary — the same split as SdlcTracksACL.
- */
 export class SdlcFoldersACL extends BaseACL<'sdlc_folders'> {
   async canInsert(
     args: InsertValue<TableSchema<'sdlc_folders'>>,
@@ -19,7 +13,6 @@ export class SdlcFoldersACL extends BaseACL<'sdlc_folders'> {
     assertWorkspaceMatch(this.ctx, args.workspaceId, 'sdlc_folders');
   }
 
-  /** Renaming only; a folder has nothing else worth changing in place. */
   async canUpdate(
     args: UpdateValue<TableSchema<'sdlc_folders'>>,
     tx: Transaction<Schema>,
@@ -31,11 +24,6 @@ export class SdlcFoldersACL extends BaseACL<'sdlc_folders'> {
     assertWorkspaceMatch(this.ctx, row.workspaceId, 'sdlc_folders');
   }
 
-  /**
-   * Deleting a folder has to decide what happens to everything inside it and
-   * clear the edges on both sides, so it belongs to a mutator that can do the
-   * whole thing at once, not to a bare row delete that would strand children.
-   */
   async canDelete(
     _args: DeleteID<TableSchema<'sdlc_folders'>>,
     _tx: Transaction<Schema>,

--- a/apps/backend/src/zero/acl/tables/sdlc-folders-acl.ts
+++ b/apps/backend/src/zero/acl/tables/sdlc-folders-acl.ts
@@ -1,0 +1,55 @@
+import type { DeleteID, InsertValue, Transaction, UpdateValue, UpsertValue } from '@rocicorp/zero';
+import type { Schema } from '@xyne/shared';
+import { BaseACL } from '../core/base-acl';
+import { MutationACLError, type TableSchema } from '../core/types';
+import { assertWorkspaceMatch } from '../core/workspace-match';
+import { zql } from '../../queries';
+
+/**
+ * A folder row carries only a name; where it sits and which hub it belongs to
+ * are its containment edge, which sdlc_entity_links guards. So membership is
+ * checked by the folder mutators that write the edge, and this ACL is left with
+ * the tenant boundary — the same split as SdlcTracksACL.
+ */
+export class SdlcFoldersACL extends BaseACL<'sdlc_folders'> {
+  async canInsert(
+    args: InsertValue<TableSchema<'sdlc_folders'>>,
+    _tx: Transaction<Schema>,
+  ): Promise<void> {
+    assertWorkspaceMatch(this.ctx, args.workspaceId, 'sdlc_folders');
+  }
+
+  /** Renaming only; a folder has nothing else worth changing in place. */
+  async canUpdate(
+    args: UpdateValue<TableSchema<'sdlc_folders'>>,
+    tx: Transaction<Schema>,
+  ): Promise<void> {
+    const row = await tx.run(zql.sdlc_folders.where('id', args.id).one());
+    if (!row) {
+      throw new MutationACLError('SDLC folder does not exist', 'sdlc_folders');
+    }
+    assertWorkspaceMatch(this.ctx, row.workspaceId, 'sdlc_folders');
+  }
+
+  /**
+   * Deleting a folder has to decide what happens to everything inside it and
+   * clear the edges on both sides, so it belongs to a mutator that can do the
+   * whole thing at once, not to a bare row delete that would strand children.
+   */
+  async canDelete(
+    _args: DeleteID<TableSchema<'sdlc_folders'>>,
+    _tx: Transaction<Schema>,
+  ): Promise<void> {
+    throw new MutationACLError(
+      'Delete SDLC folders through the folder API so their contents are handled',
+      'sdlc_folders',
+    );
+  }
+
+  async canUpsert(
+    _args: UpsertValue<TableSchema<'sdlc_folders'>>,
+    _tx: Transaction<Schema>,
+  ): Promise<void> {
+    throw new MutationACLError('SDLC folders cannot be upserted', 'sdlc_folders');
+  }
+}

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -2544,8 +2544,6 @@ export function createMutators(
             if (existingDiscussion.length > 0) {
               throw new Error('Conversation already has an SDLC discussion owner');
             }
-            // Only a folder files a second, flat copy on its track; anything else
-            // carrying one would put a conversation in a list it does not belong to.
             if (entityLinkContext.trackRollUp && entityLinkContext.sourceType !== 'FOLDER') {
               throw new Error('Invalid SDLC discussion owner');
             }
@@ -2563,9 +2561,6 @@ export function createMutators(
                 throw new Error('Invalid SDLC discussion owner');
               }
             } else if (entityLinkContext.sourceType === 'FOLDER') {
-              // A folder has no scope column either. Its flat TRACK -> FOLDER edge
-              // names both the hub it lives in and the one track it may roll up to,
-              // so the same row answers both questions.
               const folderEdge = await tx.run(
                 zql.sdlc_entity_links
                   .where('channelId', channelId)
@@ -2626,8 +2621,6 @@ export function createMutators(
               createdBy: authData.sub,
               createdAt: now,
             });
-            // A folder's discussion is filed on its track too, so the track's
-            // conversation list is everything discussed anywhere inside it.
             if (entityLinkContext.trackRollUp) {
               await tx.mutate.sdlc_entity_links.insert({
                 id: entityLinkContext.trackRollUp.linkId,
@@ -11581,10 +11574,6 @@ export function createMutators(
           if (!participant) {
             throw new Error('Hub membership required');
           }
-          // Membership was checked against the channelId the caller sent, so the
-          // folder has to actually be in that hub — its flat placement edge is
-          // what says which one. Without this, being in any hub let you rename a
-          // folder in any other.
           const placement = await tx.run(
             zql.sdlc_entity_links
               .where('channelId', args.channelId)
@@ -11628,10 +11617,6 @@ export function createMutators(
           if (args.itemType === 'FOLDER' && args.itemId === args.parentId) {
             throw new Error('A folder cannot contain itself');
           }
-          // Containment moves; the flat edge does not. So the destination has to
-          // be in the same track, or the two would disagree about where the item
-          // lives and the finder would show it under a tree its track edge never
-          // names. Resolving the parent's track also proves it exists in this hub.
           const parentTrackId =
             args.parentType === 'TRACK'
               ? args.parentId
@@ -11675,8 +11660,6 @@ export function createMutators(
           if (existing.sourceId === args.parentId) {
             return;
           }
-          // Walk up from the new parent: dropping a folder inside its own subtree
-          // would detach that subtree from the track with nothing pointing at it.
           if (args.itemType === 'FOLDER') {
             let cursor: string | null = args.parentType === 'FOLDER' ? args.parentId : null;
             for (let depth = 0; cursor && depth < 64; depth += 1) {
@@ -11732,10 +11715,6 @@ export function createMutators(
           if (!participant) {
             throw new Error('Hub membership required');
           }
-          // The track has to be one of this hub's. Its placement edge is the only
-          // thing that says so — sdlc_tracks carries no scope column — and without
-          // this the flat edge below could name a track in another hub, which
-          // resolveFolderTrackId would then report for every downstream decision.
           const trackEdge = await tx.run(
             zql.sdlc_entity_links
               .where('channelId', args.channelId)
@@ -11747,10 +11726,7 @@ export function createMutators(
           if (!trackEdge) {
             throw new Error('Track not found in this hub');
           }
-          // A folder nests under a folder in the same track, never a stray id.
           if (args.parentType === 'FOLDER') {
-            // Existence is not enough: a parent from another track would put the
-            // folder in a tree its own flat edge never mentions.
             const parentTrack = await tx.run(
               zql.sdlc_entity_links
                 .where('channelId', args.channelId)

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -96,7 +96,9 @@ import {
   deskTypeForChannelType,
   Platform,
   SDLC_MEMBERSHIP_RELATION,
+  SDLC_CONTAINMENT_RELATION,
   SDLC_STRUCTURAL_RELATIONS,
+  SDLC_TRACK_FLAT_RELATION,
   SDLC_TRACK_MEMBERSHIP_RELATION,
   createSdlcLinkSchema,
   entityLinkContextSchema,
@@ -2542,6 +2544,11 @@ export function createMutators(
             if (existingDiscussion.length > 0) {
               throw new Error('Conversation already has an SDLC discussion owner');
             }
+            // Only a folder files a second, flat copy on its track; anything else
+            // carrying one would put a conversation in a list it does not belong to.
+            if (entityLinkContext.trackRollUp && entityLinkContext.sourceType !== 'FOLDER') {
+              throw new Error('Invalid SDLC discussion owner');
+            }
             if (entityLinkContext.sourceType === 'TRACK') {
               // A track has no scope column: its CHANNEL -> TRACK edge is the check.
               const trackEdge = await tx.run(
@@ -2553,6 +2560,28 @@ export function createMutators(
                   .one(),
               );
               if (!trackEdge) {
+                throw new Error('Invalid SDLC discussion owner');
+              }
+            } else if (entityLinkContext.sourceType === 'FOLDER') {
+              // A folder has no scope column either. Its flat TRACK -> FOLDER edge
+              // names both the hub it lives in and the one track it may roll up to,
+              // so the same row answers both questions.
+              const folderEdge = await tx.run(
+                zql.sdlc_entity_links
+                  .where('channelId', channelId)
+                  .where('sourceType', 'TRACK')
+                  .where('targetType', 'FOLDER')
+                  .where('targetId', entityLinkContext.sourceId)
+                  .where('relationType', SDLC_TRACK_FLAT_RELATION)
+                  .one(),
+              );
+              if (!folderEdge) {
+                throw new Error('Invalid SDLC discussion owner');
+              }
+              if (
+                entityLinkContext.trackRollUp &&
+                entityLinkContext.trackRollUp.trackId !== folderEdge.sourceId
+              ) {
                 throw new Error('Invalid SDLC discussion owner');
               }
             } else {
@@ -2597,6 +2626,22 @@ export function createMutators(
               createdBy: authData.sub,
               createdAt: now,
             });
+            // A folder's discussion is filed on its track too, so the track's
+            // conversation list is everything discussed anywhere inside it.
+            if (entityLinkContext.trackRollUp) {
+              await tx.mutate.sdlc_entity_links.insert({
+                id: entityLinkContext.trackRollUp.linkId,
+                workspaceId: authData.workspaceId,
+                channelId,
+                sourceType: 'TRACK',
+                sourceId: entityLinkContext.trackRollUp.trackId,
+                targetType: 'CONVERSATION',
+                targetId: conversationId,
+                relationType: SDLC_TRACK_FLAT_RELATION,
+                createdBy: authData.sub,
+                createdAt: now,
+              });
+            }
           }
 
           const message = {
@@ -11499,6 +11544,190 @@ export function createMutators(
             throw new Error('Structural SDLC edges are not deleted through the link API');
           }
           await tx.mutate.sdlc_entity_links.delete({ id: linkId });
+        },
+      ),
+
+      /**
+       * A folder, and the two edges that place it.
+       *
+       * The containment edge is the tree: its source is the parent, a TRACK at
+       * the root or a FOLDER below it. The flat edge always points from the
+       * track, so "everything in this track" stays one indexed lookup however
+       * deep the folder sits. Both are written here so the pair cannot drift.
+       */
+      /**
+       * Move an item to another parent inside the same track.
+       *
+       * A move is a delete and an insert, never an update: entity links are
+       * immutable by ACL. Both happen here so an item cannot end up with two
+       * parents or none. The flat track edge is untouched — the item stays in the
+       * same track, which is the whole point of keeping that edge separate.
+       */
+      /** Rename a folder. Its placement and contents are untouched. */
+      renameSdlcFolder: defineMutator(
+        z.object({
+          folderId: z.string(),
+          channelId: z.string(),
+          name: z.string().trim().min(1).max(120),
+          timestamp: z.number(),
+        }),
+        async ({ tx, args }) => {
+          const participant = await tx.run(
+            zql.channel_participants
+              .where('channelId', args.channelId)
+              .where('userId', authData.sub)
+              .one(),
+          );
+          if (!participant) {
+            throw new Error('Hub membership required');
+          }
+          const folder = await tx.run(zql.sdlc_folders.where('id', args.folderId).one());
+          if (!folder) {
+            throw new Error('Folder not found');
+          }
+          await tx.mutate.sdlc_folders.update({
+            id: args.folderId,
+            name: args.name,
+            updatedAt: args.timestamp,
+          });
+        },
+      ),
+
+      moveSdlcItem: defineMutator(
+        z.object({
+          linkId: z.string(),
+          channelId: z.string(),
+          itemType: z.enum(['FOLDER', 'CANVAS']),
+          itemId: z.string(),
+          parentType: z.enum(['TRACK', 'FOLDER']),
+          parentId: z.string(),
+          timestamp: z.number(),
+        }),
+        async ({ tx, args }) => {
+          const participant = await tx.run(
+            zql.channel_participants
+              .where('channelId', args.channelId)
+              .where('userId', authData.sub)
+              .one(),
+          );
+          if (!participant) {
+            throw new Error('Hub membership required');
+          }
+          if (args.itemType === 'FOLDER' && args.itemId === args.parentId) {
+            throw new Error('A folder cannot contain itself');
+          }
+          const existing = await tx.run(
+            zql.sdlc_entity_links
+              .where('channelId', args.channelId)
+              .where('relationType', SDLC_CONTAINMENT_RELATION)
+              .where('targetType', args.itemType)
+              .where('targetId', args.itemId)
+              .one(),
+          );
+          if (!existing) {
+            throw new Error('Item is not filed anywhere');
+          }
+          if (existing.sourceId === args.parentId) {
+            return;
+          }
+          // Walk up from the new parent: dropping a folder inside its own subtree
+          // would detach that subtree from the track with nothing pointing at it.
+          if (args.itemType === 'FOLDER') {
+            let cursor: string | null = args.parentType === 'FOLDER' ? args.parentId : null;
+            for (let depth = 0; cursor && depth < 64; depth += 1) {
+              if (cursor === args.itemId) {
+                throw new Error('A folder cannot be moved inside itself');
+              }
+              const parentEdge = await tx.run(
+                zql.sdlc_entity_links
+                  .where('channelId', args.channelId)
+                  .where('relationType', SDLC_CONTAINMENT_RELATION)
+                  .where('targetType', 'FOLDER')
+                  .where('targetId', cursor)
+                  .one(),
+              );
+              cursor = parentEdge?.sourceType === 'FOLDER' ? parentEdge.sourceId : null;
+            }
+          }
+          await tx.mutate.sdlc_entity_links.delete({ id: existing.id });
+          await tx.mutate.sdlc_entity_links.insert({
+            id: args.linkId,
+            workspaceId: authData.workspaceId,
+            channelId: args.channelId,
+            sourceType: args.parentType,
+            sourceId: args.parentId,
+            targetType: args.itemType,
+            targetId: args.itemId,
+            relationType: SDLC_CONTAINMENT_RELATION,
+            createdBy: authData.sub,
+            createdAt: args.timestamp,
+          });
+        },
+      ),
+
+      createSdlcFolder: defineMutator(
+        z.object({
+          id: z.string(),
+          containmentLinkId: z.string(),
+          flatLinkId: z.string(),
+          channelId: z.string(),
+          trackId: z.string(),
+          parentType: z.enum(['TRACK', 'FOLDER']),
+          parentId: z.string(),
+          name: z.string().trim().min(1).max(120),
+          timestamp: z.number(),
+        }),
+        async ({ tx, args }) => {
+          const participant = await tx.run(
+            zql.channel_participants
+              .where('channelId', args.channelId)
+              .where('userId', authData.sub)
+              .one(),
+          );
+          if (!participant) {
+            throw new Error('Hub membership required');
+          }
+          // A folder nests under a folder in the same track, never a stray id.
+          if (args.parentType === 'FOLDER') {
+            const parent = await tx.run(zql.sdlc_folders.where('id', args.parentId).one());
+            if (!parent) {
+              throw new Error('Parent folder not found');
+            }
+          } else if (args.parentId !== args.trackId) {
+            throw new Error('A root folder belongs to the track it is created in');
+          }
+          await tx.mutate.sdlc_folders.insert({
+            id: args.id,
+            workspaceId: authData.workspaceId,
+            name: args.name,
+            createdBy: authData.sub,
+            createdAt: args.timestamp,
+            updatedAt: args.timestamp,
+          });
+          await tx.mutate.sdlc_entity_links.insert({
+            id: args.containmentLinkId,
+            workspaceId: authData.workspaceId,
+            channelId: args.channelId,
+            sourceType: args.parentType,
+            sourceId: args.parentId,
+            targetType: 'FOLDER',
+            targetId: args.id,
+            relationType: SDLC_CONTAINMENT_RELATION,
+            createdBy: authData.sub,
+            createdAt: args.timestamp,
+          });
+          await tx.mutate.sdlc_entity_links.insert({
+            id: args.flatLinkId,
+            workspaceId: authData.workspaceId,
+            channelId: args.channelId,
+            sourceType: 'TRACK',
+            sourceId: args.trackId,
+            targetType: 'FOLDER',
+            targetId: args.id,
+            relationType: SDLC_TRACK_FLAT_RELATION,
+            createdBy: authData.sub,
+            createdAt: args.timestamp,
+          });
         },
       ),
 

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -11581,9 +11581,21 @@ export function createMutators(
           if (!participant) {
             throw new Error('Hub membership required');
           }
-          const folder = await tx.run(zql.sdlc_folders.where('id', args.folderId).one());
-          if (!folder) {
-            throw new Error('Folder not found');
+          // Membership was checked against the channelId the caller sent, so the
+          // folder has to actually be in that hub — its flat placement edge is
+          // what says which one. Without this, being in any hub let you rename a
+          // folder in any other.
+          const placement = await tx.run(
+            zql.sdlc_entity_links
+              .where('channelId', args.channelId)
+              .where('sourceType', 'TRACK')
+              .where('targetType', 'FOLDER')
+              .where('targetId', args.folderId)
+              .where('relationType', SDLC_TRACK_FLAT_RELATION)
+              .one(),
+          );
+          if (!placement) {
+            throw new Error('Folder not found in this hub');
           }
           await tx.mutate.sdlc_folders.update({
             id: args.folderId,
@@ -11615,6 +11627,39 @@ export function createMutators(
           }
           if (args.itemType === 'FOLDER' && args.itemId === args.parentId) {
             throw new Error('A folder cannot contain itself');
+          }
+          // Containment moves; the flat edge does not. So the destination has to
+          // be in the same track, or the two would disagree about where the item
+          // lives and the finder would show it under a tree its track edge never
+          // names. Resolving the parent's track also proves it exists in this hub.
+          const parentTrackId =
+            args.parentType === 'TRACK'
+              ? args.parentId
+              : ((
+                  await tx.run(
+                    zql.sdlc_entity_links
+                      .where('channelId', args.channelId)
+                      .where('sourceType', 'TRACK')
+                      .where('targetType', 'FOLDER')
+                      .where('targetId', args.parentId)
+                      .where('relationType', SDLC_TRACK_FLAT_RELATION)
+                      .one(),
+                  )
+                )?.sourceId ?? null);
+          if (!parentTrackId) {
+            throw new Error('Destination folder not found in this hub');
+          }
+          const itemTrackEdge = await tx.run(
+            zql.sdlc_entity_links
+              .where('channelId', args.channelId)
+              .where('sourceType', 'TRACK')
+              .where('targetType', args.itemType)
+              .where('targetId', args.itemId)
+              .where('relationType', SDLC_TRACK_FLAT_RELATION)
+              .one(),
+          );
+          if (!itemTrackEdge || itemTrackEdge.sourceId !== parentTrackId) {
+            throw new Error('An item can only be moved within its own track');
           }
           const existing = await tx.run(
             zql.sdlc_entity_links
@@ -11687,11 +11732,36 @@ export function createMutators(
           if (!participant) {
             throw new Error('Hub membership required');
           }
+          // The track has to be one of this hub's. Its placement edge is the only
+          // thing that says so — sdlc_tracks carries no scope column — and without
+          // this the flat edge below could name a track in another hub, which
+          // resolveFolderTrackId would then report for every downstream decision.
+          const trackEdge = await tx.run(
+            zql.sdlc_entity_links
+              .where('channelId', args.channelId)
+              .where('targetType', 'TRACK')
+              .where('targetId', args.trackId)
+              .where('relationType', SDLC_TRACK_MEMBERSHIP_RELATION)
+              .one(),
+          );
+          if (!trackEdge) {
+            throw new Error('Track not found in this hub');
+          }
           // A folder nests under a folder in the same track, never a stray id.
           if (args.parentType === 'FOLDER') {
-            const parent = await tx.run(zql.sdlc_folders.where('id', args.parentId).one());
-            if (!parent) {
-              throw new Error('Parent folder not found');
+            // Existence is not enough: a parent from another track would put the
+            // folder in a tree its own flat edge never mentions.
+            const parentTrack = await tx.run(
+              zql.sdlc_entity_links
+                .where('channelId', args.channelId)
+                .where('sourceType', 'TRACK')
+                .where('targetType', 'FOLDER')
+                .where('targetId', args.parentId)
+                .where('relationType', SDLC_TRACK_FLAT_RELATION)
+                .one(),
+            );
+            if (!parentTrack || parentTrack.sourceId !== args.trackId) {
+              throw new Error('Parent folder belongs to another track');
             }
           } else if (args.parentId !== args.trackId) {
             throw new Error('A root folder belongs to the track it is created in');

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -4467,11 +4467,6 @@ dmChannelsLatestMessagesPaginated: defineQuery(
       .where(helpers =>
         helpers.cmp('relationType', 'NOT IN', [...SDLC_HUB_GRAPH_EXCLUDED_RELATIONS]),
       )
-      // The flat edge is worth syncing for artifacts and conversations, which
-      // readers here resolve back to a track. Its FOLDER rows are the largest
-      // group in the graph and no reader touches them — the finder gets folders
-      // from getSdlcFoldersByChannel, which matches this edge server-side. Cut by
-      // target rather than by a whitelist, so a new flat target still arrives.
       .where(helpers =>
         helpers.or(
           helpers.cmp('relationType', '!=', SDLC_TRACK_FLAT_RELATION),

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -30,7 +30,10 @@ import {
   AttachmentEntityType,
   ChannelType,
   SDLC_MEMBERSHIP_RELATION,
-  SDLC_STRUCTURAL_RELATIONS,
+  SDLC_CONTAINMENT_RELATION,
+  SDLC_HUB_GRAPH_EXCLUDED_RELATIONS,
+  SDLC_TREE_TARGET_TYPES,
+  SDLC_TRACK_FLAT_RELATION,
   SDLC_TRACK_MEMBERSHIP_RELATION,
   EmailType,
   ActivityClassification, LinkVisibility,
@@ -4396,7 +4399,47 @@ dmChannelsLatestMessagesPaginated: defineQuery(
       )
       .one(),
   ),
+  /**
+   * One level of a track's folder tree: the things directly inside `parentId`.
+   *
+   * Containment is an edge, so this is the same query at every depth — only the
+   * parent changes, from the TRACK at the root to a FOLDER below it. Covered by
+   * the (sourceType, sourceId, relationType) index.
+   *
+   * The entities themselves are fetched separately by id: sourceId and targetId
+   * are polymorphic, so no relation covers them. The targetType filter keeps the
+   * tree to things it can render — TRACK -> TICKET edges share this relationType
+   * and are not part of the folder tree.
+   */
+  getSdlcFolderChildren: defineQuery(
+    z.object({
+      channelId: z.string(),
+      parentType: z.enum(['TRACK', 'FOLDER']),
+      parentId: z.string(),
+    }),
+    ({ args: { channelId, parentType, parentId } }) =>
+      zql.sdlc_entity_links
+        .where('channelId', channelId)
+        .where('relationType', SDLC_CONTAINMENT_RELATION)
+        .where('sourceType', parentType)
+        .where('sourceId', parentId)
+        .where(helpers => helpers.cmp('targetType', 'IN', [...SDLC_TREE_TARGET_TYPES]))
+        .orderBy('createdAt', 'asc'),
+  ),
   /** A hub's tracks. Tracks carry no scope column; the CHANNEL -> TRACK edge places them. */
+  /**
+   * Every folder in a hub, in one subscription. Folders carry no scope column,
+   * so the flat TRACK -> FOLDER edge places them — the same shape getSdlcTracks
+   * uses. One query for the hub beats one per open finder column, and it is what
+   * lets a conversation say which folder it belongs to without a second fetch.
+   */
+  getSdlcFoldersByChannel: defineQuery(
+    z.object({ channelId: z.string() }),
+    ({ args: { channelId } }) =>
+      zql.sdlc_folders.whereExists('sdlcEntityLinks', link =>
+        link.where('channelId', channelId).where('relationType', SDLC_TRACK_FLAT_RELATION),
+      ),
+  ),
   getSdlcTracks: defineQuery(z.object({ channelId: z.string() }), ({ args: { channelId } }) =>
     zql.sdlc_tracks
       .whereExists('sdlcEntityLinks', link =>
@@ -4421,7 +4464,20 @@ dmChannelsLatestMessagesPaginated: defineQuery(
   getSdlcLinks: defineQuery(z.object({ channelId: z.string() }), ({ args: { channelId } }) =>
     zql.sdlc_entity_links
       .where('channelId', channelId)
-      .where(helpers => helpers.cmp('relationType', 'NOT IN', [...SDLC_STRUCTURAL_RELATIONS]))
+      .where(helpers =>
+        helpers.cmp('relationType', 'NOT IN', [...SDLC_HUB_GRAPH_EXCLUDED_RELATIONS]),
+      )
+      // The flat edge is worth syncing for artifacts and conversations, which
+      // readers here resolve back to a track. Its FOLDER rows are the largest
+      // group in the graph and no reader touches them — the finder gets folders
+      // from getSdlcFoldersByChannel, which matches this edge server-side. Cut by
+      // target rather than by a whitelist, so a new flat target still arrives.
+      .where(helpers =>
+        helpers.or(
+          helpers.cmp('relationType', '!=', SDLC_TRACK_FLAT_RELATION),
+          helpers.cmp('targetType', '!=', 'FOLDER'),
+        ),
+      )
       .orderBy('createdAt', 'asc'),
   ),
   sdlcTicketsByIds: defineQuery(
@@ -4537,17 +4593,6 @@ dmChannelsLatestMessagesPaginated: defineQuery(
         .related('call')
         .related('ticket');
     },
-  ),
-  sdlcRelatedConversations: defineQuery(
-    z.object({ conversationIds: z.array(z.string()) }),
-    ({ args: { conversationIds } }) =>
-      zql.conversations.where(helpers =>
-        helpers.cmp(
-          'conversationId',
-          'IN',
-          conversationIds.length > 0 ? conversationIds : ['__no_sdlc_related_conversation__'],
-        ),
-      ),
   ),
   getAllForms: defineQuery(() => {
     return zql.forms

--- a/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
@@ -919,8 +919,6 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
                   sourceType: entityLinkScope.sourceType,
                   sourceId: entityLinkScope.sourceId,
                   linkId: uuidv4(),
-                  // Its own row, so its own id: the scope names the track, the
-                  // composer is what can mint an id the mutator will replay.
                   ...(entityLinkScope.rollUpTrackId && {
                     trackRollUp: {
                       trackId: entityLinkScope.rollUpTrackId,

--- a/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
@@ -915,7 +915,19 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
               timestamp: messageCreatedAt,
               ...(pendingAttachments.length > 0 && { attachments: pendingAttachments }),
               ...(entityLinkScope && {
-                entityLinkContext: { ...entityLinkScope, linkId: uuidv4() },
+                entityLinkContext: {
+                  sourceType: entityLinkScope.sourceType,
+                  sourceId: entityLinkScope.sourceId,
+                  linkId: uuidv4(),
+                  // Its own row, so its own id: the scope names the track, the
+                  // composer is what can mint an id the mutator will replay.
+                  ...(entityLinkScope.rollUpTrackId && {
+                    trackRollUp: {
+                      trackId: entityLinkScope.rollUpTrackId,
+                      linkId: uuidv4(),
+                    },
+                  }),
+                },
               }),
             });
 

--- a/apps/dashboard/src/components/Chat/ConversationPannel/ConversationBadgeContext.ts
+++ b/apps/dashboard/src/components/Chat/ConversationPannel/ConversationBadgeContext.ts
@@ -1,0 +1,14 @@
+import { createContext, type ReactNode } from 'react';
+
+/**
+ * Lets a host mark each conversation in the feed without threading a prop
+ * through the panel, the list, the item and the bubble. The SDLC hub uses it to
+ * say which folder a conversation was started in, because a track's list shows
+ * the conversations of every folder inside it alongside its own.
+ *
+ * Returning null for a conversation renders nothing for it, which is what every
+ * surface that does not provide a renderer does.
+ */
+export type ConversationBadgeRenderer = (conversationId: string) => ReactNode;
+
+export const ConversationBadgeContext = createContext<ConversationBadgeRenderer | null>(null);

--- a/apps/dashboard/src/components/Chat/ConversationPannel/ConversationBadgeContext.ts
+++ b/apps/dashboard/src/components/Chat/ConversationPannel/ConversationBadgeContext.ts
@@ -1,14 +1,5 @@
 import { createContext, type ReactNode } from 'react';
 
-/**
- * Lets a host mark each conversation in the feed without threading a prop
- * through the panel, the list, the item and the bubble. The SDLC hub uses it to
- * say which folder a conversation was started in, because a track's list shows
- * the conversations of every folder inside it alongside its own.
- *
- * Returning null for a conversation renders nothing for it, which is what every
- * surface that does not provide a renderer does.
- */
 export type ConversationBadgeRenderer = (conversationId: string) => ReactNode;
 
 export const ConversationBadgeContext = createContext<ConversationBadgeRenderer | null>(null);

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -141,17 +141,7 @@ interface ThreadMessagesProps {
   /** Forces the initial active tab, overriding the ?selectedTab URL param. Used by modal hosts to avoid inheriting the outer page's tab state. */
   defaultTab?: TabType;
   headerActionsContainer?: HTMLElement | null;
-  /**
-   * Render the tabbed layout for a thread that has no ticket. The tab list
-   * already drops Details and RCA without one, leaving Messages and Files —
-   * worth having rather than falling back to a bare message list.
-   */
   tabbedView?: boolean;
-  /**
-   * Keep only the overflow menu in the header actions. For hosts whose own bar
-   * already offers Ask AI, calls and recording, or where the thread is a side
-   * panel too narrow to carry all four.
-   */
   overflowActionsOnly?: boolean;
 }
 

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -812,7 +812,15 @@ export const ThreadMessages = ({
 
   const showSubTicketsTab = isDeskChannelType(channel?.type);
   // The panel is reused across threads, so this tab can vanish while still selected.
-  const currentTab = !showSubTicketsTab && activeTab === 'subtickets' ? 'thread' : activeTab;
+  // A tab can be selected and then vanish, because the panel is reused across
+  // threads: subtickets when the channel type changes, and details/rca when the
+  // next thread has no ticket. Both leave the strip with nothing selected and an
+  // empty body, so they fall back to the one tab every thread has.
+  const ticketOnlyTab = activeTab === 'details' || activeTab === 'rca';
+  const currentTab =
+    (!showSubTicketsTab && activeTab === 'subtickets') || (!derivedTicketId && ticketOnlyTab)
+      ? 'thread'
+      : activeTab;
 
   const tabs = useMemo(() => {
     const allTabs = [

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -141,6 +141,18 @@ interface ThreadMessagesProps {
   /** Forces the initial active tab, overriding the ?selectedTab URL param. Used by modal hosts to avoid inheriting the outer page's tab state. */
   defaultTab?: TabType;
   headerActionsContainer?: HTMLElement | null;
+  /**
+   * Render the tabbed layout for a thread that has no ticket. The tab list
+   * already drops Details and RCA without one, leaving Messages and Files —
+   * worth having rather than falling back to a bare message list.
+   */
+  tabbedView?: boolean;
+  /**
+   * Keep only the overflow menu in the header actions. For hosts whose own bar
+   * already offers Ask AI, calls and recording, or where the thread is a side
+   * panel too narrow to carry all four.
+   */
+  overflowActionsOnly?: boolean;
 }
 
 export const ThreadMessages = ({
@@ -165,6 +177,8 @@ export const ThreadMessages = ({
   onUserClick,
   defaultTab,
   headerActionsContainer,
+  overflowActionsOnly = false,
+  tabbedView = false,
 }: ThreadMessagesProps = {}): ReactElement => {
   const {
     channelId: paramChannelId,
@@ -1184,7 +1198,7 @@ export const ThreadMessages = ({
   const simpleViewHeaderActions = (
     <div className='flex items-center gap-1 shrink-0' style={APP_NO_DRAG_STYLE}>
       {/* Ask AI */}
-      {!isStandaloneWindow() && (
+      {!overflowActionsOnly && !isStandaloneWindow() && (
         <Tooltip content='Ask AI Conversation'>
           <Button
             size='sm'
@@ -1210,7 +1224,7 @@ export const ThreadMessages = ({
       )}
 
       {/* Initiate Call Button */}
-      {derivedConversationId && !channel?.isArchived && (
+      {!overflowActionsOnly && derivedConversationId && !channel?.isArchived && (
         <ThreadCallButton
           onStartCall={handleInitiateCall}
           onScheduleCall={() => setIsScheduleCallModalOpen(true)}
@@ -1225,7 +1239,7 @@ export const ThreadMessages = ({
       )}
 
       {/* Start Recording (Take Notes) Button */}
-      {derivedConversationId && !channel?.isArchived && (
+      {!overflowActionsOnly && derivedConversationId && !channel?.isArchived && (
         <ThreadRecordingButton
           onStartRecording={handleStartRecordingFromThread}
           hasActiveRecording={recordingStatus !== 'idle' && recordingStatus !== 'error'}
@@ -1583,8 +1597,9 @@ export const ThreadMessages = ({
             </div>
           </div>
         )}
-        {/* Ticket Thread with Tabs - only when NOT simpleView */}
-        {!simpleView && derivedTicketId ? (
+        {/* Tabbed thread. A ticket brings Details and RCA with it; without one
+            the same layout still carries Messages and Files. */}
+        {!simpleView && (derivedTicketId || tabbedView) ? (
           /* Ticket Thread: Header with Tabs */
           <Tabs.Root
             value={currentTab}
@@ -1601,8 +1616,11 @@ export const ThreadMessages = ({
             {headerActionsContainer
               ? createPortal(simpleViewHeaderActions, headerActionsContainer)
               : null}
-            {/* Header with title, close button, and tabs */}
-            <div className='w-full pl-2 pr-3 py-3'>
+            {/* Header with title, close button, and tabs. When the host draws its
+                own bar above this one, the generous padding reads as a gap
+                between the tabs and the first message rather than as breathing
+                room, so it tightens. */}
+            <div className={cn('w-full pl-2 pr-3', hideHeader ? 'pb-1 pt-1.5' : 'py-3')}>
               <div className='relative flex justify-between w-full'>
                 {/* Tabs List */}
                 <div className='overflow-x-auto no-scrollbar'>
@@ -1723,12 +1741,14 @@ export const ThreadMessages = ({
             </Tabs.Content>
 
             {/* Details Tab Content */}
-            <Tabs.Content
-              value='details'
-              className='flex-1 min-h-0 bg-background overflow-hidden data-[state=inactive]:hidden'
-            >
-              <TicketDetails ticketId={derivedTicketId} onFillRCA={() => setActiveTab('rca')} />
-            </Tabs.Content>
+            {derivedTicketId && (
+              <Tabs.Content
+                value='details'
+                className='flex-1 min-h-0 bg-background overflow-hidden data-[state=inactive]:hidden'
+              >
+                <TicketDetails ticketId={derivedTicketId} onFillRCA={() => setActiveTab('rca')} />
+              </Tabs.Content>
+            )}
 
             {/* Sub-tickets Tab Content */}
             {showSubTicketsTab && (

--- a/apps/dashboard/src/components/ui/EntitySelector/EntitySelector.tsx
+++ b/apps/dashboard/src/components/ui/EntitySelector/EntitySelector.tsx
@@ -25,6 +25,7 @@ export const EntitySelector: React.FC<EntitySelectorProps> = ({
   searchPlaceholder,
   showSearch = true,
   matchTriggerWidth = false,
+  dropdownMinWidth,
   isLoading = false,
   width = 'auto',
   onSearchChange,
@@ -420,7 +421,9 @@ export const EntitySelector: React.FC<EntitySelectorProps> = ({
             pointerEvents: 'auto',
             // Never narrower than the trigger it drops from; a compact trigger
             // still lets the content size the popover as before.
-            minWidth: 'var(--radix-popover-trigger-width)',
+            minWidth: dropdownMinWidth
+              ? `max(${dropdownMinWidth}, var(--radix-popover-trigger-width))`
+              : 'var(--radix-popover-trigger-width)',
             ...(matchTriggerWidth && {
               width: 'var(--radix-popover-trigger-width)',
               maxWidth: 'var(--radix-popover-trigger-width)',

--- a/apps/dashboard/src/components/ui/EntitySelector/EntitySelector.types.ts
+++ b/apps/dashboard/src/components/ui/EntitySelector/EntitySelector.types.ts
@@ -122,6 +122,11 @@ export interface EntitySelectorProps {
 
   /** Lock the dropdown to the trigger's width instead of letting content size it. */
   matchTriggerWidth?: boolean;
+  /**
+   * Floor for the dropdown's width, for triggers too narrow to read the options
+   * against — a sidebar selector, say. Defaults to the trigger's own width.
+   */
+  dropdownMinWidth?: string;
 
   /** Opt in to virtualizing the options list (for large user/group lists). */
   virtualize?: boolean;

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
+import { ConversationBadgeContext } from '../../Chat/ConversationPannel/ConversationBadgeContext';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Tooltip from '../Tooltip/Tooltip';
 import { AvatarSize } from '../../UserAvatar/UserAvatar';
@@ -506,6 +507,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
   headerContent,
   onUserClick,
 }) => {
+  const renderConversationBadge = useContext(ConversationBadgeContext);
   const navigate = useNavigate();
   const { toggleReaction } = useReactions();
   const attachments = message.attachments || [];
@@ -1170,6 +1172,9 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
               {metadata?.['clawRunOrigin'] ? (
                 <RunOriginChip origin={metadata['clawRunOrigin']} />
               ) : null}
+              {/* Host-supplied mark for where this conversation belongs. Null in
+                  every surface that does not provide one. */}
+              {message.conversationId ? renderConversationBadge?.(message.conversationId) : null}
               {headerContent}
             </div>
           )}

--- a/apps/dashboard/src/components/ui/Resizable/Resizable.tsx
+++ b/apps/dashboard/src/components/ui/Resizable/Resizable.tsx
@@ -1,5 +1,11 @@
 import { ReactElement } from 'react';
-import { Group, useDefaultLayout, type GroupProps } from 'react-resizable-panels';
+import {
+  Group,
+  useDefaultLayout,
+  type GroupProps,
+  type Layout,
+  type LayoutChangedMeta,
+} from 'react-resizable-panels';
 
 export {
   Panel,
@@ -11,7 +17,7 @@ export {
   type PanelSize,
 } from 'react-resizable-panels';
 
-type ResizableGroupProps = Omit<GroupProps, 'defaultLayout' | 'onLayoutChanged'> & {
+type ResizableGroupProps = Omit<GroupProps, 'defaultLayout'> & {
   /**
    * Persist this group's layout to localStorage under the given id.
    *
@@ -29,6 +35,7 @@ type ResizableGroupProps = Omit<GroupProps, 'defaultLayout' | 'onLayoutChanged'>
 const PersistedGroup = ({
   autoSaveId,
   panelIds,
+  onLayoutChanged: onLayoutChangedProp,
   ...rest
 }: ResizableGroupProps & { autoSaveId: string }): ReactElement => {
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
@@ -39,7 +46,14 @@ const PersistedGroup = ({
     onlySaveAfterUserInteractions: true,
   });
 
-  return <Group defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged} {...rest} />;
+  // Saving the layout is this wrapper's job, so a caller's own handler runs
+  // alongside it rather than replacing it.
+  const handleLayoutChanged = (layout: Layout, meta: LayoutChangedMeta): void => {
+    onLayoutChanged(layout, meta);
+    onLayoutChangedProp?.(layout, meta);
+  };
+
+  return <Group defaultLayout={defaultLayout} onLayoutChanged={handleLayoutChanged} {...rest} />;
 };
 
 /**

--- a/apps/dashboard/src/components/ui/Resizable/Resizable.tsx
+++ b/apps/dashboard/src/components/ui/Resizable/Resizable.tsx
@@ -46,8 +46,6 @@ const PersistedGroup = ({
     onlySaveAfterUserInteractions: true,
   });
 
-  // Saving the layout is this wrapper's job, so a caller's own handler runs
-  // alongside it rather than replacing it.
   const handleLayoutChanged = (layout: Layout, meta: LayoutChangedMeta): void => {
     onLayoutChanged(layout, meta);
     onLayoutChangedProp?.(layout, meta);

--- a/apps/dashboard/src/contexts/EntityLinkContext.ts
+++ b/apps/dashboard/src/contexts/EntityLinkContext.ts
@@ -1,8 +1,13 @@
 import { createContext } from 'react';
 
 export type EntityLinkScope = {
-  sourceType: 'CANVAS' | 'TRACK';
+  sourceType: 'CANVAS' | 'TRACK' | 'FOLDER';
   sourceId: string;
+  /**
+   * File the conversation on this track as well as on the owner. Set for folder
+   * scopes, so a track's conversation list covers everything discussed inside it.
+   */
+  rollUpTrackId?: string;
 };
 
 export const EntityLinkContext = createContext<EntityLinkScope | null>(null);

--- a/apps/dashboard/src/contexts/EntityLinkContext.ts
+++ b/apps/dashboard/src/contexts/EntityLinkContext.ts
@@ -3,10 +3,6 @@ import { createContext } from 'react';
 export type EntityLinkScope = {
   sourceType: 'CANVAS' | 'TRACK' | 'FOLDER';
   sourceId: string;
-  /**
-   * File the conversation on this track as well as on the owner. Set for folder
-   * scopes, so a track's conversation list covers everything discussed inside it.
-   */
   rollUpTrackId?: string;
 };
 

--- a/apps/dashboard/src/machines/userPreferencesMachine.ts
+++ b/apps/dashboard/src/machines/userPreferencesMachine.ts
@@ -1,0 +1,196 @@
+import { useSyncExternalStore } from 'react';
+import { setup, assign, createActor } from 'xstate';
+import { indexedDBService } from '../services/indexedDBService';
+
+/* -------------------------- TYPES -------------------------- */
+
+/**
+ * Everything the reader has chosen about how the app looks to them — as opposed
+ * to anything about the workspace, which belongs to the workspace and not to
+ * one person's browser.
+ *
+ * One flat, typed object rather than a key per preference: it is written and
+ * read as a whole, so a new preference costs a field and a default and nothing
+ * else. Every field needs a default, since a reader who has never expressed a
+ * preference must still get a sensible app.
+ */
+export interface UserPreferences {
+  /** SDLC hub sidebar folded to its icon rail. */
+  sdlcSidebarCollapsed: boolean;
+  /** Width in pixels of the SDLC hub sidebar when it is not folded. */
+  sdlcSidebarWidth: number;
+  /**
+   * Width in pixels of each column in the track's folder browser, by the id of
+   * the parent it lists. Per column rather than one shared width: a level you
+   * widened to read long titles should stay wide without dragging every other
+   * level with it.
+   */
+  sdlcFinderColumnWidths: Record<string, number>;
+  /** How a column's contents are grouped: not at all, or by kind and artifact type. */
+  sdlcFinderGroupBy: 'none' | 'type';
+  /**
+   * The folder path open in each track's browser, by track id — so returning to a
+   * track puts you back where you were rather than at its root. Names are stored
+   * with the ids because the column headers need them before the folders load.
+   */
+  sdlcFinderPathByTrack: Record<
+    string,
+    Array<{ type: 'TRACK' | 'FOLDER'; id: string; name: string }>
+  >;
+  /** SDLC hub sidebar sections that are folded to their header, by panel id. */
+  sdlcSidebarSectionsCollapsed: Record<string, boolean>;
+  /**
+   * Height in pixels each SDLC sidebar section returns to when opened, by panel
+   * id. Pixels rather than the group's own percentages: percentages are relative
+   * to a container the sections do not fill on their own, so they drifted every
+   * time one folded and another took the slack.
+   */
+  sdlcSidebarSectionHeights: Record<string, number>;
+  /** Completed and parked tracks shown in the SDLC sidebar. */
+  sdlcShowClosedTracks: boolean;
+}
+
+export const DEFAULT_USER_PREFERENCES: UserPreferences = {
+  sdlcSidebarCollapsed: false,
+  sdlcSidebarWidth: 260,
+  sdlcFinderColumnWidths: {},
+  sdlcFinderGroupBy: 'none',
+  sdlcFinderPathByTrack: {},
+  // Hub and Tracks are what a reader arrives wanting; the other two are there to
+  // be opened when needed. Ids are literals rather than an import so this module
+  // stays free of the screen it stores preferences for, and are built into the
+  // record rather than written as keys, which their kebab-case would fail lint on.
+  sdlcSidebarSectionsCollapsed: Object.fromEntries(
+    ['sdlc-sidebar-artifacts', 'sdlc-sidebar-repositories'].map(id => [id, true]),
+  ),
+  sdlcSidebarSectionHeights: {},
+  sdlcShowClosedTracks: false,
+};
+
+export interface UserPreferencesContext {
+  preferences: UserPreferences;
+  /** False until IndexedDB has answered, so nothing is written over a stored value. */
+  hydrated: boolean;
+}
+
+export type UserPreferencesEvent =
+  | { type: 'HYDRATED'; preferences: Partial<UserPreferences> }
+  | { type: 'SET'; key: keyof UserPreferences; value: UserPreferences[keyof UserPreferences] }
+  | { type: 'RESET' };
+
+/* -------------------------- PERSISTENCE -------------------------- */
+
+/** One row in the existing context store, rather than a store of its own. */
+const STORAGE_KEY = 'userPreferences';
+
+/**
+ * Writes are fire-and-forget and coalesced to the end of the turn: preferences
+ * change in bursts — a drag that collapses two sections at once — and each one
+ * is worth less than the next render.
+ */
+let pendingWrite: ReturnType<typeof setTimeout> | null = null;
+
+function persist(preferences: UserPreferences): void {
+  if (pendingWrite) clearTimeout(pendingWrite);
+  pendingWrite = setTimeout(() => {
+    pendingWrite = null;
+    if (!indexedDBService.isInitialized()) return;
+    void indexedDBService.saveContextProperty(STORAGE_KEY, preferences).catch(() => {
+      // A preference is not worth surfacing an error for; the session keeps the
+      // value in memory either way.
+    });
+  }, 200);
+}
+
+/* -------------------------- MACHINE -------------------------- */
+
+export const userPreferencesMachine = setup({
+  types: {
+    context: {} as UserPreferencesContext,
+    events: {} as UserPreferencesEvent,
+  },
+  actions: {
+    persistPreferences: ({ context }) => persist(context.preferences),
+  },
+}).createMachine({
+  id: 'userPreferences',
+  context: {
+    preferences: DEFAULT_USER_PREFERENCES,
+    hydrated: false,
+  },
+  on: {
+    // Stored values win over defaults but never over a choice already made in
+    // this session — hydration can land after the reader has clicked something.
+    HYDRATED: {
+      actions: assign(({ context, event }) => ({
+        preferences: context.hydrated
+          ? context.preferences
+          : { ...DEFAULT_USER_PREFERENCES, ...event.preferences },
+        hydrated: true,
+      })),
+    },
+    SET: {
+      actions: [
+        assign(({ context, event }) => ({
+          preferences: { ...context.preferences, [event.key]: event.value },
+          // A choice made before hydration is a choice: it must not be
+          // overwritten by whatever IndexedDB says a moment later.
+          hydrated: true,
+        })),
+        'persistPreferences',
+      ],
+    },
+    RESET: {
+      actions: [
+        assign(() => ({ preferences: DEFAULT_USER_PREFERENCES, hydrated: true })),
+        'persistPreferences',
+      ],
+    },
+  },
+});
+
+export const userPreferencesActor = createActor(userPreferencesMachine).start();
+
+/**
+ * Read stored preferences into the actor. Safe to call more than once — the
+ * machine keeps whatever the reader has already chosen this session.
+ */
+export async function hydrateUserPreferences(): Promise<void> {
+  try {
+    if (!indexedDBService.isInitialized()) return;
+    const stored = await indexedDBService.loadContextProperty(STORAGE_KEY);
+    if (stored && typeof stored === 'object') {
+      userPreferencesActor.send({
+        type: 'HYDRATED',
+        preferences: stored as Partial<UserPreferences>,
+      });
+    }
+  } catch {
+    // Defaults are a working app.
+  }
+}
+
+/* -------------------------- REACT -------------------------- */
+
+export function setUserPreference<K extends keyof UserPreferences>(
+  key: K,
+  value: UserPreferences[K],
+): void {
+  userPreferencesActor.send({ type: 'SET', key, value });
+}
+
+/** Every preference, read once — for callers outside React's render cycle. */
+export function userPreferencesSnapshot(): UserPreferences {
+  return userPreferencesActor.getSnapshot().context.preferences;
+}
+
+/** One preference, re-rendering only the components that read it. */
+export function useUserPreference<K extends keyof UserPreferences>(key: K): UserPreferences[K] {
+  return useSyncExternalStore(
+    onChange => {
+      const subscription = userPreferencesActor.subscribe(() => onChange());
+      return () => subscription.unsubscribe();
+    },
+    () => userPreferencesActor.getSnapshot().context.preferences[key],
+  );
+}

--- a/apps/dashboard/src/machines/userPreferencesMachine.ts
+++ b/apps/dashboard/src/machines/userPreferencesMachine.ts
@@ -2,51 +2,17 @@ import { useSyncExternalStore } from 'react';
 import { setup, assign, createActor } from 'xstate';
 import { indexedDBService } from '../services/indexedDBService';
 
-/* -------------------------- TYPES -------------------------- */
-
-/**
- * Everything the reader has chosen about how the app looks to them — as opposed
- * to anything about the workspace, which belongs to the workspace and not to
- * one person's browser.
- *
- * One flat, typed object rather than a key per preference: it is written and
- * read as a whole, so a new preference costs a field and a default and nothing
- * else. Every field needs a default, since a reader who has never expressed a
- * preference must still get a sensible app.
- */
 export interface UserPreferences {
-  /** SDLC hub sidebar folded to its icon rail. */
   sdlcSidebarCollapsed: boolean;
-  /** Width in pixels of the SDLC hub sidebar when it is not folded. */
   sdlcSidebarWidth: number;
-  /**
-   * Width in pixels of each column in the track's folder browser, by the id of
-   * the parent it lists. Per column rather than one shared width: a level you
-   * widened to read long titles should stay wide without dragging every other
-   * level with it.
-   */
   sdlcFinderColumnWidths: Record<string, number>;
-  /** How a column's contents are grouped: not at all, or by kind and artifact type. */
   sdlcFinderGroupBy: 'none' | 'type';
-  /**
-   * The folder path open in each track's browser, by track id — so returning to a
-   * track puts you back where you were rather than at its root. Names are stored
-   * with the ids because the column headers need them before the folders load.
-   */
   sdlcFinderPathByTrack: Record<
     string,
     Array<{ type: 'TRACK' | 'FOLDER'; id: string; name: string }>
   >;
-  /** SDLC hub sidebar sections that are folded to their header, by panel id. */
   sdlcSidebarSectionsCollapsed: Record<string, boolean>;
-  /**
-   * Height in pixels each SDLC sidebar section returns to when opened, by panel
-   * id. Pixels rather than the group's own percentages: percentages are relative
-   * to a container the sections do not fill on their own, so they drifted every
-   * time one folded and another took the slack.
-   */
   sdlcSidebarSectionHeights: Record<string, number>;
-  /** Completed and parked tracks shown in the SDLC sidebar. */
   sdlcShowClosedTracks: boolean;
 }
 
@@ -56,10 +22,6 @@ export const DEFAULT_USER_PREFERENCES: UserPreferences = {
   sdlcFinderColumnWidths: {},
   sdlcFinderGroupBy: 'none',
   sdlcFinderPathByTrack: {},
-  // Hub and Tracks are what a reader arrives wanting; the other two are there to
-  // be opened when needed. Ids are literals rather than an import so this module
-  // stays free of the screen it stores preferences for, and are built into the
-  // record rather than written as keys, which their kebab-case would fail lint on.
   sdlcSidebarSectionsCollapsed: Object.fromEntries(
     ['sdlc-sidebar-artifacts', 'sdlc-sidebar-repositories'].map(id => [id, true]),
   ),
@@ -69,13 +31,7 @@ export const DEFAULT_USER_PREFERENCES: UserPreferences = {
 
 export interface UserPreferencesContext {
   preferences: UserPreferences;
-  /** False until IndexedDB has answered, so nothing is written over a stored value. */
   hydrated: boolean;
-  /**
-   * Whose preferences these are. The actor is a module singleton, so signing out
-   * and in as someone else in the same tab would otherwise leave the previous
-   * reader's choices in place — and then persist them into the new reader's store.
-   */
   ownerId: string | null;
 }
 
@@ -84,16 +40,8 @@ export type UserPreferencesEvent =
   | { type: 'SET'; key: keyof UserPreferences; value: UserPreferences[keyof UserPreferences] }
   | { type: 'RESET' };
 
-/* -------------------------- PERSISTENCE -------------------------- */
-
-/** One row in the existing context store, rather than a store of its own. */
 const STORAGE_KEY = 'userPreferences';
 
-/**
- * Writes are fire-and-forget and coalesced to the end of the turn: preferences
- * change in bursts — a drag that collapses two sections at once — and each one
- * is worth less than the next render.
- */
 let pendingWrite: ReturnType<typeof setTimeout> | null = null;
 
 function persist(preferences: UserPreferences): void {
@@ -101,14 +49,9 @@ function persist(preferences: UserPreferences): void {
   pendingWrite = setTimeout(() => {
     pendingWrite = null;
     if (!indexedDBService.isInitialized()) return;
-    void indexedDBService.saveContextProperty(STORAGE_KEY, preferences).catch(() => {
-      // A preference is not worth surfacing an error for; the session keeps the
-      // value in memory either way.
-    });
+    void indexedDBService.saveContextProperty(STORAGE_KEY, preferences).catch(() => {});
   }, 200);
 }
-
-/* -------------------------- MACHINE -------------------------- */
 
 export const userPreferencesMachine = setup({
   types: {
@@ -126,13 +69,8 @@ export const userPreferencesMachine = setup({
     ownerId: null,
   },
   on: {
-    // Stored values win over defaults but never over a choice already made in
-    // this session — hydration can land after the reader has clicked something.
     HYDRATED: {
       actions: assign(({ context, event }) => {
-        // A different reader replaces everything: the in-session latch protects
-        // one person's choices from a late load, not one person's choices from
-        // another person.
         const sameReader = context.ownerId === null || context.ownerId === event.userId;
         return {
           preferences:
@@ -148,8 +86,6 @@ export const userPreferencesMachine = setup({
       actions: [
         assign(({ context, event }) => ({
           preferences: { ...context.preferences, [event.key]: event.value },
-          // A choice made before hydration is a choice: it must not be
-          // overwritten by whatever IndexedDB says a moment later.
           hydrated: true,
         })),
         'persistPreferences',
@@ -166,28 +102,19 @@ export const userPreferencesMachine = setup({
 
 export const userPreferencesActor = createActor(userPreferencesMachine).start();
 
-/**
- * Read stored preferences into the actor. Safe to call more than once — the
- * machine keeps whatever the reader has already chosen this session.
- */
 export async function hydrateUserPreferences(userId: string | null): Promise<void> {
   try {
     if (!indexedDBService.isInitialized()) return;
     const stored = await indexedDBService.loadContextProperty(STORAGE_KEY);
-    // Sent even when nothing is stored: a reader with no saved preferences still
-    // has to displace the previous reader's, which an early return would keep.
     userPreferencesActor.send({
       type: 'HYDRATED',
       userId,
-      preferences:
-        stored && typeof stored === 'object' ? (stored as Partial<UserPreferences>) : {},
+      preferences: stored && typeof stored === 'object' ? (stored as Partial<UserPreferences>) : {},
     });
   } catch {
     // Defaults are a working app.
   }
 }
-
-/* -------------------------- REACT -------------------------- */
 
 export function setUserPreference<K extends keyof UserPreferences>(
   key: K,
@@ -196,12 +123,10 @@ export function setUserPreference<K extends keyof UserPreferences>(
   userPreferencesActor.send({ type: 'SET', key, value });
 }
 
-/** Every preference, read once — for callers outside React's render cycle. */
 export function userPreferencesSnapshot(): UserPreferences {
   return userPreferencesActor.getSnapshot().context.preferences;
 }
 
-/** One preference, re-rendering only the components that read it. */
 export function useUserPreference<K extends keyof UserPreferences>(key: K): UserPreferences[K] {
   return useSyncExternalStore(
     onChange => {

--- a/apps/dashboard/src/machines/userPreferencesMachine.ts
+++ b/apps/dashboard/src/machines/userPreferencesMachine.ts
@@ -71,10 +71,16 @@ export interface UserPreferencesContext {
   preferences: UserPreferences;
   /** False until IndexedDB has answered, so nothing is written over a stored value. */
   hydrated: boolean;
+  /**
+   * Whose preferences these are. The actor is a module singleton, so signing out
+   * and in as someone else in the same tab would otherwise leave the previous
+   * reader's choices in place — and then persist them into the new reader's store.
+   */
+  ownerId: string | null;
 }
 
 export type UserPreferencesEvent =
-  | { type: 'HYDRATED'; preferences: Partial<UserPreferences> }
+  | { type: 'HYDRATED'; userId: string | null; preferences: Partial<UserPreferences> }
   | { type: 'SET'; key: keyof UserPreferences; value: UserPreferences[keyof UserPreferences] }
   | { type: 'RESET' };
 
@@ -117,17 +123,26 @@ export const userPreferencesMachine = setup({
   context: {
     preferences: DEFAULT_USER_PREFERENCES,
     hydrated: false,
+    ownerId: null,
   },
   on: {
     // Stored values win over defaults but never over a choice already made in
     // this session — hydration can land after the reader has clicked something.
     HYDRATED: {
-      actions: assign(({ context, event }) => ({
-        preferences: context.hydrated
-          ? context.preferences
-          : { ...DEFAULT_USER_PREFERENCES, ...event.preferences },
-        hydrated: true,
-      })),
+      actions: assign(({ context, event }) => {
+        // A different reader replaces everything: the in-session latch protects
+        // one person's choices from a late load, not one person's choices from
+        // another person.
+        const sameReader = context.ownerId === null || context.ownerId === event.userId;
+        return {
+          preferences:
+            sameReader && context.hydrated
+              ? context.preferences
+              : { ...DEFAULT_USER_PREFERENCES, ...event.preferences },
+          hydrated: true,
+          ownerId: event.userId,
+        };
+      }),
     },
     SET: {
       actions: [
@@ -155,16 +170,18 @@ export const userPreferencesActor = createActor(userPreferencesMachine).start();
  * Read stored preferences into the actor. Safe to call more than once — the
  * machine keeps whatever the reader has already chosen this session.
  */
-export async function hydrateUserPreferences(): Promise<void> {
+export async function hydrateUserPreferences(userId: string | null): Promise<void> {
   try {
     if (!indexedDBService.isInitialized()) return;
     const stored = await indexedDBService.loadContextProperty(STORAGE_KEY);
-    if (stored && typeof stored === 'object') {
-      userPreferencesActor.send({
-        type: 'HYDRATED',
-        preferences: stored as Partial<UserPreferences>,
-      });
-    }
+    // Sent even when nothing is stored: a reader with no saved preferences still
+    // has to displace the previous reader's, which an early return would keep.
+    userPreferencesActor.send({
+      type: 'HYDRATED',
+      userId,
+      preferences:
+        stored && typeof stored === 'object' ? (stored as Partial<UserPreferences>) : {},
+    });
   } catch {
     // Defaults are a working app.
   }

--- a/apps/dashboard/src/providers/InitialStateLoader.tsx
+++ b/apps/dashboard/src/providers/InitialStateLoader.tsx
@@ -11,6 +11,7 @@ import {
   hydrateQueryCacheFromIndexedDB,
   queryCacheActor,
 } from '../machines/queryCacheMachine';
+import { hydrateUserPreferences } from '../machines/userPreferencesMachine';
 import { UserPermission } from '../machines/stateMachine';
 import { apiInstance } from '../services/clients/apiClient';
 import { useFallbackHydratedQuery } from '@xyne/shared/hooks';
@@ -225,6 +226,9 @@ const InitialStateLoader: React.FC<InitialStateLoaderProps> = ({ children }): Re
           const hydrationStartTime = Date.now();
           // User is logged in - hydrate their specific database
           await hydrateQueryCacheFromIndexedDB(context.userID, schemaVersion, context.workspaceId);
+
+          // The reader's own preferences ride the same open database.
+          await hydrateUserPreferences();
 
           const hydrationLatency = Date.now() - hydrationStartTime;
 

--- a/apps/dashboard/src/providers/InitialStateLoader.tsx
+++ b/apps/dashboard/src/providers/InitialStateLoader.tsx
@@ -227,7 +227,6 @@ const InitialStateLoader: React.FC<InitialStateLoaderProps> = ({ children }): Re
           // User is logged in - hydrate their specific database
           await hydrateQueryCacheFromIndexedDB(context.userID, schemaVersion, context.workspaceId);
 
-          // The reader's own preferences ride the same open database.
           await hydrateUserPreferences(context.userID);
 
           const hydrationLatency = Date.now() - hydrationStartTime;

--- a/apps/dashboard/src/providers/InitialStateLoader.tsx
+++ b/apps/dashboard/src/providers/InitialStateLoader.tsx
@@ -228,7 +228,7 @@ const InitialStateLoader: React.FC<InitialStateLoaderProps> = ({ children }): Re
           await hydrateQueryCacheFromIndexedDB(context.userID, schemaVersion, context.workspaceId);
 
           // The reader's own preferences ride the same open database.
-          await hydrateUserPreferences();
+          await hydrateUserPreferences(context.userID);
 
           const hydrationLatency = Date.now() - hydrationStartTime;
 

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcChatPanel.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcChatPanel.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useMemo, type ReactElement } from 'react';
+import { useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react';
+import { ChevronLeft, Folder } from 'lucide-react';
 import type { SdlcDiscussion } from '@xyne/shared';
 import type { ThreadInfo } from '../../machines/xyneAIMachine';
 import { useCachedQuery } from '../../hooks/useCachedQuery';
 import { queries } from '../../zero/queries';
 import { ThreadMessages } from '../../components/Chat/ThreadPannel';
 import ConversationPanelV2 from '../../components/Chat/ConversationPannel/ConversationPanelV2';
+import { ConversationBadgeContext } from '../../components/Chat/ConversationPannel/ConversationBadgeContext';
 import {
   SearchResultsContext,
   type SearchResultsThread,
@@ -26,7 +28,19 @@ interface SdlcChatPanelProps {
   ) => void;
   /** Thread header's Ask AI. Raised so the host can route it past the frame. */
   onAskAI?: (threadInfo?: ThreadInfo) => void;
-  headerActionsContainer?: HTMLElement | null;
+  /** Whose conversations these are, named in the panel's own bar. */
+  title: string;
+  /**
+   * Set when the conversations belong to something inside the track rather than
+   * to the track itself, so the bar says whose it is and offers the way back.
+   */
+  scopeHeader?: { name: string; onExit: () => void };
+  /**
+   * Marks each row in the list with where it came from. A track's list carries
+   * the conversations of every folder inside it, which otherwise arrive with
+   * nothing to say they were not started on the track itself.
+   */
+  renderConversationBadge?: (conversationId: string) => ReactNode;
 }
 
 const noopUserClick = (): void => {};
@@ -38,8 +52,15 @@ export function SdlcChatPanel({
   selectedConversationId,
   onSelectConversation,
   onAskAI,
-  headerActionsContainer,
+  title,
+  scopeHeader,
+  renderConversationBadge,
 }: SdlcChatPanelProps): ReactElement {
+  /**
+   * The thread's own actions render in this panel's bar rather than in the page
+   * header, so opening a conversation changes nothing above the panel.
+   */
+  const [headerActionsEl, setHeaderActionsEl] = useState<HTMLElement | null>(null);
   const [selectedConversation, selectedConversationDetails] = useCachedQuery(
     queries.sdlcDiscussionConversation({
       channelId,
@@ -71,21 +92,56 @@ export function SdlcChatPanel({
     selectedConversationId,
   ]);
 
-  if (selectedConversationId && selectedConversation) {
-    const selectedTicketId = selectedConversation.ticketId ?? null;
+  const threadOpen = Boolean(selectedConversationId && selectedConversation);
+  const selectedTicketId = selectedConversation?.ticketId ?? null;
 
-    return (
-      <SearchResultsContext.Provider value={ticketCardClickOverride}>
-        <aside
-          className='flex h-full min-w-0 flex-col bg-background'
-          aria-label='SDLC conversation'
+  /**
+   * The bar earns its place only when it has something to say: whose folder
+   * these conversations are, or the way back out of a thread. A track's list
+   * already sits under the page header naming the track, so it gets none.
+   * Sticky as well as shrink-0, to hold whichever element ends up scrolling.
+   */
+  const header =
+    scopeHeader || threadOpen ? (
+      <div className='sticky top-0 z-10 flex shrink-0 items-center gap-1.5 border-b border-border bg-background px-2.5 py-1.5'>
+        <button
+          type='button'
+          onClick={() => (threadOpen ? onSelectConversation(null) : scopeHeader?.onExit())}
+          title={threadOpen ? 'Back to conversations' : 'Back to the track'}
+          aria-label={threadOpen ? 'Back to conversations' : 'Back to the track'}
+          className='shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-foreground/[0.08] hover:text-foreground'
           data-track-category='SdlcHub'
-          data-track-name='SdlcChatThreadViewed'
-          data-track-metadata={JSON.stringify({
-            ownerType: discussion.ownerType,
-            conversationId: selectedConversationId,
-          })}
+          data-track-name={threadOpen ? 'SdlcChatThreadExited' : 'FolderConversationsExited'}
         >
+          <ChevronLeft className='size-4' />
+        </button>
+        {scopeHeader && <Folder className='size-3.5 shrink-0 fill-primary/25 text-primary/70' />}
+        <span className='min-w-0 flex-1 truncate text-[12.5px] font-semibold tracking-[-0.01em]'>
+          {scopeHeader?.name ?? title}
+        </span>
+        {/* Where ThreadMessages portals its overflow menu. */}
+        <div
+          ref={setHeaderActionsEl}
+          className='flex shrink-0 items-center [&>div]:animate-in [&>div]:fade-in [&>div]:duration-300 [&>div]:!gap-1.5'
+        />
+      </div>
+    ) : null;
+
+  return (
+    <SearchResultsContext.Provider value={ticketCardClickOverride}>
+      <aside
+        className='flex h-full min-w-0 flex-col bg-background'
+        aria-label={threadOpen ? 'SDLC conversation' : 'SDLC conversations'}
+        data-track-category='SdlcHub'
+        data-track-name={threadOpen ? 'SdlcChatThreadViewed' : 'SdlcChatListViewed'}
+        data-track-metadata={JSON.stringify(
+          threadOpen
+            ? { ownerType: discussion.ownerType, conversationId: selectedConversationId }
+            : { ownerType: discussion.ownerType },
+        )}
+      >
+        {header}
+        {threadOpen && selectedConversationId ? (
           <div className='flex min-h-0 flex-1 flex-col [&_.relative.min-h-0.max-h-full]:flex-1'>
             <ThreadMessages
               channelId={channelId}
@@ -93,35 +149,24 @@ export function SdlcChatPanel({
               onClose={() => onSelectConversation(null)}
               onUserClick={noopUserClick}
               {...(onAskAI && { onAskAI })}
-              {...(headerActionsContainer !== undefined && {
-                headerActionsContainer,
-                hideHeader: true,
-              })}
-              {...(selectedTicketId ? { ticketId: selectedTicketId } : { simpleView: true })}
+              headerActionsContainer={headerActionsEl}
+              hideHeader
+              overflowActionsOnly
+              {...(selectedTicketId ? { ticketId: selectedTicketId } : { tabbedView: true })}
               disableAskAI
             />
           </div>
-        </aside>
-      </SearchResultsContext.Provider>
-    );
-  }
-
-  return (
-    <SearchResultsContext.Provider value={ticketCardClickOverride}>
-      <aside
-        className='flex h-full min-w-0 flex-col bg-background'
-        aria-label='SDLC conversations'
-        data-track-category='SdlcHub'
-        data-track-name='SdlcChatListViewed'
-        data-track-metadata={JSON.stringify({ ownerType: discussion.ownerType })}
-      >
-        <ConversationPanelV2
-          channelId={channelId}
-          previousChannelId={null}
-          showHeader={false}
-          conversationIds={conversationIds}
-          onOpenThread={conversationId => onSelectConversation(conversationId)}
-        />
+        ) : (
+          <ConversationBadgeContext.Provider value={renderConversationBadge ?? null}>
+            <ConversationPanelV2
+              channelId={channelId}
+              previousChannelId={null}
+              showHeader={false}
+              conversationIds={conversationIds}
+              onOpenThread={conversationId => onSelectConversation(conversationId)}
+            />
+          </ConversationBadgeContext.Provider>
+        )}
       </aside>
     </SearchResultsContext.Provider>
   );

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcChatPanel.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcChatPanel.tsx
@@ -28,7 +28,6 @@ interface SdlcChatPanelProps {
   ) => void;
   /** Thread header's Ask AI. Raised so the host can route it past the frame. */
   onAskAI?: (threadInfo?: ThreadInfo) => void;
-  /** Whose conversations these are, named in the panel's own bar. */
   title: string;
   /**
    * Set when the conversations belong to something inside the track rather than

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcFinder.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcFinder.tsx
@@ -123,6 +123,8 @@ export function SdlcFinderColumn(props: {
   const groupBy = useUserPreference('sdlcFinderGroupBy');
   /** The row the pointer is currently over mid-drag, so only it shows a target. */
   const [dragOverId, setDragOverId] = useState<string | null>(null);
+  /** The pointer is over this column but not over a row, so the drop lands here. */
+  const [columnDragOver, setColumnDragOver] = useState(false);
   const [addOpen, setAddOpen] = useState(false);
   /** The folder being renamed in place, and the text so far. */
   const [renamingId, setRenamingId] = useState<string | null>(null);
@@ -250,10 +252,20 @@ export function SdlcFinderColumn(props: {
   return (
     <div
       onDragOver={event => {
-        if (props.draggingItem) event.preventDefault();
+        if (!props.draggingItem) return;
+        event.preventDefault();
+        setColumnDragOver(true);
+      }}
+      onDragLeave={event => {
+        // dragleave also fires crossing into a child, so only a pointer that has
+        // actually left the column clears the highlight.
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          setColumnDragOver(false);
+        }
       }}
       onDrop={event => {
         event.preventDefault();
+        setColumnDragOver(false);
         const dragged = props.draggingItem;
         if (!dragged) return;
         props.onMoveItem(dragged, { type: props.parent.type, id: props.parent.id });
@@ -262,9 +274,12 @@ export function SdlcFinderColumn(props: {
       ref={columnRef}
       style={props.isLast ? { minWidth: FINDER_MIN_COLUMN_WIDTH } : { width: columnWidth }}
       className={cn(
-        'relative flex shrink-0 flex-col border-r border-border last:border-r-0',
+        'relative flex shrink-0 flex-col border-r border-border transition-colors last:border-r-0',
         // The open level takes the slack so the columns fill the width.
         props.isLast && 'flex-1',
+        // Where the drop would land, when it is the level itself rather than a
+        // folder in it. A row under the pointer owns the target instead.
+        props.draggingItem && columnDragOver && !dragOverId && 'bg-primary/[0.06]',
       )}
     >
       {/* A real step, not a theme surface: --card and --background are the same
@@ -363,7 +378,9 @@ export function SdlcFinderColumn(props: {
           />
         </div>
       )}
-      <div className='scrollbar-none min-h-0 flex-1 overflow-y-auto p-1.5'>
+      {/* Deep bottom padding, not a spacer row: the last item should never sit
+          against the edge, and the slack scrolls away with the list. */}
+      <div className='scrollbar-none min-h-0 flex-1 overflow-y-auto p-1.5 pb-[150px]'>
         {groups.map(group => (
           <div key={group.label ?? 'all'} className='mb-1 last:mb-0'>
             {group.label && (

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcFinder.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcFinder.tsx
@@ -1,0 +1,702 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactElement,
+} from 'react';
+import { ChevronRight, FileText, Folder, FolderOpen, MessageCircle, Plus } from 'lucide-react';
+import { useCachedQuery } from '../../hooks/useCachedQuery';
+import { queries } from '../../zero/queries';
+import { cn } from '../../utils/classNames';
+import Avatar from '../../components/ui/Avatar/Avatar';
+import { Popover } from '../../components/ui/Popover';
+import { useUser } from '../../hooks/useUsers';
+import { getUserDisplayName } from '../../utils/userDisplayName';
+import { setUserPreference, useUserPreference } from '../../machines/userPreferencesMachine';
+
+/**
+ * Column width bounds. The minimum is set by the empty state's two buttons: any
+ * narrower and "New artifact" and "New folder" wrap onto separate lines.
+ */
+const FINDER_MIN_COLUMN_WIDTH = 244;
+const FINDER_MAX_COLUMN_WIDTH = 560;
+const FINDER_DEFAULT_COLUMN_WIDTH = 248;
+
+/** What a column can show. Anything else on the edge is not a tree node. */
+export type SdlcFinderNodeType = 'FOLDER' | 'CANVAS';
+
+/** The edge fields a column reads; the row type is wider than this. */
+interface ContainmentEdge {
+  sourceId: string;
+  targetType: string;
+  targetId: string;
+}
+
+export interface SdlcFinderFolder {
+  id: string;
+  name: string;
+}
+
+/** A rendered row, whichever kind of node it came from. */
+interface FinderRow {
+  kind: SdlcFinderNodeType;
+  id: string;
+  name: string;
+  meta: string | null;
+  createdBy: string | null;
+}
+
+export interface SdlcFinderCanvas {
+  id: string;
+  title: string;
+  /** The artifact's type — PRD, Tech Doc — which is its folder in the old sense. */
+  typeName: string;
+  createdBy: string;
+  createdAt: number;
+  updatedAt: number;
+  lastEditedBy?: string | undefined;
+  lastEditedAt?: number | undefined;
+}
+
+/** One step down the tree. The track is the first, and is never a folder. */
+export interface SdlcFinderStep {
+  type: 'TRACK' | 'FOLDER';
+  id: string;
+  name: string;
+}
+
+/**
+ * One level of the tree: the things directly inside `parent`.
+ *
+ * Containment is an edge, so a column is the same query at every depth. The
+ * component is repeated once per open level and owns exactly one live query,
+ * which is what makes the tree lazy — closing a column drops its query rather
+ * than keeping the whole hub in sync.
+ */
+export function SdlcFinderColumn(props: {
+  channelId: string;
+  parent: SdlcFinderStep;
+  /** The child on the path below this column, if one is open. */
+  selectedId: string | null;
+  /** The deepest selection on the path — the one that is live rather than trail. */
+  activeSelectionId: string | null;
+  canvasById: Map<string, SdlcFinderCanvas>;
+  isLast: boolean;
+  onSelectFolder: (folder: { id: string; name: string }) => void;
+  /** A single click: select the artifact so the preview can show it. */
+  onSelectCanvas: (canvasId: string) => void;
+  /** A double click, or a modified click that opens in its own window. */
+  onOpenCanvas: (canvasId: string, event?: ReactMouseEvent) => void;
+  /** The artifact being previewed, so its row reads as selected. */
+  previewCanvasId: string | null;
+  onNewFolder: (parent: SdlcFinderStep) => void;
+  onNewArtifact: (parent: SdlcFinderStep) => void;
+  /**
+   * Open this column's own folder's conversations. The action is here rather
+   * than on the rows because a row is a button already, and the folder you are
+   * looking into is the one a conversation started here belongs to.
+   */
+  onDiscussFolder: (folder: { id: string; name: string }) => void;
+  /** Every folder in the hub, by id — the page owns the one query behind it. */
+  folderById: ReadonlyMap<string, SdlcFinderFolder>;
+  /**
+   * The folder whose conversations the right panel is currently showing, so the
+   * browser says which one the panel belongs to. Null whenever the panel is
+   * closed or bound to the track.
+   */
+  discussingFolderId: string | null;
+  /** Committing a rename typed into a folder row. */
+  onRenameFolder: (folderId: string, name: string) => void;
+  /** Dropping an item on a folder row, or on the column's own parent. */
+  onMoveItem: (
+    item: { type: SdlcFinderNodeType; id: string },
+    parent: { type: 'TRACK' | 'FOLDER'; id: string },
+  ) => void;
+  draggingItem: { type: SdlcFinderNodeType; id: string } | null;
+  onDragItem: (item: { type: SdlcFinderNodeType; id: string } | null) => void;
+}): ReactElement {
+  const columnWidths = useUserPreference('sdlcFinderColumnWidths');
+  const columnWidth = columnWidths[props.parent.id] ?? FINDER_DEFAULT_COLUMN_WIDTH;
+  const groupBy = useUserPreference('sdlcFinderGroupBy');
+  /** The row the pointer is currently over mid-drag, so only it shows a target. */
+  const [dragOverId, setDragOverId] = useState<string | null>(null);
+  const [addOpen, setAddOpen] = useState(false);
+  /** The folder being renamed in place, and the text so far. */
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameDraft, setRenameDraft] = useState('');
+  /** Set when Escape ends a rename, so the blur that follows does not save it. */
+  const renameAbandoned = useRef(false);
+  const columnRef = useRef<HTMLDivElement | null>(null);
+
+  // Opening a folder puts its column past the right edge when the browser is
+  // already full; bring it into view so a click never appears to do nothing.
+  // `nearest` vertically, so this never scrolls the page itself.
+  useEffect(() => {
+    if (props.isLast) {
+      columnRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'end' });
+    }
+  }, [props.isLast, props.parent.id]);
+
+  // A drag that ends anywhere — dropped, cancelled, or left the column — must not
+  // leave a row still marked as the target.
+  useEffect(() => {
+    if (!props.draggingItem) setDragOverId(null);
+  }, [props.draggingItem]);
+
+  /** Drag the divider on this column's right edge; only this column moves. */
+  const startColumnResize = (event: ReactPointerEvent<HTMLDivElement>): void => {
+    event.preventDefault();
+    event.stopPropagation();
+    const startX = event.clientX;
+    const startWidth = columnWidth;
+    let latest = startWidth;
+
+    const onMove = (moveEvent: globalThis.PointerEvent): void => {
+      latest = Math.min(
+        FINDER_MAX_COLUMN_WIDTH,
+        Math.max(FINDER_MIN_COLUMN_WIDTH, startWidth + (moveEvent.clientX - startX)),
+      );
+      setUserPreference('sdlcFinderColumnWidths', { ...columnWidths, [props.parent.id]: latest });
+    };
+    const finish = (): void => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', finish);
+      window.removeEventListener('pointercancel', finish);
+      document.body.style.removeProperty('cursor');
+      document.body.style.removeProperty('user-select');
+    };
+    document.body.style.setProperty('cursor', 'col-resize');
+    document.body.style.setProperty('user-select', 'none');
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', finish);
+    window.addEventListener('pointercancel', finish);
+  };
+
+  const [edgeRows] = useCachedQuery(
+    queries.getSdlcFolderChildren({
+      channelId: props.channelId,
+      parentType: props.parent.type,
+      parentId: props.parent.id,
+    }),
+    { enabled: Boolean(props.channelId && props.parent.id) },
+  );
+  const edges: ContainmentEdge[] = Array.isArray(edgeRows) ? (edgeRows as ContainmentEdge[]) : [];
+
+  // Names come from the page's one hub-wide folder subscription rather than a
+  // per-column fetch: the columns differ in which edges they read, not in which
+  // folders exist, so one query serves every level and the page besides.
+  const folderById = props.folderById;
+
+  const rows = useMemo(
+    () =>
+      edges.flatMap<FinderRow>(edge => {
+        if (edge.targetType === 'FOLDER') {
+          const folder = folderById.get(edge.targetId);
+          // An edge whose folder has not arrived yet renders nothing rather than
+          // a blank row; a deleted one never arrives and is skipped the same way.
+          if (!folder) return [];
+          // No count line: a folder is one line, and what is inside it is one
+          // click away rather than a number to read.
+          return [
+            {
+              kind: 'FOLDER' as const,
+              id: folder.id,
+              name: folder.name,
+              meta: null,
+              createdBy: null,
+            },
+          ];
+        }
+        const canvas = props.canvasById.get(edge.targetId);
+        if (!canvas) return [];
+        return [
+          {
+            kind: 'CANVAS' as const,
+            id: canvas.id,
+            name: canvas.title,
+            meta: canvas.typeName,
+            createdBy: canvas.createdBy,
+          },
+        ];
+      }),
+    [edges, folderById, props.canvasById],
+  );
+
+  /**
+   * Rows split into labelled groups, or one unlabelled group when grouping is off.
+   * Folders lead: they are the structure, and the artifacts under a type heading
+   * are what the structure holds.
+   */
+  const groups = useMemo(() => {
+    if (groupBy === 'none') return [{ label: null, rows }];
+    const byLabel = new Map<string, FinderRow[]>();
+    for (const row of rows) {
+      const label = row.kind === 'FOLDER' ? 'Folders' : (row.meta ?? 'Artifacts');
+      const bucket = byLabel.get(label);
+      if (bucket) bucket.push(row);
+      else byLabel.set(label, [row]);
+    }
+    const labels = [...byLabel.keys()].sort((left, right) => {
+      if (left === 'Folders') return -1;
+      if (right === 'Folders') return 1;
+      return left.localeCompare(right);
+    });
+    return labels.map(label => ({ label, rows: byLabel.get(label) ?? [] }));
+  }, [groupBy, rows]);
+
+  return (
+    <div
+      onDragOver={event => {
+        if (props.draggingItem) event.preventDefault();
+      }}
+      onDrop={event => {
+        event.preventDefault();
+        const dragged = props.draggingItem;
+        if (!dragged) return;
+        props.onMoveItem(dragged, { type: props.parent.type, id: props.parent.id });
+        props.onDragItem(null);
+      }}
+      ref={columnRef}
+      style={props.isLast ? { minWidth: FINDER_MIN_COLUMN_WIDTH } : { width: columnWidth }}
+      className={cn(
+        'relative flex shrink-0 flex-col border-r border-border last:border-r-0',
+        // The open level takes the slack so the columns fill the width.
+        props.isLast && 'flex-1',
+      )}
+    >
+      {/* A real step, not a theme surface: --card and --background are the same
+          value in dark, so a tint the app already uses for its sidebar rows is
+          what actually reads as a header here. */}
+      <div className='flex shrink-0 items-center gap-2 border-b border-border bg-foreground/[0.05] px-3 py-1.5'>
+        <span className='min-w-0 flex-1 truncate text-[10px] font-semibold uppercase tracking-[0.11em] text-muted-foreground'>
+          {props.parent.name}
+        </span>
+        <span className='shrink-0 text-[10.5px] tabular-nums text-muted-foreground'>
+          {rows.length}
+        </span>
+        {props.parent.type === 'FOLDER' && (
+          <button
+            type='button'
+            title={`Conversations in ${props.parent.name}`}
+            aria-label={`Conversations in ${props.parent.name}`}
+            aria-pressed={props.discussingFolderId === props.parent.id}
+            onClick={() => props.onDiscussFolder({ id: props.parent.id, name: props.parent.name })}
+            className={cn(
+              'shrink-0 rounded p-0.5 transition-colors',
+              props.discussingFolderId === props.parent.id
+                ? 'bg-primary/15 text-primary'
+                : 'text-muted-foreground hover:bg-foreground/[0.08] hover:text-foreground',
+            )}
+            data-track-category='SdlcHub'
+            data-track-name='FolderConversationsOpened'
+          >
+            <MessageCircle className='size-3.5' />
+          </button>
+        )}
+        {/* Creating into *this* level, whatever it already holds. The empty state
+            offers the same two actions, but a column with contents had no way to
+            add to it except the page heading, whose target is not obvious. */}
+        <Popover
+          open={addOpen}
+          onOpenChange={setAddOpen}
+          align='end'
+          sideOffset={6}
+          className='w-[170px] p-1'
+          trigger={
+            <button
+              type='button'
+              title={`Add to ${props.parent.name}`}
+              aria-label={`Add to ${props.parent.name}`}
+              className='-mr-1 shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-foreground/[0.08] hover:text-foreground'
+              data-track-category='SdlcHub'
+              data-track-name='FinderColumnAddOpened'
+            >
+              <Plus className='size-3.5' />
+            </button>
+          }
+        >
+          <button
+            type='button'
+            onClick={() => {
+              setAddOpen(false);
+              props.onNewArtifact(props.parent);
+            }}
+            className='flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[12.5px] transition-colors hover:bg-muted'
+            data-track-category='SdlcHub'
+            data-track-name='NewArtifactOpened'
+          >
+            <FileText className='size-3.5 shrink-0 text-muted-foreground' />
+            New artifact
+          </button>
+          <button
+            type='button'
+            onClick={() => {
+              setAddOpen(false);
+              props.onNewFolder(props.parent);
+            }}
+            className='flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[12.5px] transition-colors hover:bg-muted'
+            data-track-category='SdlcHub'
+            data-track-name='NewFolderOpened'
+          >
+            <Folder className='size-3.5 shrink-0 text-muted-foreground' />
+            New folder
+          </button>
+        </Popover>
+      </div>
+
+      {!props.isLast && (
+        <div
+          role='separator'
+          aria-orientation='vertical'
+          aria-label='Resize columns'
+          onPointerDown={startColumnResize}
+          className='group absolute inset-y-0 -right-1 z-10 w-2 cursor-col-resize'
+          data-track-category='SdlcHub'
+          data-track-name='FinderColumnResized'
+        >
+          <div
+            className='pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-primary opacity-0 transition-opacity duration-150 group-hover:opacity-70'
+            aria-hidden='true'
+          />
+        </div>
+      )}
+      <div className='scrollbar-none min-h-0 flex-1 overflow-y-auto p-1.5'>
+        {groups.map(group => (
+          <div key={group.label ?? 'all'} className='mb-1 last:mb-0'>
+            {group.label && (
+              <div className='px-2 pb-1 pt-1.5 text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground'>
+                {group.label}
+              </div>
+            )}
+            {group.rows.map(row => {
+              const selected =
+                props.selectedId === row.id ||
+                (row.kind === 'CANVAS' && props.previewCanvasId === row.id);
+              // The deepest selection is the live one; the selections above it only
+              // mark the path taken to get here, so they go quiet rather than
+              // competing with it.
+              const activeSelected =
+                selected &&
+                (row.id === props.activeSelectionId || props.previewCanvasId === row.id);
+              return (
+                <button
+                  key={row.id}
+                  type='button'
+                  onClick={event => {
+                    if (row.kind === 'FOLDER') {
+                      props.onSelectFolder({ id: row.id, name: row.name });
+                      return;
+                    }
+                    // Cmd/Ctrl-click keeps its existing meaning — open in a window —
+                    // so a plain click is free to mean "show me this" as it does in
+                    // a file browser.
+                    if (event.metaKey || event.ctrlKey || event.shiftKey) {
+                      props.onOpenCanvas(row.id, event);
+                      return;
+                    }
+                    props.onSelectCanvas(row.id);
+                  }}
+                  onDoubleClick={event => {
+                    if (row.kind === 'CANVAS') {
+                      props.onOpenCanvas(row.id, event);
+                      return;
+                    }
+                    // Only a folder already selected: the first click of a
+                    // double-click opens a folder, so renaming an unselected one
+                    // would race with stepping into it.
+                    if (selected) {
+                      event.preventDefault();
+                      setRenameDraft(row.name);
+                      setRenamingId(row.id);
+                    }
+                  }}
+                  draggable={renamingId !== row.id}
+                  onDragStart={() => props.onDragItem({ type: row.kind, id: row.id })}
+                  onDragEnd={() => props.onDragItem(null)}
+                  onDragOver={event => {
+                    // Only folders take a drop, and nothing may be dropped on itself.
+                    if (
+                      row.kind === 'FOLDER' &&
+                      props.draggingItem?.id &&
+                      props.draggingItem?.id !== row.id
+                    ) {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      setDragOverId(row.id);
+                    }
+                  }}
+                  onDragLeave={() =>
+                    setDragOverId(current => (current === row.id ? null : current))
+                  }
+                  onDrop={event => {
+                    setDragOverId(null);
+                    const dragged = props.draggingItem;
+                    if (row.kind !== 'FOLDER' || !dragged || dragged.id === row.id) return;
+                    event.preventDefault();
+                    event.stopPropagation();
+                    props.onMoveItem(dragged, { type: 'FOLDER', id: row.id });
+                    props.onDragItem(null);
+                  }}
+                  className={cn(
+                    'mb-px flex w-full items-center gap-2.5 rounded-md px-2 py-2 text-left transition-colors',
+                    activeSelected && 'bg-primary text-primary-foreground',
+                    selected && !activeSelected && 'bg-foreground/[0.07] text-foreground',
+                    !selected && 'hover:bg-muted',
+                    props.draggingItem?.id === row.id && 'opacity-40',
+                    dragOverId === row.id && 'ring-1 ring-inset ring-primary',
+                  )}
+                  data-track-category='SdlcHub'
+                  data-track-name={row.kind === 'FOLDER' ? 'FolderOpened' : 'FinderCanvasOpened'}
+                  data-track-metadata={JSON.stringify({ id: row.id })}
+                >
+                  {row.kind === 'FOLDER' ? (
+                    // Filled, so a folder reads as a solid shape beside the outlined
+                    // documents rather than as another line drawing.
+                    <Folder
+                      className={cn(
+                        'size-[18px] shrink-0',
+                        activeSelected ? 'fill-current' : 'fill-primary/25 text-primary/70',
+                      )}
+                    />
+                  ) : (
+                    <FileText
+                      className={cn(
+                        'size-[18px] shrink-0',
+                        activeSelected ? '' : 'text-primary/70',
+                      )}
+                    />
+                  )}
+                  {renamingId === row.id ? (
+                    <input
+                      autoFocus
+                      value={renameDraft}
+                      maxLength={120}
+                      onChange={event => setRenameDraft(event.target.value)}
+                      onClick={event => event.stopPropagation()}
+                      onDoubleClick={event => event.stopPropagation()}
+                      onFocus={event =>
+                        event.target.setSelectionRange(0, event.target.value.length)
+                      }
+                      onKeyDown={event => {
+                        if (event.key === 'Escape') {
+                          renameAbandoned.current = true;
+                          setRenamingId(null);
+                        }
+                        if (event.key === 'Enter') event.currentTarget.blur();
+                      }}
+                      onBlur={() => {
+                        const next = renameDraft.trim();
+                        setRenamingId(null);
+                        if (renameAbandoned.current) {
+                          renameAbandoned.current = false;
+                          return;
+                        }
+                        // A folder has to be called something, and renaming it to
+                        // what it already is is not a change worth a round trip.
+                        if (next.length > 0 && next !== row.name) {
+                          props.onRenameFolder(row.id, next);
+                        }
+                      }}
+                      className='min-w-0 flex-1 rounded border-0 bg-background px-1 text-[12.5px] font-semibold leading-[18px] tracking-[-0.01em] text-foreground outline-none ring-1 ring-primary'
+                      data-track-category='SdlcHub'
+                      data-track-name='FolderRenamed'
+                    />
+                  ) : (
+                    <span
+                      className={cn(
+                        'min-w-0 flex-1 truncate text-[12.5px] leading-[18px] tracking-[-0.01em]',
+                        row.kind === 'FOLDER' ? 'font-semibold' : 'font-medium',
+                      )}
+                    >
+                      {row.name}
+                    </span>
+                  )}
+                  {/* The type sits beside the name rather than beneath it, so a file
+                  row is the same height as a folder row and the column keeps one
+                  rhythm. */}
+                  {row.meta && (
+                    <span
+                      className={cn(
+                        'shrink-0 truncate text-[10.5px]',
+                        activeSelected ? 'opacity-75' : 'text-muted-foreground',
+                      )}
+                    >
+                      {row.meta}
+                    </span>
+                  )}
+                  {row.createdBy && (
+                    <Avatar userId={row.createdBy} size='xs' showActiveStatus={false} />
+                  )}
+                  {row.kind === 'FOLDER' && (
+                    <ChevronRight
+                      className={cn(
+                        'size-3 shrink-0',
+                        activeSelected ? '' : 'text-muted-foreground',
+                      )}
+                    />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        ))}
+        {rows.length === 0 && (
+          // Centred in the column rather than perched at the top of it, and it
+          // says what to do next: an empty column is the one place a reader has
+          // nothing to go on.
+          <div className='flex h-full flex-col items-center justify-center gap-2 px-6 py-10 text-center'>
+            <div className='grid size-9 place-items-center rounded-lg bg-foreground/[0.05]'>
+              <FolderOpen className='size-4 text-muted-foreground' aria-hidden='true' />
+            </div>
+            <p className='text-[12.5px] font-medium text-foreground'>
+              {props.parent.type === 'TRACK' ? 'Nothing here yet' : 'This folder is empty'}
+            </p>
+            <p className='max-w-[190px] text-[11.5px] leading-relaxed text-muted-foreground'>
+              {props.parent.type === 'TRACK'
+                ? 'Create an artifact, or add a folder to group them.'
+                : 'Create an artifact here, or drag one in from another folder.'}
+            </p>
+            <div className='mt-1 flex items-center gap-1.5'>
+              <button
+                type='button'
+                onClick={() => props.onNewArtifact(props.parent)}
+                className='flex items-center gap-1.5 whitespace-nowrap rounded-md bg-primary px-2.5 py-1 text-[11.5px] font-medium text-primary-foreground transition-opacity hover:opacity-90'
+                data-track-category='SdlcHub'
+                data-track-name='NewArtifactOpened'
+              >
+                <Plus className='size-3' />
+                New artifact
+              </button>
+              <button
+                type='button'
+                onClick={() => props.onNewFolder(props.parent)}
+                className='flex items-center gap-1.5 whitespace-nowrap rounded-md border border-border px-2.5 py-1 text-[11.5px] font-medium text-foreground transition-colors hover:bg-muted'
+                data-track-category='SdlcHub'
+                data-track-name='NewFolderOpened'
+              >
+                <Plus className='size-3' />
+                New folder
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The preview a single click opens, standing where the next column would be.
+ *
+ * A file has no children, so the column that would list them says what the file
+ * is instead — which is what makes one click worth making in a browser like this.
+ */
+export function SdlcFinderPreview(props: {
+  canvas: SdlcFinderCanvas;
+  onOpen: (canvasId: string, event?: ReactMouseEvent) => void;
+  /** Read it in place, in the side panel, without leaving the browser. */
+  onPreview: (canvasId: string) => void;
+}): ReactElement {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const owner = useUser(props.canvas.createdBy);
+  useEffect(() => {
+    panelRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'end' });
+  }, [props.canvas.id]);
+
+  const when = (value: number | undefined): string =>
+    value
+      ? new Date(value).toLocaleDateString(undefined, {
+          day: 'numeric',
+          month: 'short',
+          year: 'numeric',
+        })
+      : '—';
+
+  const edited = props.canvas.lastEditedAt ?? props.canvas.updatedAt;
+  const editedBy = props.canvas.lastEditedBy ?? props.canvas.createdBy;
+
+  return (
+    // Fixed and narrow: a preview stretched across the remaining width is mostly
+    // empty, and the facts in it read better in a column than in a banner.
+    <div ref={panelRef} className='flex w-[300px] shrink-0 flex-col border-r border-border'>
+      <div className='flex shrink-0 items-center border-b border-border bg-foreground/[0.05] px-3 py-1.5'>
+        <span className='truncate text-[10px] font-semibold uppercase tracking-[0.11em] text-muted-foreground'>
+          Preview
+        </span>
+      </div>
+
+      <div className='scrollbar-none flex min-h-0 flex-1 flex-col overflow-y-auto p-4'>
+        <div className='flex items-start gap-3'>
+          <div className='grid size-10 shrink-0 place-items-center rounded-lg bg-primary/10'>
+            <FileText className='size-5 text-primary' />
+          </div>
+          <div className='min-w-0 flex-1'>
+            <p className='text-[13.5px] font-semibold leading-snug'>{props.canvas.title}</p>
+            <p className='mt-0.5 text-[11.5px] text-muted-foreground'>{props.canvas.typeName}</p>
+          </div>
+        </div>
+
+        {/* The facts the hub already knows, rather than an icon and a title the
+            row beside it has just shown. */}
+        <dl className='mt-4 space-y-2.5 border-t border-border pt-3'>
+          <div className='flex items-center justify-between gap-3'>
+            <dt className='shrink-0 text-[11px] text-muted-foreground'>Type</dt>
+            <dd className='min-w-0 truncate text-[11.5px] font-medium'>{props.canvas.typeName}</dd>
+          </div>
+          <div className='flex items-center justify-between gap-3'>
+            <dt className='shrink-0 text-[11px] text-muted-foreground'>Owner</dt>
+            {/* Named, not just pictured: an initial in a circle is not an answer
+                to "who owns this". No hover card here — the panel is already the
+                place you came to read the details. */}
+            <dd className='flex min-w-0 items-center gap-1.5'>
+              <Avatar userId={props.canvas.createdBy} size='xs' showActiveStatus={false} />
+              <span className='min-w-0 truncate text-[11.5px]'>
+                {owner ? getUserDisplayName(owner) : 'Unknown'}
+              </span>
+            </dd>
+          </div>
+          <div className='flex items-center justify-between gap-3'>
+            <dt className='shrink-0 text-[11px] text-muted-foreground'>Created</dt>
+            <dd className='text-[11.5px] tabular-nums'>{when(props.canvas.createdAt)}</dd>
+          </div>
+          <div className='flex items-center justify-between gap-3'>
+            <dt className='shrink-0 text-[11px] text-muted-foreground'>Last edited</dt>
+            <dd className='flex items-center gap-1.5 text-[11.5px] tabular-nums'>
+              {when(edited)}
+              <Avatar userId={editedBy} size='xs' showActiveStatus={false} />
+            </dd>
+          </div>
+        </dl>
+
+        <div className='mt-auto flex items-center gap-1.5 pt-4'>
+          <button
+            type='button'
+            onClick={() => props.onPreview(props.canvas.id)}
+            title='Preview in a side panel'
+            className='h-8 flex-1 rounded-md bg-primary text-[12px] font-medium text-primary-foreground transition-opacity hover:opacity-90'
+            data-track-category='SdlcHub'
+            data-track-name='FinderPreviewPaneOpened'
+          >
+            Preview
+          </button>
+          <button
+            type='button'
+            onClick={event => props.onOpen(props.canvas.id, event)}
+            title='Open the artifact'
+            className='h-8 flex-1 rounded-md border border-border text-[12px] font-medium text-foreground transition-colors hover:bg-muted'
+            data-track-category='SdlcHub'
+            data-track-name='FinderPreviewOpened'
+          >
+            Open
+          </button>
+        </div>
+        <p className='mt-2 text-center text-[10.5px] leading-relaxed text-muted-foreground'>
+          Double-click the row to open · ⌘-click for a new window
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcFinder.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcFinder.tsx
@@ -17,18 +17,12 @@ import { useUser } from '../../hooks/useUsers';
 import { getUserDisplayName } from '../../utils/userDisplayName';
 import { setUserPreference, useUserPreference } from '../../machines/userPreferencesMachine';
 
-/**
- * Column width bounds. The minimum is set by the empty state's two buttons: any
- * narrower and "New artifact" and "New folder" wrap onto separate lines.
- */
 const FINDER_MIN_COLUMN_WIDTH = 244;
 const FINDER_MAX_COLUMN_WIDTH = 560;
 const FINDER_DEFAULT_COLUMN_WIDTH = 248;
 
-/** What a column can show. Anything else on the edge is not a tree node. */
 export type SdlcFinderNodeType = 'FOLDER' | 'CANVAS';
 
-/** The edge fields a column reads; the row type is wider than this. */
 interface ContainmentEdge {
   sourceId: string;
   targetType: string;
@@ -40,7 +34,6 @@ export interface SdlcFinderFolder {
   name: string;
 }
 
-/** A rendered row, whichever kind of node it came from. */
 interface FinderRow {
   kind: SdlcFinderNodeType;
   id: string;
@@ -52,7 +45,6 @@ interface FinderRow {
 export interface SdlcFinderCanvas {
   id: string;
   title: string;
-  /** The artifact's type — PRD, Tech Doc — which is its folder in the old sense. */
   typeName: string;
   createdBy: string;
   createdAt: number;
@@ -61,56 +53,29 @@ export interface SdlcFinderCanvas {
   lastEditedAt?: number | undefined;
 }
 
-/** One step down the tree. The track is the first, and is never a folder. */
 export interface SdlcFinderStep {
   type: 'TRACK' | 'FOLDER';
   id: string;
   name: string;
 }
 
-/**
- * One level of the tree: the things directly inside `parent`.
- *
- * Containment is an edge, so a column is the same query at every depth. The
- * component is repeated once per open level and owns exactly one live query,
- * which is what makes the tree lazy — closing a column drops its query rather
- * than keeping the whole hub in sync.
- */
 export function SdlcFinderColumn(props: {
   channelId: string;
   parent: SdlcFinderStep;
-  /** The child on the path below this column, if one is open. */
   selectedId: string | null;
-  /** The deepest selection on the path — the one that is live rather than trail. */
   activeSelectionId: string | null;
   canvasById: Map<string, SdlcFinderCanvas>;
   isLast: boolean;
   onSelectFolder: (folder: { id: string; name: string }) => void;
-  /** A single click: select the artifact so the preview can show it. */
   onSelectCanvas: (canvasId: string) => void;
-  /** A double click, or a modified click that opens in its own window. */
   onOpenCanvas: (canvasId: string, event?: ReactMouseEvent) => void;
-  /** The artifact being previewed, so its row reads as selected. */
   previewCanvasId: string | null;
   onNewFolder: (parent: SdlcFinderStep) => void;
   onNewArtifact: (parent: SdlcFinderStep) => void;
-  /**
-   * Open this column's own folder's conversations. The action is here rather
-   * than on the rows because a row is a button already, and the folder you are
-   * looking into is the one a conversation started here belongs to.
-   */
   onDiscussFolder: (folder: { id: string; name: string }) => void;
-  /** Every folder in the hub, by id — the page owns the one query behind it. */
   folderById: ReadonlyMap<string, SdlcFinderFolder>;
-  /**
-   * The folder whose conversations the right panel is currently showing, so the
-   * browser says which one the panel belongs to. Null whenever the panel is
-   * closed or bound to the track.
-   */
   discussingFolderId: string | null;
-  /** Committing a rename typed into a folder row. */
   onRenameFolder: (folderId: string, name: string) => void;
-  /** Dropping an item on a folder row, or on the column's own parent. */
   onMoveItem: (
     item: { type: SdlcFinderNodeType; id: string },
     parent: { type: 'TRACK' | 'FOLDER'; id: string },
@@ -119,43 +84,27 @@ export function SdlcFinderColumn(props: {
   onDragItem: (item: { type: SdlcFinderNodeType; id: string } | null) => void;
 }): ReactElement {
   const columnWidths = useUserPreference('sdlcFinderColumnWidths');
-  /**
-   * The width mid-drag. Persisting on every pointermove re-rendered every open
-   * column each frame, because the preference is shared; holding it here keeps
-   * the drag to this column and writes once, on release.
-   */
   const [dragWidth, setDragWidth] = useState<number | null>(null);
-  const columnWidth =
-    dragWidth ?? columnWidths[props.parent.id] ?? FINDER_DEFAULT_COLUMN_WIDTH;
+  const columnWidth = dragWidth ?? columnWidths[props.parent.id] ?? FINDER_DEFAULT_COLUMN_WIDTH;
   const groupBy = useUserPreference('sdlcFinderGroupBy');
-  /** The row the pointer is currently over mid-drag, so only it shows a target. */
   const [dragOverId, setDragOverId] = useState<string | null>(null);
-  /** The pointer is over this column but not over a row, so the drop lands here. */
   const [columnDragOver, setColumnDragOver] = useState(false);
   const [addOpen, setAddOpen] = useState(false);
-  /** The folder being renamed in place, and the text so far. */
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameDraft, setRenameDraft] = useState('');
-  /** Set when Escape ends a rename, so the blur that follows does not save it. */
   const renameAbandoned = useRef(false);
   const columnRef = useRef<HTMLDivElement | null>(null);
 
-  // Opening a folder puts its column past the right edge when the browser is
-  // already full; bring it into view so a click never appears to do nothing.
-  // `nearest` vertically, so this never scrolls the page itself.
   useEffect(() => {
     if (props.isLast) {
       columnRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'end' });
     }
   }, [props.isLast, props.parent.id]);
 
-  // A drag that ends anywhere — dropped, cancelled, or left the column — must not
-  // leave a row still marked as the target.
   useEffect(() => {
     if (!props.draggingItem) setDragOverId(null);
   }, [props.draggingItem]);
 
-  /** Drag the divider on this column's right edge; only this column moves. */
   const startColumnResize = (event: ReactPointerEvent<HTMLDivElement>): void => {
     event.preventDefault();
     event.stopPropagation();
@@ -196,9 +145,6 @@ export function SdlcFinderColumn(props: {
   );
   const edges: ContainmentEdge[] = Array.isArray(edgeRows) ? (edgeRows as ContainmentEdge[]) : [];
 
-  // Names come from the page's one hub-wide folder subscription rather than a
-  // per-column fetch: the columns differ in which edges they read, not in which
-  // folders exist, so one query serves every level and the page besides.
   const folderById = props.folderById;
 
   const rows = useMemo(
@@ -206,11 +152,7 @@ export function SdlcFinderColumn(props: {
       edges.flatMap<FinderRow>(edge => {
         if (edge.targetType === 'FOLDER') {
           const folder = folderById.get(edge.targetId);
-          // An edge whose folder has not arrived yet renders nothing rather than
-          // a blank row; a deleted one never arrives and is skipped the same way.
           if (!folder) return [];
-          // No count line: a folder is one line, and what is inside it is one
-          // click away rather than a number to read.
           return [
             {
               kind: 'FOLDER' as const,
@@ -236,11 +178,6 @@ export function SdlcFinderColumn(props: {
     [edges, folderById, props.canvasById],
   );
 
-  /**
-   * Rows split into labelled groups, or one unlabelled group when grouping is off.
-   * Folders lead: they are the structure, and the artifacts under a type heading
-   * are what the structure holds.
-   */
   const groups = useMemo(() => {
     if (groupBy === 'none') return [{ label: null, rows }];
     const byLabel = new Map<string, FinderRow[]>();
@@ -266,8 +203,6 @@ export function SdlcFinderColumn(props: {
         setColumnDragOver(true);
       }}
       onDragLeave={event => {
-        // dragleave also fires crossing into a child, so only a pointer that has
-        // actually left the column clears the highlight.
         if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
           setColumnDragOver(false);
         }
@@ -284,10 +219,7 @@ export function SdlcFinderColumn(props: {
       style={props.isLast ? { minWidth: FINDER_MIN_COLUMN_WIDTH } : { width: columnWidth }}
       className={cn(
         'relative flex shrink-0 flex-col border-r border-border transition-colors last:border-r-0',
-        // The open level takes the slack so the columns fill the width.
         props.isLast && 'flex-1',
-        // Where the drop would land, when it is the level itself rather than a
-        // folder in it. A row under the pointer owns the target instead.
         props.draggingItem && columnDragOver && !dragOverId && 'bg-primary/[0.06]',
       )}
     >
@@ -401,9 +333,6 @@ export function SdlcFinderColumn(props: {
               const selected =
                 props.selectedId === row.id ||
                 (row.kind === 'CANVAS' && props.previewCanvasId === row.id);
-              // The deepest selection is the live one; the selections above it only
-              // mark the path taken to get here, so they go quiet rather than
-              // competing with it.
               const activeSelected =
                 selected &&
                 (row.id === props.activeSelectionId || props.previewCanvasId === row.id);
@@ -416,9 +345,6 @@ export function SdlcFinderColumn(props: {
                       props.onSelectFolder({ id: row.id, name: row.name });
                       return;
                     }
-                    // Cmd/Ctrl-click keeps its existing meaning — open in a window —
-                    // so a plain click is free to mean "show me this" as it does in
-                    // a file browser.
                     if (event.metaKey || event.ctrlKey || event.shiftKey) {
                       props.onOpenCanvas(row.id, event);
                       return;
@@ -430,14 +356,8 @@ export function SdlcFinderColumn(props: {
                       props.onOpenCanvas(row.id, event);
                       return;
                     }
-                    // Only a folder already selected: the first click of a
-                    // double-click opens a folder, so renaming an unselected one
-                    // would race with stepping into it.
                     if (selected) {
                       event.preventDefault();
-                      // Escape unmounts the input and React fires no blur for
-                      // an unmounted element, so arm the guard as the editor
-                      // opens rather than clearing it on the way out.
                       renameAbandoned.current = false;
                       setRenameDraft(row.name);
                       setRenamingId(row.id);
@@ -445,15 +365,12 @@ export function SdlcFinderColumn(props: {
                   }}
                   draggable={renamingId !== row.id}
                   onDragStart={event => {
-                    // Firefox starts no drag without a dataTransfer entry, which
-                    // left the whole move-by-drag feature silently inert there.
                     event.dataTransfer.effectAllowed = 'move';
                     event.dataTransfer.setData('text/plain', row.id);
                     props.onDragItem({ type: row.kind, id: row.id });
                   }}
                   onDragEnd={() => props.onDragItem(null)}
                   onDragOver={event => {
-                    // Only folders take a drop, and nothing may be dropped on itself.
                     if (
                       row.kind === 'FOLDER' &&
                       props.draggingItem?.id &&
@@ -489,8 +406,6 @@ export function SdlcFinderColumn(props: {
                   data-track-metadata={JSON.stringify({ id: row.id })}
                 >
                   {row.kind === 'FOLDER' ? (
-                    // Filled, so a folder reads as a solid shape beside the outlined
-                    // documents rather than as another line drawing.
                     <Folder
                       className={cn(
                         'size-[18px] shrink-0',
@@ -530,8 +445,6 @@ export function SdlcFinderColumn(props: {
                           renameAbandoned.current = false;
                           return;
                         }
-                        // A folder has to be called something, and renaming it to
-                        // what it already is is not a change worth a round trip.
                         if (next.length > 0 && next !== row.name) {
                           props.onRenameFolder(row.id, next);
                         }
@@ -580,9 +493,6 @@ export function SdlcFinderColumn(props: {
           </div>
         ))}
         {rows.length === 0 && (
-          // Centred in the column rather than perched at the top of it, and it
-          // says what to do next: an empty column is the one place a reader has
-          // nothing to go on.
           <div className='flex h-full flex-col items-center justify-center gap-2 px-6 py-10 text-center'>
             <div className='grid size-9 place-items-center rounded-lg bg-foreground/[0.05]'>
               <FolderOpen className='size-4 text-muted-foreground' aria-hidden='true' />
@@ -624,16 +534,9 @@ export function SdlcFinderColumn(props: {
   );
 }
 
-/**
- * The preview a single click opens, standing where the next column would be.
- *
- * A file has no children, so the column that would list them says what the file
- * is instead — which is what makes one click worth making in a browser like this.
- */
 export function SdlcFinderPreview(props: {
   canvas: SdlcFinderCanvas;
   onOpen: (canvasId: string, event?: ReactMouseEvent) => void;
-  /** Read it in place, in the side panel, without leaving the browser. */
   onPreview: (canvasId: string) => void;
 }): ReactElement {
   const panelRef = useRef<HTMLDivElement | null>(null);
@@ -655,8 +558,6 @@ export function SdlcFinderPreview(props: {
   const editedBy = props.canvas.lastEditedBy ?? props.canvas.createdBy;
 
   return (
-    // Fixed and narrow: a preview stretched across the remaining width is mostly
-    // empty, and the facts in it read better in a column than in a banner.
     <div ref={panelRef} className='flex w-[300px] shrink-0 flex-col border-r border-border'>
       <div className='flex shrink-0 items-center border-b border-border bg-foreground/[0.05] px-3 py-1.5'>
         <span className='truncate text-[10px] font-semibold uppercase tracking-[0.11em] text-muted-foreground'>

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcFinder.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcFinder.tsx
@@ -119,7 +119,14 @@ export function SdlcFinderColumn(props: {
   onDragItem: (item: { type: SdlcFinderNodeType; id: string } | null) => void;
 }): ReactElement {
   const columnWidths = useUserPreference('sdlcFinderColumnWidths');
-  const columnWidth = columnWidths[props.parent.id] ?? FINDER_DEFAULT_COLUMN_WIDTH;
+  /**
+   * The width mid-drag. Persisting on every pointermove re-rendered every open
+   * column each frame, because the preference is shared; holding it here keeps
+   * the drag to this column and writes once, on release.
+   */
+  const [dragWidth, setDragWidth] = useState<number | null>(null);
+  const columnWidth =
+    dragWidth ?? columnWidths[props.parent.id] ?? FINDER_DEFAULT_COLUMN_WIDTH;
   const groupBy = useUserPreference('sdlcFinderGroupBy');
   /** The row the pointer is currently over mid-drag, so only it shows a target. */
   const [dragOverId, setDragOverId] = useState<string | null>(null);
@@ -161,9 +168,11 @@ export function SdlcFinderColumn(props: {
         FINDER_MAX_COLUMN_WIDTH,
         Math.max(FINDER_MIN_COLUMN_WIDTH, startWidth + (moveEvent.clientX - startX)),
       );
-      setUserPreference('sdlcFinderColumnWidths', { ...columnWidths, [props.parent.id]: latest });
+      setDragWidth(latest);
     };
     const finish = (): void => {
+      setUserPreference('sdlcFinderColumnWidths', { ...columnWidths, [props.parent.id]: latest });
+      setDragWidth(null);
       window.removeEventListener('pointermove', onMove);
       window.removeEventListener('pointerup', finish);
       window.removeEventListener('pointercancel', finish);

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcFinder.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcFinder.tsx
@@ -426,12 +426,22 @@ export function SdlcFinderColumn(props: {
                     // would race with stepping into it.
                     if (selected) {
                       event.preventDefault();
+                      // Escape unmounts the input and React fires no blur for
+                      // an unmounted element, so arm the guard as the editor
+                      // opens rather than clearing it on the way out.
+                      renameAbandoned.current = false;
                       setRenameDraft(row.name);
                       setRenamingId(row.id);
                     }
                   }}
                   draggable={renamingId !== row.id}
-                  onDragStart={() => props.onDragItem({ type: row.kind, id: row.id })}
+                  onDragStart={event => {
+                    // Firefox starts no drag without a dataTransfer entry, which
+                    // left the whole move-by-drag feature silently inert there.
+                    event.dataTransfer.effectAllowed = 'move';
+                    event.dataTransfer.setData('text/plain', row.id);
+                    props.onDragItem({ type: row.kind, id: row.id });
+                  }}
                   onDragEnd={() => props.onDragItem(null)}
                   onDragOver={event => {
                     // Only folders take a drop, and nothing may be dropped on itself.

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcHubSidebar.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcHubSidebar.tsx
@@ -1,8 +1,45 @@
-import { useMemo, useState, type ReactElement } from 'react';
-import { ChevronRight, ExternalLink, GitBranch, Hash, Lock, Settings2 } from 'lucide-react';
+import { useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react';
+import {
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  GitBranch,
+  Hash,
+  Lock,
+  Plus,
+  Settings2,
+} from 'lucide-react';
+import { Panel, Separator, usePanelRef } from '../../components/ui/Resizable/Resizable';
+import { cn } from '../../utils/classNames';
+import {
+  setUserPreference,
+  useUserPreference,
+  userPreferencesSnapshot,
+} from '../../machines/userPreferencesMachine';
 import { EntitySelector } from '../../components/ui/EntitySelector/EntitySelector';
 import type { SelectorOption } from '../../components/ui/EntitySelector/EntitySelector.types';
 import { Popover } from '../../components/ui/Popover';
+
+/** Header height, and therefore the height a collapsed section folds down to. */
+const SECTION_HEADER_HEIGHT = 28;
+/** Height a section opens to when neither the reader nor the caller has said. */
+const DEFAULT_SECTION_HEIGHT = 170;
+/** Least an open section may be squeezed to — enough to be worth having open. */
+const MIN_OPEN_SECTION_HEIGHT = 150;
+/** Height of a drag handle. The sections share what is left after these. */
+const SECTION_SEPARATOR_HEIGHT = 7;
+/**
+ * The resizable sections, in the order they appear, with the height each opens
+ * to before the reader drags it anywhere. They live here rather than at the call
+ * site because working out one section's height needs all of them: the space is
+ * shared, so the answer is a layout, not four independent decisions.
+ */
+export const SDLC_SECTIONS: ReadonlyArray<{ id: string; defaultHeight: number }> = [
+  { id: 'sdlc-sidebar-hub', defaultHeight: 180 },
+  { id: 'sdlc-sidebar-tracks', defaultHeight: 200 },
+  { id: 'sdlc-sidebar-artifacts', defaultHeight: 180 },
+  { id: 'sdlc-sidebar-repositories', defaultHeight: 180 },
+];
 
 export interface SdlcHubRepository {
   id: string;
@@ -22,7 +59,11 @@ function repositoryHref(repository: SdlcHubRepository): string {
   return repository.canonicalUrl || repository.url;
 }
 
-/** Hub switcher. Repository names ride in the subtitle, which the selector searches. */
+/**
+ * Hub switcher. Repository names ride in the subtitle, which the selector
+ * searches — and they need room, so the dropdown is left to size itself to its
+ * content rather than being pinned to the trigger's sidebar-narrow width.
+ */
 export function SdlcHubPicker(props: {
   hubs: SdlcHubOption[];
   selectedHubId: string;
@@ -56,7 +97,7 @@ export function SdlcHubPicker(props: {
       placeholder='Select hub'
       searchPlaceholder='Search hubs and repositories...'
       width='100%'
-      matchTriggerWidth
+      dropdownMinWidth='22rem'
     />
   );
 }
@@ -131,5 +172,286 @@ export function SdlcHubRepositories(props: {
         Manage repositories
       </button>
     </Popover>
+  );
+}
+
+/**
+ * How tall each section should be, given the space there is and what the reader
+ * has asked for.
+ *
+ * When the stored heights fit, they are used as-is. When they do not — a height
+ * Whatever is open fills the sidebar between the folded headers, sharing the room
+ * in proportion to the heights asked for. Sections are not left at a height that
+ * strands empty space below the last one — a folded header belongs against the
+ * section under it, not floating with a gap beneath. Only when every section is
+ * folded do the headers stack and the space below them go unused.
+ *
+ * Each open section is first given enough to look open, so none is ever squeezed
+ * to its header while its chevron points open, and a sidebar too short for what
+ * was asked for shrinks everything a little rather than starving whichever
+ * sections happen to come last.
+ */
+export function sdlcSectionLayout(
+  groupHeight: number,
+  collapsedSections: Record<string, boolean>,
+  sectionHeights: Record<string, number>,
+): Record<string, number> {
+  const heights: Record<string, number> = {};
+  for (const section of SDLC_SECTIONS) {
+    if (collapsedSections[section.id]) heights[section.id] = SECTION_HEADER_HEIGHT;
+  }
+  const open = SDLC_SECTIONS.filter(section => !collapsedSections[section.id]);
+  if (open.length === 0) return heights;
+
+  // The drag handles between the sections take height too. Leaving them out
+  // scaled every section up by the few percent they occupy, which is a visible
+  // jump the moment a drag ends and the layout is reapplied.
+  const available =
+    groupHeight -
+    (SDLC_SECTIONS.length - 1) * SECTION_SEPARATOR_HEIGHT -
+    (SDLC_SECTIONS.length - open.length) * SECTION_HEADER_HEIGHT;
+  if (available <= 0) {
+    for (const section of open) heights[section.id] = SECTION_HEADER_HEIGHT;
+    return heights;
+  }
+
+  const wanted = new Map(
+    open.map(section => [
+      section.id,
+      Math.max(MIN_OPEN_SECTION_HEIGHT, sectionHeights[section.id] ?? section.defaultHeight),
+    ]),
+  );
+  const wantedTotal = open.reduce((total, section) => total + (wanted.get(section.id) ?? 0), 0);
+
+  // When what the reader asked for fits, they get exactly that, and the last open
+  // section takes up whatever is left over. Sharing the slack across all of them
+  // instead meant folding one section resized every other one, so the whole
+  // sidebar shifted under the pointer to open a single list.
+  if (wantedTotal <= available) {
+    const last = open[open.length - 1];
+    open.forEach(section => {
+      heights[section.id] = wanted.get(section.id) ?? section.defaultHeight;
+    });
+    if (last) heights[last.id] = (heights[last.id] ?? 0) + (available - wantedTotal);
+    return heights;
+  }
+
+  // Too tall to fit: everything shrinks a little, in proportion. Straight scaling,
+  // so heights that already fill the sidebar map to themselves — anything that
+  // reshuffles them gives a different answer each time it runs over its own
+  // output, which walks the sections further on every collapse and snaps them
+  // away from where a drag just put them.
+  const settled = new Map<string, number>();
+  let pool = [...open];
+  let remaining = available;
+  for (;;) {
+    const poolTotal = pool.reduce((total, section) => total + (wanted.get(section.id) ?? 0), 0);
+    if (poolTotal <= 0) {
+      for (const section of pool) settled.set(section.id, remaining / pool.length);
+      break;
+    }
+    // A section too small to read as open takes its minimum off the top; the rest
+    // then share what is left, which may push another below the line in turn.
+    const starved = pool.filter(
+      section => ((wanted.get(section.id) ?? 0) / poolTotal) * remaining < MIN_OPEN_SECTION_HEIGHT,
+    );
+    if (starved.length === 0) {
+      for (const section of pool) {
+        settled.set(section.id, ((wanted.get(section.id) ?? 0) / poolTotal) * remaining);
+      }
+      break;
+    }
+    for (const section of starved) {
+      settled.set(section.id, MIN_OPEN_SECTION_HEIGHT);
+      remaining -= MIN_OPEN_SECTION_HEIGHT;
+    }
+    pool = pool.filter(section => !starved.includes(section));
+    if (pool.length === 0) break;
+  }
+
+  // Round so the sections still add up to exactly the space there is — otherwise
+  // the leftover pixel lands somewhere on its own and the layout creeps.
+  let used = 0;
+  open.forEach((section, index) => {
+    const exact = settled.get(section.id) ?? MIN_OPEN_SECTION_HEIGHT;
+    const height = index === open.length - 1 ? available - used : Math.round(exact);
+    heights[section.id] = height;
+    used += height;
+  });
+  return heights;
+}
+
+/**
+ * One collapsible, vertically resizable list in the hub sidebar — the VS Code
+ * explorer arrangement, where each section keeps a height you can drag and
+ * folds down to just its header.
+ *
+ * Sizing is in pixels and ours, not the group's. The group's own collapse/expand
+ * remembers a *percentage*, and since these sections do not fill the sidebar on
+ * their own, every fold handed slack to a neighbour and the percentages drifted:
+ * one section grew on each cycle until the last one had nothing left to expand
+ * into and stayed shut with its chevron pointing open. Pinning each section to a
+ * pixel height and letting the trailing slack panel — the one panel left
+ * relative — absorb the remainder keeps the heights stable across any number of
+ * cycles, and keeps chevron and section in agreement because both read the
+ * stored preference.
+ */
+export function SdlcSidebarSection(props: {
+  /** Stable across renders — heights and collapse are stored against it. */
+  id: string;
+  title: string;
+  count?: number | undefined;
+  /** The `+` beside the header, when the section can be added to. */
+  action?: { label: string; onClick: () => void; trackName: string } | undefined;
+  children: ReactNode;
+}): ReactElement {
+  const panel = usePanelRef();
+  const collapsedSections = useUserPreference('sdlcSidebarSectionsCollapsed');
+  const sectionHeights = useUserPreference('sdlcSidebarSectionHeights');
+  const defaultHeight =
+    sectionHeights[props.id] ??
+    SDLC_SECTIONS.find(section => section.id === props.id)?.defaultHeight ??
+    DEFAULT_SECTION_HEIGHT;
+
+  const collapsed = collapsedSections[props.id] ?? false;
+
+  // The preference is the single source of truth: the chevron renders from it and
+  // the panel is sized from it, so the two cannot disagree. Every section runs the
+  // same layout over the same inputs, so they agree with each other too.
+  useEffect(() => {
+    const apply = (): void => {
+      const element = document.getElementById(props.id);
+      const groupHeight = element?.parentElement?.getBoundingClientRect().height ?? 0;
+      if (!groupHeight) return;
+      const height = sdlcSectionLayout(groupHeight, collapsedSections, sectionHeights)[props.id];
+      if (height !== undefined) panel.current?.resize(`${height}px`);
+    };
+    // Twice: once now, once after the group has taken this render's minSize. A
+    // section folding to its header is asking for a height below the floor it
+    // had a moment ago, and the first call alone gets clamped short of it.
+    apply();
+    const frame = requestAnimationFrame(apply);
+    return () => cancelAnimationFrame(frame);
+  }, [panel, props.id, collapsed, collapsedSections, sectionHeights]);
+
+  const toggle = (): void =>
+    setUserPreference('sdlcSidebarSectionsCollapsed', {
+      ...collapsedSections,
+      [props.id]: !collapsed,
+    });
+
+  return (
+    <Panel
+      id={props.id}
+      panelRef={panel}
+      // Pixels, not percentages — see the note above. The trailing slack panel is
+      // the group's one relative panel and gives up the space these take.
+      groupResizeBehavior='preserve-pixel-size'
+      // Folded, a section is its header. Open, a drag stops here — the group
+      // enforces this live, so the section never travels below the floor and
+      // springs back, it simply will not go.
+      minSize={`${collapsed ? SECTION_HEADER_HEIGHT : MIN_OPEN_SECTION_HEIGHT}px`}
+      defaultSize={`${collapsed ? SECTION_HEADER_HEIGHT : defaultHeight}px`}
+      className='flex min-h-0 flex-col'
+    >
+      <div
+        className='flex shrink-0 items-center gap-1 px-2'
+        style={{ height: SECTION_HEADER_HEIGHT }}
+      >
+        <button
+          type='button'
+          onClick={toggle}
+          aria-expanded={!collapsed}
+          className='flex min-w-0 flex-1 items-center gap-1 rounded-[5px] py-1 pr-1 text-left text-[10.5px] font-bold uppercase tracking-[0.13em] text-foreground/45 transition-colors hover:text-foreground/70'
+          data-track-category='SdlcHub'
+          data-track-name='SidebarSectionToggled'
+          data-track-metadata={JSON.stringify({ section: props.id })}
+        >
+          <ChevronDown
+            className={cn('size-3 shrink-0 transition-transform', collapsed && '-rotate-90')}
+          />
+          <span className='truncate'>{props.title}</span>
+          {props.count !== undefined && (
+            <span className='ml-1 shrink-0 text-[10.5px] tabular-nums text-foreground/35'>
+              {props.count}
+            </span>
+          )}
+        </button>
+        {props.action && (
+          <button
+            type='button'
+            title={props.action.label}
+            aria-label={props.action.label}
+            onClick={props.action.onClick}
+            className='-mr-[7px] flex size-[22px] shrink-0 items-center justify-center rounded-[5px] text-foreground/45 transition-colors hover:bg-foreground/[0.06] hover:text-foreground'
+            data-track-category='SdlcHub'
+            data-track-name={props.action.trackName}
+          >
+            <Plus className='size-3.5' />
+          </button>
+        )}
+      </div>
+      {!collapsed && (
+        <div className='min-h-0 flex-1 overflow-y-auto px-2 pb-2'>{props.children}</div>
+      )}
+    </Panel>
+  );
+}
+
+/**
+ * Record the heights a drag just produced, for the group these sections live in.
+ *
+ * Only a real separator drag counts. Every other layout pass — mount, a window
+ * resize, our own `resize()` calls — reports sizes too, and taking those at face
+ * value is what previously let the first section record the whole sidebar as its
+ * chosen height and squash everything below it.
+ */
+export function persistSdlcSectionHeights(meta: { isUserInteraction: boolean }): void {
+  if (!meta.isUserInteraction) return;
+  const preferences = userPreferencesSnapshot();
+  const stored = { ...preferences.sdlcSidebarSectionHeights };
+  const collapsed = preferences.sdlcSidebarSectionsCollapsed;
+  let changed = false;
+  for (const { id } of SDLC_SECTIONS) {
+    const element = document.getElementById(id);
+    if (!element) continue;
+    // A folded section's height is its header, not a height to return to.
+    if (collapsed[id]) continue;
+    const measured = Math.round(element.getBoundingClientRect().height);
+    const height = Math.max(MIN_OPEN_SECTION_HEIGHT, measured);
+    const previous = preferences.sdlcSidebarSectionHeights[id];
+    stored[id] = height;
+    // A drag below the floor republishes even when it lands on a height already
+    // stored: the republish is what re-runs the layout and springs the section
+    // back, and skipping it as a no-op left every drag after the first squashed
+    // where the pointer dropped it.
+    if (measured < MIN_OPEN_SECTION_HEIGHT || previous !== height) changed = true;
+  }
+  if (changed) setUserPreference('sdlcSidebarSectionHeights', stored);
+}
+
+/**
+ * The drag handle between two sections.
+ *
+ * Taller than the line it draws so there is something to actually grab, and the
+ * live line is brightest under the middle and fades to nothing at both ends —
+ * the same edge treatment the canvas resize handles use, which reads as a grip
+ * rather than a border drawn across the sidebar.
+ */
+export function SdlcSidebarSectionSeparator(): ReactElement {
+  return (
+    <Separator
+      className='group relative shrink-0 cursor-row-resize'
+      style={{ height: SECTION_SEPARATOR_HEIGHT }}
+    >
+      <div
+        className='pointer-events-none absolute inset-x-0 top-[3px] h-px bg-sidebar-border-muted'
+        aria-hidden='true'
+      />
+      <div
+        className='pointer-events-none absolute inset-x-2 top-[2px] h-[3px] rounded-full bg-gradient-to-r from-transparent via-primary to-transparent opacity-0 transition-opacity duration-150 group-hover:opacity-70 group-active:opacity-100'
+        aria-hidden='true'
+      />
+    </Separator>
   );
 }

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcHubSidebar.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcHubSidebar.tsx
@@ -274,7 +274,14 @@ export function sdlcSectionLayout(
   let used = 0;
   open.forEach((section, index) => {
     const exact = settled.get(section.id) ?? MIN_OPEN_SECTION_HEIGHT;
-    const height = index === open.length - 1 ? available - used : Math.round(exact);
+    // The last section absorbs the rounding, but `available - used` goes negative
+    // when every section has been starved to the minimum and there was never
+    // enough room — a short viewport with four sections open. A negative resize
+    // is worse than overflowing, so the floor wins.
+    const height =
+      index === open.length - 1
+        ? Math.max(MIN_OPEN_SECTION_HEIGHT, available - used)
+        : Math.round(exact);
     heights[section.id] = height;
     used += height;
   });

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcHubSidebar.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcHubSidebar.tsx
@@ -20,20 +20,10 @@ import { EntitySelector } from '../../components/ui/EntitySelector/EntitySelecto
 import type { SelectorOption } from '../../components/ui/EntitySelector/EntitySelector.types';
 import { Popover } from '../../components/ui/Popover';
 
-/** Header height, and therefore the height a collapsed section folds down to. */
 const SECTION_HEADER_HEIGHT = 28;
-/** Height a section opens to when neither the reader nor the caller has said. */
 const DEFAULT_SECTION_HEIGHT = 170;
-/** Least an open section may be squeezed to — enough to be worth having open. */
 const MIN_OPEN_SECTION_HEIGHT = 150;
-/** Height of a drag handle. The sections share what is left after these. */
 const SECTION_SEPARATOR_HEIGHT = 7;
-/**
- * The resizable sections, in the order they appear, with the height each opens
- * to before the reader drags it anywhere. They live here rather than at the call
- * site because working out one section's height needs all of them: the space is
- * shared, so the answer is a layout, not four independent decisions.
- */
 export const SDLC_SECTIONS: ReadonlyArray<{ id: string; defaultHeight: number }> = [
   { id: 'sdlc-sidebar-hub', defaultHeight: 180 },
   { id: 'sdlc-sidebar-tracks', defaultHeight: 200 },
@@ -59,11 +49,6 @@ function repositoryHref(repository: SdlcHubRepository): string {
   return repository.canonicalUrl || repository.url;
 }
 
-/**
- * Hub switcher. Repository names ride in the subtitle, which the selector
- * searches — and they need room, so the dropdown is left to size itself to its
- * content rather than being pinned to the trigger's sidebar-narrow width.
- */
 export function SdlcHubPicker(props: {
   hubs: SdlcHubOption[];
   selectedHubId: string;
@@ -175,22 +160,6 @@ export function SdlcHubRepositories(props: {
   );
 }
 
-/**
- * How tall each section should be, given the space there is and what the reader
- * has asked for.
- *
- * When the stored heights fit, they are used as-is. When they do not — a height
- * Whatever is open fills the sidebar between the folded headers, sharing the room
- * in proportion to the heights asked for. Sections are not left at a height that
- * strands empty space below the last one — a folded header belongs against the
- * section under it, not floating with a gap beneath. Only when every section is
- * folded do the headers stack and the space below them go unused.
- *
- * Each open section is first given enough to look open, so none is ever squeezed
- * to its header while its chevron points open, and a sidebar too short for what
- * was asked for shrinks everything a little rather than starving whichever
- * sections happen to come last.
- */
 export function sdlcSectionLayout(
   groupHeight: number,
   collapsedSections: Record<string, boolean>,
@@ -203,9 +172,6 @@ export function sdlcSectionLayout(
   const open = SDLC_SECTIONS.filter(section => !collapsedSections[section.id]);
   if (open.length === 0) return heights;
 
-  // The drag handles between the sections take height too. Leaving them out
-  // scaled every section up by the few percent they occupy, which is a visible
-  // jump the moment a drag ends and the layout is reapplied.
   const available =
     groupHeight -
     (SDLC_SECTIONS.length - 1) * SECTION_SEPARATOR_HEIGHT -
@@ -223,10 +189,6 @@ export function sdlcSectionLayout(
   );
   const wantedTotal = open.reduce((total, section) => total + (wanted.get(section.id) ?? 0), 0);
 
-  // When what the reader asked for fits, they get exactly that, and the last open
-  // section takes up whatever is left over. Sharing the slack across all of them
-  // instead meant folding one section resized every other one, so the whole
-  // sidebar shifted under the pointer to open a single list.
   if (wantedTotal <= available) {
     const last = open[open.length - 1];
     open.forEach(section => {
@@ -236,11 +198,6 @@ export function sdlcSectionLayout(
     return heights;
   }
 
-  // Too tall to fit: everything shrinks a little, in proportion. Straight scaling,
-  // so heights that already fill the sidebar map to themselves — anything that
-  // reshuffles them gives a different answer each time it runs over its own
-  // output, which walks the sections further on every collapse and snaps them
-  // away from where a drag just put them.
   const settled = new Map<string, number>();
   let pool = [...open];
   let remaining = available;
@@ -250,8 +207,6 @@ export function sdlcSectionLayout(
       for (const section of pool) settled.set(section.id, remaining / pool.length);
       break;
     }
-    // A section too small to read as open takes its minimum off the top; the rest
-    // then share what is left, which may push another below the line in turn.
     const starved = pool.filter(
       section => ((wanted.get(section.id) ?? 0) / poolTotal) * remaining < MIN_OPEN_SECTION_HEIGHT,
     );
@@ -269,15 +224,9 @@ export function sdlcSectionLayout(
     if (pool.length === 0) break;
   }
 
-  // Round so the sections still add up to exactly the space there is — otherwise
-  // the leftover pixel lands somewhere on its own and the layout creeps.
   let used = 0;
   open.forEach((section, index) => {
     const exact = settled.get(section.id) ?? MIN_OPEN_SECTION_HEIGHT;
-    // The last section absorbs the rounding, but `available - used` goes negative
-    // when every section has been starved to the minimum and there was never
-    // enough room — a short viewport with four sections open. A negative resize
-    // is worse than overflowing, so the floor wins.
     const height =
       index === open.length - 1
         ? Math.max(MIN_OPEN_SECTION_HEIGHT, available - used)
@@ -288,27 +237,10 @@ export function sdlcSectionLayout(
   return heights;
 }
 
-/**
- * One collapsible, vertically resizable list in the hub sidebar — the VS Code
- * explorer arrangement, where each section keeps a height you can drag and
- * folds down to just its header.
- *
- * Sizing is in pixels and ours, not the group's. The group's own collapse/expand
- * remembers a *percentage*, and since these sections do not fill the sidebar on
- * their own, every fold handed slack to a neighbour and the percentages drifted:
- * one section grew on each cycle until the last one had nothing left to expand
- * into and stayed shut with its chevron pointing open. Pinning each section to a
- * pixel height and letting the trailing slack panel — the one panel left
- * relative — absorb the remainder keeps the heights stable across any number of
- * cycles, and keeps chevron and section in agreement because both read the
- * stored preference.
- */
 export function SdlcSidebarSection(props: {
-  /** Stable across renders — heights and collapse are stored against it. */
   id: string;
   title: string;
   count?: number | undefined;
-  /** The `+` beside the header, when the section can be added to. */
   action?: { label: string; onClick: () => void; trackName: string } | undefined;
   children: ReactNode;
 }): ReactElement {
@@ -322,9 +254,6 @@ export function SdlcSidebarSection(props: {
 
   const collapsed = collapsedSections[props.id] ?? false;
 
-  // The preference is the single source of truth: the chevron renders from it and
-  // the panel is sized from it, so the two cannot disagree. Every section runs the
-  // same layout over the same inputs, so they agree with each other too.
   useEffect(() => {
     const apply = (): void => {
       const element = document.getElementById(props.id);
@@ -333,9 +262,6 @@ export function SdlcSidebarSection(props: {
       const height = sdlcSectionLayout(groupHeight, collapsedSections, sectionHeights)[props.id];
       if (height !== undefined) panel.current?.resize(`${height}px`);
     };
-    // Twice: once now, once after the group has taken this render's minSize. A
-    // section folding to its header is asking for a height below the floor it
-    // had a moment ago, and the first call alone gets clamped short of it.
     apply();
     const frame = requestAnimationFrame(apply);
     return () => cancelAnimationFrame(frame);
@@ -351,12 +277,7 @@ export function SdlcSidebarSection(props: {
     <Panel
       id={props.id}
       panelRef={panel}
-      // Pixels, not percentages — see the note above. The trailing slack panel is
-      // the group's one relative panel and gives up the space these take.
       groupResizeBehavior='preserve-pixel-size'
-      // Folded, a section is its header. Open, a drag stops here — the group
-      // enforces this live, so the section never travels below the floor and
-      // springs back, it simply will not go.
       minSize={`${collapsed ? SECTION_HEADER_HEIGHT : MIN_OPEN_SECTION_HEIGHT}px`}
       defaultSize={`${collapsed ? SECTION_HEADER_HEIGHT : defaultHeight}px`}
       className='flex min-h-0 flex-col'
@@ -405,14 +326,6 @@ export function SdlcSidebarSection(props: {
   );
 }
 
-/**
- * Record the heights a drag just produced, for the group these sections live in.
- *
- * Only a real separator drag counts. Every other layout pass — mount, a window
- * resize, our own `resize()` calls — reports sizes too, and taking those at face
- * value is what previously let the first section record the whole sidebar as its
- * chosen height and squash everything below it.
- */
 export function persistSdlcSectionHeights(meta: { isUserInteraction: boolean }): void {
   if (!meta.isUserInteraction) return;
   const preferences = userPreferencesSnapshot();
@@ -422,29 +335,16 @@ export function persistSdlcSectionHeights(meta: { isUserInteraction: boolean }):
   for (const { id } of SDLC_SECTIONS) {
     const element = document.getElementById(id);
     if (!element) continue;
-    // A folded section's height is its header, not a height to return to.
     if (collapsed[id]) continue;
     const measured = Math.round(element.getBoundingClientRect().height);
     const height = Math.max(MIN_OPEN_SECTION_HEIGHT, measured);
     const previous = preferences.sdlcSidebarSectionHeights[id];
     stored[id] = height;
-    // A drag below the floor republishes even when it lands on a height already
-    // stored: the republish is what re-runs the layout and springs the section
-    // back, and skipping it as a no-op left every drag after the first squashed
-    // where the pointer dropped it.
     if (measured < MIN_OPEN_SECTION_HEIGHT || previous !== height) changed = true;
   }
   if (changed) setUserPreference('sdlcSidebarSectionHeights', stored);
 }
 
-/**
- * The drag handle between two sections.
- *
- * Taller than the line it draws so there is something to actually grab, and the
- * live line is brightest under the middle and fades to nothing at both ends —
- * the same edge treatment the canvas resize handles use, which reads as a grip
- * rather than a border drawn across the sidebar.
- */
 export function SdlcSidebarSectionSeparator(): ReactElement {
   return (
     <Separator

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -173,19 +173,9 @@ const SECTIONS: Array<{ id: Exclude<Section, 'artifacts'>; label: string; icon: 
   { id: 'overview', label: 'Overview', icon: Boxes },
   { id: 'wiki', label: 'Wiki', icon: BookOpen },
   { id: 'baseline', label: 'Repo Knowledge', icon: ShieldCheck },
-  // Tracks are the sidebar's own list now, not a page, so they leave this nav.
   { id: 'tickets', label: 'Issues', icon: CircleDot },
 ];
 
-// Artifacts and tracks have no row in the nav above — both are reached from the
-// sidebar's own lists — but their URLs still have to resolve. An id missing here
-// silently falls back to Overview rather than erroring.
-/** How wide the sidebar may be dragged, and the point below which it folds. */
-/**
- * Sizes the rename field to the text it holds, measured rather than estimated.
- * The mirror's content is set here instead of waiting for React so the width
- * tracks the keystroke that caused it.
- */
 function sizeNameFieldToText(input: HTMLInputElement): void {
   const mirror = input.parentElement?.querySelector('[data-name-mirror]');
   if (!(mirror instanceof HTMLElement)) return;
@@ -193,8 +183,6 @@ function sizeNameFieldToText(input: HTMLInputElement): void {
   input.style.width = `${Math.ceil(mirror.getBoundingClientRect().width) + 2}px`;
 }
 
-/** Match the updateTrack mutator's own caps. */
-/** Only priorities worth interrupting a row for; LOW is the default and stays quiet. */
 const TICKET_PRIORITY_LABEL: Record<TicketPriority, string> = {
   [TicketPriority.LOW]: 'Low',
   [TicketPriority.MEDIUM]: 'Medium',
@@ -202,7 +190,6 @@ const TICKET_PRIORITY_LABEL: Record<TicketPriority, string> = {
   [TicketPriority.CRITICAL]: 'Critical',
 };
 
-/** Matches the reader's exit animation, so it unmounts as the panel leaves. */
 const READER_EXIT_MS = 200;
 
 const TRACK_NAME_LIMIT = 120;
@@ -210,28 +197,16 @@ const TRACK_DESCRIPTION_LIMIT = 2000;
 
 const SIDEBAR_MIN_WIDTH = 200;
 const SIDEBAR_MAX_WIDTH = 360;
-/** Drag narrower than this and the sidebar folds to its rail instead of resisting. */
 const SIDEBAR_COLLAPSE_AT = 150;
-/** Width of the folded rail, and of the panel it floats out on hover. Both are
- *  fixed: a rail that inherited a 480px drag would cover half the page to show a
- *  few icons' worth of lists. */
 const SIDEBAR_RAIL_WIDTH = 52;
 const SIDEBAR_HOVER_WIDTH = 260;
 
-/** Track status, as the heading pill presents it. */
 const TRACK_STATUS_OPTIONS = [
   { value: 'ACTIVE', label: 'Active' },
   { value: 'COMPLETED', label: 'Completed' },
   { value: 'ARCHIVED', label: 'Archived' },
 ] as const;
 
-/**
- * Status colour rides on a dot, not the label. The status tokens are plain hex
- * variables, so Tailwind cannot tint them per theme, and a coloured label ends up
- * either washed out on dark or short of contrast on light. A dot in the token
- * colour beside a `text-foreground` label reads clearly in both, and keeps the
- * status legible without relying on colour to carry it.
- */
 const TRACK_STATUS_DOT: Record<string, string> = {
   ACTIVE: 'bg-status-success',
   COMPLETED: 'bg-status-scheduled',
@@ -351,19 +326,13 @@ export default function SdlcScreen(): ReactElement {
   const [renameTypeName, setRenameTypeName] = useState('');
   const [hoveredTypeId, setHoveredTypeId] = useState<string | null>(null);
   const [trackDialog, setTrackDialog] = useState(false);
-  // Sidebar shape is the reader's preference, not the workspace's, so it lives
-  // in the preferences machine and comes back from IndexedDB on their next visit.
   const showClosedTracks = useUserPreference('sdlcShowClosedTracks');
   const setShowClosedTracks = (next: boolean): void =>
     setUserPreference('sdlcShowClosedTracks', next);
-  // Collapsed to a rail of icons. Hovering floats the full sidebar over the page
-  // rather than widening the layout, so the reading area keeps every pixel.
   const finderGroupBy = useUserPreference('sdlcFinderGroupBy');
   const railCollapsed = useUserPreference('sdlcSidebarCollapsed');
   const storedRailWidth = useUserPreference('sdlcSidebarWidth');
   const [railHovered, setRailHovered] = useState(false);
-  // Live width while a drag is in flight; the preference is written once, on
-  // release, so a drag is one stored value rather than one per pointer move.
   const [draggingWidth, setDraggingWidth] = useState<number | null>(null);
   const railWidth =
     draggingWidth ?? Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, storedRailWidth));
@@ -377,8 +346,6 @@ export default function SdlcScreen(): ReactElement {
 
     const onMove = (moveEvent: globalThis.PointerEvent): void => {
       const raw = startWidth + (moveEvent.clientX - startX);
-      // Dragged in past the fold point, the sidebar gets out of the way rather
-      // than sitting at a width too narrow to read.
       if (raw < SIDEBAR_COLLAPSE_AT) {
         folded = true;
         finish();
@@ -403,8 +370,6 @@ export default function SdlcScreen(): ReactElement {
       }
     }
 
-    // The pointer leaves the handle almost immediately, so the cursor is held on
-    // the body for the length of the drag.
     document.body.style.setProperty('cursor', 'col-resize');
     document.body.style.setProperty('user-select', 'none');
     window.addEventListener('pointermove', onMove);
@@ -428,29 +393,14 @@ export default function SdlcScreen(): ReactElement {
   const [linkDialog, setLinkDialog] = useState(false);
   const [membersDialog, setMembersDialog] = useState(false);
   const [trackStatusOpen, setTrackStatusOpen] = useState(false);
-  /** Null when not editing; the draft text while the description is being written. */
   const [descriptionDraft, setDescriptionDraft] = useState<string | null>(null);
-  /** Set when Escape closes the editor, so the blur that follows does not save. */
   const descriptionAbandoned = useRef(false);
   const [nameDraft, setNameDraft] = useState<string | null>(null);
   const nameAbandoned = useRef(false);
-  /**
-   * The open path down the folder tree, below the track. Column n renders the
-   * children of step n, so this array is both the breadcrumb and the set of
-   * live queries.
-   */
-  /** The artifact a single click is previewing, if any. */
   const [previewCanvasId, setPreviewCanvasId] = useState<string | null>(null);
-  /** The artifact being read in the side panel, if any. */
   const [readerCanvasId, setReaderCanvasId] = useState<string | null>(null);
-  /** True while the reader plays its exit; it stays mounted until that finishes. */
   const [readerClosing, setReaderClosing] = useState(false);
 
-  /**
-   * Dismissing has to outlive the click: unmounting on the spot removes the
-   * element before its exit animation can run, which is why closing used to snap
-   * while opening slid.
-   */
   const closeReader = (): void => {
     setReaderClosing(true);
     window.setTimeout(() => {
@@ -458,22 +408,13 @@ export default function SdlcScreen(): ReactElement {
       setReaderClosing(false);
     }, READER_EXIT_MS);
   };
-  /**
-   * The folder whose conversations the right panel is showing, if any. Folder
-   * discussions share the track's panel rather than opening a surface of their
-   * own, so this is what decides which of the two the panel is bound to.
-   */
   const [folderDiscussion, setFolderDiscussion] = useState<{ id: string; name: string } | null>(
     null,
   );
-  /** Set to the parent a new folder is being created under; null when closed. */
   const [newFolderParent, setNewFolderParent] = useState<SdlcFinderStep | null>(null);
   const [newFolderName, setNewFolderName] = useState('');
-  /** Where a new artifact should land; null when the type chooser is closed. */
   const [newArtifactParent, setNewArtifactParent] = useState<SdlcFinderStep | null>(null);
-  /** A folder a just-created artifact must be filed into, applied after creation. */
   const [pendingArtifactFolder, setPendingArtifactFolder] = useState<string | null>(null);
-  /** The row currently being dragged in the finder, if any. */
   const [draggingItem, setDraggingItem] = useState<{
     type: 'FOLDER' | 'CANVAS';
     id: string;
@@ -525,26 +466,19 @@ export default function SdlcScreen(): ReactElement {
   );
   const selectedTrackId = routeSearchParams.get('track');
   const selectedTrack = tracks.find(track => track.id === selectedTrackId);
-  // Hooks cannot run inside renderTrack, which is only called on the track page,
-  // so the owner is looked up here and read there.
   const trackOwner = useUser(selectedTrack?.createdBy ?? '');
 
   const finderPathByTrack = useUserPreference('sdlcFinderPathByTrack');
   const finderPath: SdlcFinderStep[] = selectedTrackId
     ? (finderPathByTrack[selectedTrackId] ?? [])
     : [];
-  /** Stored per track, so each one remembers where it was left open. */
   const setFinderPath = (next: SdlcFinderStep[]): void => {
     if (!selectedTrackId) return;
     setUserPreference('sdlcFinderPathByTrack', { ...finderPathByTrack, [selectedTrackId]: next });
   };
-  // The preview is per visit, not per track: an artifact selected last time is
-  // not what you asked to see now. The folder path is remembered; this is not.
   useEffect(() => {
     setPreviewCanvasId(null);
   }, [selectedTrackId]);
-  // What the sidebar shows standing: work in flight, with anything finished or
-  // parked folded behind a toggle rather than dropped.
   const openTracks = useMemo(
     () => tracks.filter(track => track.status !== 'COMPLETED' && track.status !== 'ARCHIVED'),
     [tracks],
@@ -787,8 +721,6 @@ export default function SdlcScreen(): ReactElement {
                     link.sourceType === 'TRACK' &&
                     link.sourceId === selectedTrackId &&
                     link.targetType === 'CONVERSATION' &&
-                    // Both edges count: the track's own discussions, and the flat
-                    // rows folders inside it file so their conversations roll up.
                     (link.relationType === 'DISCUSSION' ||
                       link.relationType === SDLC_TRACK_FLAT_RELATION),
                 )
@@ -813,11 +745,6 @@ export default function SdlcScreen(): ReactElement {
         : [],
     [links, folderDiscussion],
   );
-  /**
-   * Every folder in the hub, once. This replaces the per-open-column lookup the
-   * finder used to run, and is what lets a conversation in the track's list name
-   * the folder it came from without a fetch of its own.
-   */
   const [hubFolderRows] = useCachedQuery(
     queries.getSdlcFoldersByChannel({ channelId: channelId || '' }),
     { enabled: Boolean(channelId) },
@@ -826,7 +753,6 @@ export default function SdlcScreen(): ReactElement {
     () => new Map((hubFolderRows ?? []).map(row => [row.id, { id: row.id, name: row.name }])),
     [hubFolderRows],
   );
-  /** Which folder each conversation was started in, for the list's marker. */
   const folderIdByConversationId = useMemo(() => {
     const map = new Map<string, string>();
     for (const link of links) {
@@ -840,7 +766,6 @@ export default function SdlcScreen(): ReactElement {
     }
     return map;
   }, [links]);
-  // A folder belongs to one track, so switching tracks cannot keep its binding.
   useEffect(() => {
     setFolderDiscussion(null);
   }, [selectedTrackId]);
@@ -939,10 +864,6 @@ export default function SdlcScreen(): ReactElement {
     () => discussionIdsForOwner(discussionOwner?.canvasId ?? null, links),
     [discussionOwner, links],
   );
-  /**
-   * The folder binding only holds while the track page is what is on screen: an
-   * open artifact owns the panel itself, and leaving the track drops the folder.
-   */
   const activeFolderDiscussion =
     folderDiscussion && !discussionOwner && section === 'tracks' && selectedTrack
       ? folderDiscussion
@@ -950,8 +871,6 @@ export default function SdlcScreen(): ReactElement {
   const entityLinkScope = useMemo<EntityLinkScope | null>(() => {
     if (discussionOwner) return { sourceType: 'CANVAS', sourceId: discussionOwner.canvasId };
     if (section === 'tracks' && selectedTrack) {
-      // A folder conversation is filed on the folder and, so the track's list
-      // stays complete, on the track as well.
       return activeFolderDiscussion
         ? {
             sourceType: 'FOLDER',
@@ -1218,7 +1137,6 @@ export default function SdlcScreen(): ReactElement {
 
   const openConversations = useCallback((): void => {
     closeExternalDebugger();
-    // The header button is the track's, so it drops any folder binding.
     setFolderDiscussion(null);
     setDiscussionUrl({ open: true, conversationId: null });
   }, [closeExternalDebugger, setDiscussionUrl]);
@@ -1232,19 +1150,12 @@ export default function SdlcScreen(): ReactElement {
     [closeExternalDebugger, setDiscussionUrl],
   );
 
-  /**
-   * The mark on a conversation in the track's list saying which folder it came
-   * from, and taking you to that folder's conversations. Both halves come from
-   * data the page already holds.
-   */
   const renderFolderConversationBadge = useCallback(
     (conversationId: string): ReactNode => {
       const folderId = folderIdByConversationId.get(conversationId);
       const name = folderId ? folderById.get(folderId)?.name : undefined;
       if (!folderId || !name) return null;
       return (
-        // A floor so it never collapses in the sender's line, a ceiling so a long
-        // name cannot push the timestamp out of it, an ellipsis in between.
         <button
           type='button'
           onClick={() => openFolderConversations({ id: folderId, name })}
@@ -1445,8 +1356,6 @@ export default function SdlcScreen(): ReactElement {
   const resetArtifactDialog = (): void => {
     setArtifactDialog(null);
     clearArtifactDialogFields();
-    // Cancelling used to leave the folder behind, so the next artifact created
-    // anywhere on the page was silently filed into it.
     setPendingArtifactFolder(null);
   };
 
@@ -1499,12 +1408,9 @@ export default function SdlcScreen(): ReactElement {
         ...(relatedCanvasIds.length > 0 && { relatedCanvasIds }),
       },
     );
-    // Read before the reset clears it; the move below is what consumes it.
     const fileIntoFolder = pendingArtifactFolder;
     resetArtifactDialog();
     const newCanvasId = response.data.artifact.canvasId;
-    // Creation always files an artifact at the track's root, so one started from
-    // inside a folder is moved there straight after.
     if (fileIntoFolder && channel) {
       await fileNewArtifactIntoFolder(newCanvasId, fileIntoFolder);
     }
@@ -1752,12 +1658,6 @@ export default function SdlcScreen(): ReactElement {
 
   const isDocumentWindow = isSdlcDocumentWindow();
 
-  /**
-   * The page for one track: its artifacts and issues, reached by selecting the
-   * track in the sidebar. The list of tracks that used to sit alongside it is
-   * gone — the sidebar is the list now, so the page only ever shows the one
-   * track that is selected.
-   */
   const setTrackStatusAction = async (trackId: string, status: string): Promise<void> => {
     await runTrackMutation(
       zero.mutate(
@@ -1782,18 +1682,9 @@ export default function SdlcScreen(): ReactElement {
         }),
       ),
     );
-    // The stored path carries names for the column headers, so a rename has to
-    // reach it too or the breadcrumb keeps the old one until a reload.
     setFinderPath(finderPath.map(step => (step.id === folderId ? { ...step, name } : step)));
   };
 
-  /**
-   * Filing a just-created artifact. It was created over HTTP, so its containment
-   * edge reaches the Zero client by replication — usually a moment after this
-   * runs, and moveSdlcItem refuses a move it cannot find an edge for. Waiting for
-   * the row beats reporting a failure the reader can do nothing about; only that
-   * one refusal is retried, since every other is a real answer.
-   */
   const fileNewArtifactIntoFolder = async (canvasId: string, folderId: string): Promise<void> => {
     const attempts = 10;
     for (let attempt = 1; attempt <= attempts; attempt += 1) {
@@ -1862,8 +1753,6 @@ export default function SdlcScreen(): ReactElement {
       zero.mutate(
         mutators.sdlc.updateTrack({
           trackId,
-          // Cleared to null rather than an empty string, so "no description" is
-          // one value and the heading has one thing to test.
           description: description.length > 0 ? description : null,
           timestamp: Date.now(),
         }),
@@ -1913,9 +1802,6 @@ export default function SdlcScreen(): ReactElement {
                 <button
                   type='button'
                   onClick={() => {
-                    // Escape unmounts the input, and React fires no blur for an
-                    // unmounted element — so the guard is armed here rather than
-                    // cleared on the way out, where it would leak into this edit.
                     nameAbandoned.current = false;
                     setNameDraft(selectedTrack.name);
                   }}
@@ -1955,7 +1841,6 @@ export default function SdlcScreen(): ReactElement {
                         nameAbandoned.current = true;
                         setNameDraft(null);
                       }
-                      // One line, so Enter is the natural way to finish.
                       if (event.key === 'Enter') event.currentTarget.blur();
                     }}
                     onBlur={() => {
@@ -1965,8 +1850,6 @@ export default function SdlcScreen(): ReactElement {
                       }
                       const next = nameDraft.trim();
                       setNameDraft(null);
-                      // A track has to be called something; an empty box reverts
-                      // rather than writing a nameless track.
                       if (next.length > 0 && next !== selectedTrack.name) {
                         void call(
                           `track-name-${selectedTrack.id}`,
@@ -2059,7 +1942,6 @@ export default function SdlcScreen(): ReactElement {
               <button
                 type='button'
                 onClick={() => {
-                  // Armed here for the same reason as the name editor above.
                   descriptionAbandoned.current = false;
                   setDescriptionDraft(selectedTrack.description ?? '');
                 }}
@@ -2084,7 +1966,6 @@ export default function SdlcScreen(): ReactElement {
                   maxLength={TRACK_DESCRIPTION_LIMIT}
                   onChange={event => {
                     setDescriptionDraft(event.target.value);
-                    // Grow with the text rather than scrolling inside a fixed box.
                     event.target.style.height = 'auto';
                     event.target.style.height = `${event.target.scrollHeight}px`;
                   }}
@@ -2098,7 +1979,6 @@ export default function SdlcScreen(): ReactElement {
                   }}
                   onKeyDown={event => {
                     if (event.key === 'Escape') {
-                      // Leave without writing; the blur that follows must not save.
                       descriptionAbandoned.current = true;
                       setDescriptionDraft(null);
                     }
@@ -2250,10 +2130,6 @@ export default function SdlcScreen(): ReactElement {
                 }}
                 previewCanvasId={previewCanvasId}
                 onSelectCanvas={canvasId => {
-                  // Selecting a file closes everything to the right of its own
-                  // column: those levels were reached through a folder that is no
-                  // longer what is selected, and the preview belongs immediately
-                  // after the column the file is in.
                   setFinderPath(steps.slice(1, index + 1));
                   setPreviewCanvasId(canvasId);
                 }}
@@ -2320,17 +2196,10 @@ export default function SdlcScreen(): ReactElement {
               <button
                 key={ticket.id}
                 type='button'
-                // The ticket's own conversation, not just the panel: openConversations
-                // passes a null conversation, which leaves the reader on whichever
-                // thread was last selected rather than the ticket they clicked.
                 onClick={() =>
                   setDiscussionUrl({
                     open: true,
                     conversationId: ticket.conversationId,
-                    // Clicking a ticket is a request to see the ticket, so it
-                    // lands on Details rather than the thread. Details is a
-                    // properties view with no composer — switching to Messages
-                    // brings the reply box back, and the panel remembers that.
                     selectedTab: 'details',
                   })
                 }
@@ -2372,8 +2241,6 @@ export default function SdlcScreen(): ReactElement {
                 {ticket.assignedTo ? (
                   <Avatar userId={ticket.assignedTo} size='xs' showActiveStatus={false} />
                 ) : (
-                  // An unowned ticket is worth seeing at a glance, so the gap
-                  // where an owner would be is drawn rather than left blank.
                   <span
                     className='size-5 shrink-0 rounded-full border border-dashed border-border'
                     title='Unassigned'
@@ -2434,14 +2301,7 @@ export default function SdlcScreen(): ReactElement {
           While collapsed the panel floats above the page on hover, so widening
           it costs the content nothing. */}
       <aside
-        className={cn(
-          // One width for every view. It used to widen for the pages that hung an
-          // extra tree or panel under the lists, but a sidebar that changes size
-          // as you move between pages reads as a glitch, and the content it was
-          // making room for now fits.
-          'relative shrink-0',
-          isDocumentWindow && 'hidden',
-        )}
+        className={cn('relative shrink-0', isDocumentWindow && 'hidden')}
         style={{ width: railCollapsed ? SIDEBAR_RAIL_WIDTH : railWidth }}
         onMouseEnter={() => railCollapsed && setRailHovered(true)}
         onMouseLeave={() => setRailHovered(false)}
@@ -2449,7 +2309,6 @@ export default function SdlcScreen(): ReactElement {
         <div
           className={cn(
             'flex h-full flex-col overflow-x-hidden border-r border-sidebar-border-muted bg-sidebar text-sidebar-foreground',
-            // No width animation mid-drag: the panel has to track the pointer.
             draggingWidth === null && 'transition-[width] duration-150',
             railCollapsed
               ? cn('absolute inset-y-0 left-0 z-30', railHovered && 'shadow-2xl')
@@ -2840,8 +2699,6 @@ export default function SdlcScreen(): ReactElement {
                 </h1>
               </>
             ) : section === 'tracks' && selectedTrack ? (
-              // Tracks left the nav, so the lookup below cannot name this page.
-              // There is no list to go back to either, so the track names itself.
               <h1 className='truncate font-semibold'>{selectedTrack.name}</h1>
             ) : (
               <h1 className='font-semibold'>

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -6,7 +6,9 @@ import {
   useRef,
   useState,
   type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
   type ReactElement,
+  type ReactNode,
 } from 'react';
 import {
   ChannelRole,
@@ -18,6 +20,9 @@ import {
   type SdlcRelationType,
   type SdlcSetupStatus,
   type SdlcCallLink,
+  SDLC_TRACK_FLAT_RELATION,
+  TicketStatusV2,
+  TicketPriority,
 } from '@xyne/shared';
 import { useQuery } from '@tanstack/react-query';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
@@ -27,16 +32,20 @@ import {
   Boxes,
   Bug,
   Check,
+  ChevronDown,
   ChevronRight,
   CircleAlert,
   CircleDot,
   FileText,
   Folder,
+  ExternalLink,
+  Maximize2,
   GitBranch,
   Layers,
+  Link2,
+  PanelLeft,
   Loader2,
   MessageCircle,
-  Network,
   Pencil,
   Plus,
   RefreshCw,
@@ -45,14 +54,19 @@ import {
   ShieldCheck,
   Sparkles,
   SquareArrowOutUpRight,
-  Trash2,
   Users,
   X,
 } from 'lucide-react';
 import { EntitySelector } from '../../components/ui/EntitySelector/EntitySelector';
 import NotFoundScreen from '../NotFoundScreen/NotFoundScreen';
 import { SdlcHubDialog } from './SdlcHubDialog';
-import { SdlcHubPicker, SdlcHubRepositories } from './SdlcHubSidebar';
+import {
+  SdlcHubPicker,
+  persistSdlcSectionHeights,
+  SdlcSidebarSection,
+  SdlcSidebarSectionSeparator,
+} from './SdlcHubSidebar';
+import { setUserPreference, useUserPreference } from '../../machines/userPreferencesMachine';
 import {
   isFramedSdlcSurface,
   isSdlcDocumentWindow,
@@ -68,13 +82,7 @@ import { Dialog } from '../../components/ui/Dialog/Dialog';
 import Input from '../../components/ui/Input';
 import Textarea from '../../components/ui/Textarea';
 import { Panel, ResizableGroup, Separator } from '../../components/ui/Resizable/Resizable';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '../../components/ui/Select';
+import {} from '../../components/ui/Select';
 import { v4 as uuidv4 } from 'uuid';
 import { useCachedQuery } from '../../hooks/useCachedQuery';
 import { useZero } from '../../hooks/useZero';
@@ -127,11 +135,19 @@ import {
   sdlcRightPanelMode,
   shouldCloseInvalidSdlcConversationDeepLink,
   shouldStartFreshSdlcAssistant,
-  shouldShowSdlcRelatedLink,
 } from './sdlcChatPolicy';
 import { formatRelativeTime } from '../../utils/dateUtils';
 import Avatar from '../../components/ui/Avatar/Avatar';
+import { UserHoverWrapper } from '../../components/ui/UserMentionPopover/UserMentionPopover';
 import { useUser } from '../../hooks/useUsers';
+import { getUserDisplayName } from '../../utils/userDisplayName';
+import { Popover } from '../../components/ui/Popover';
+import {
+  SdlcFinderColumn,
+  SdlcFinderPreview,
+  type SdlcFinderCanvas,
+  type SdlcFinderStep,
+} from './SdlcFinder';
 import { type SdlcTicket } from './ticketPolicy';
 import { linkedTicketIds } from './artifactTicketPolicy';
 import {
@@ -158,10 +174,76 @@ const SECTIONS: Array<{ id: Exclude<Section, 'artifacts'>; label: string; icon: 
   { id: 'overview', label: 'Overview', icon: Boxes },
   { id: 'wiki', label: 'Wiki', icon: BookOpen },
   { id: 'baseline', label: 'Repo Knowledge', icon: ShieldCheck },
-  { id: 'tracks', label: 'Tracks', icon: Layers },
-  { id: 'tickets', label: 'Tickets', icon: CircleDot },
+  // Tracks are the sidebar's own list now, not a page, so they leave this nav.
+  { id: 'tickets', label: 'Issues', icon: CircleDot },
 ];
-const SECTION_IDS: ReadonlySet<string> = new Set<string>([...SECTIONS.map(s => s.id), 'artifacts']);
+
+// Artifacts and tracks have no row in the nav above — both are reached from the
+// sidebar's own lists — but their URLs still have to resolve. An id missing here
+// silently falls back to Overview rather than erroring.
+/** How wide the sidebar may be dragged, and the point below which it folds. */
+/**
+ * Sizes the rename field to the text it holds, measured rather than estimated.
+ * The mirror's content is set here instead of waiting for React so the width
+ * tracks the keystroke that caused it.
+ */
+function sizeNameFieldToText(input: HTMLInputElement): void {
+  const mirror = input.parentElement?.querySelector('[data-name-mirror]');
+  if (!(mirror instanceof HTMLElement)) return;
+  mirror.textContent = input.value || ' ';
+  input.style.width = `${Math.ceil(mirror.getBoundingClientRect().width) + 2}px`;
+}
+
+/** Match the updateTrack mutator's own caps. */
+/** Only priorities worth interrupting a row for; LOW is the default and stays quiet. */
+const TICKET_PRIORITY_LABEL: Record<TicketPriority, string> = {
+  [TicketPriority.LOW]: 'Low',
+  [TicketPriority.MEDIUM]: 'Medium',
+  [TicketPriority.HIGH]: 'High',
+  [TicketPriority.CRITICAL]: 'Critical',
+};
+
+/** Matches the reader's exit animation, so it unmounts as the panel leaves. */
+const READER_EXIT_MS = 200;
+
+const TRACK_NAME_LIMIT = 120;
+const TRACK_DESCRIPTION_LIMIT = 2000;
+
+const SIDEBAR_MIN_WIDTH = 200;
+const SIDEBAR_MAX_WIDTH = 360;
+/** Drag narrower than this and the sidebar folds to its rail instead of resisting. */
+const SIDEBAR_COLLAPSE_AT = 150;
+/** Width of the folded rail, and of the panel it floats out on hover. Both are
+ *  fixed: a rail that inherited a 480px drag would cover half the page to show a
+ *  few icons' worth of lists. */
+const SIDEBAR_RAIL_WIDTH = 52;
+const SIDEBAR_HOVER_WIDTH = 260;
+
+/** Track status, as the heading pill presents it. */
+const TRACK_STATUS_OPTIONS = [
+  { value: 'ACTIVE', label: 'Active' },
+  { value: 'COMPLETED', label: 'Completed' },
+  { value: 'ARCHIVED', label: 'Archived' },
+] as const;
+
+/**
+ * Status colour rides on a dot, not the label. The status tokens are plain hex
+ * variables, so Tailwind cannot tint them per theme, and a coloured label ends up
+ * either washed out on dark or short of contrast on light. A dot in the token
+ * colour beside a `text-foreground` label reads clearly in both, and keeps the
+ * status legible without relying on colour to carry it.
+ */
+const TRACK_STATUS_DOT: Record<string, string> = {
+  ACTIVE: 'bg-status-success',
+  COMPLETED: 'bg-status-scheduled',
+  ARCHIVED: 'bg-status-new',
+};
+
+const SECTION_IDS: ReadonlySet<string> = new Set<string>([
+  ...SECTIONS.map(s => s.id),
+  'artifacts',
+  'tracks',
+]);
 
 const BASELINE_LABELS: Record<string, string> = {
   CORE_CODE_MAP: 'Core Code Map',
@@ -270,6 +352,72 @@ export default function SdlcScreen(): ReactElement {
   const [renameTypeName, setRenameTypeName] = useState('');
   const [hoveredTypeId, setHoveredTypeId] = useState<string | null>(null);
   const [trackDialog, setTrackDialog] = useState(false);
+  // Sidebar shape is the reader's preference, not the workspace's, so it lives
+  // in the preferences machine and comes back from IndexedDB on their next visit.
+  const showClosedTracks = useUserPreference('sdlcShowClosedTracks');
+  const setShowClosedTracks = (next: boolean): void =>
+    setUserPreference('sdlcShowClosedTracks', next);
+  // Collapsed to a rail of icons. Hovering floats the full sidebar over the page
+  // rather than widening the layout, so the reading area keeps every pixel.
+  const finderGroupBy = useUserPreference('sdlcFinderGroupBy');
+  const railCollapsed = useUserPreference('sdlcSidebarCollapsed');
+  const storedRailWidth = useUserPreference('sdlcSidebarWidth');
+  const [railHovered, setRailHovered] = useState(false);
+  // Live width while a drag is in flight; the preference is written once, on
+  // release, so a drag is one stored value rather than one per pointer move.
+  const [draggingWidth, setDraggingWidth] = useState<number | null>(null);
+  const railWidth =
+    draggingWidth ?? Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, storedRailWidth));
+
+  const startRailResize = (event: ReactPointerEvent<HTMLDivElement>): void => {
+    event.preventDefault();
+    const startX = event.clientX;
+    const startWidth = railWidth;
+    let latest = startWidth;
+    let folded = false;
+
+    const onMove = (moveEvent: globalThis.PointerEvent): void => {
+      const raw = startWidth + (moveEvent.clientX - startX);
+      // Dragged in past the fold point, the sidebar gets out of the way rather
+      // than sitting at a width too narrow to read.
+      if (raw < SIDEBAR_COLLAPSE_AT) {
+        folded = true;
+        finish();
+        return;
+      }
+      latest = Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, raw));
+      setDraggingWidth(latest);
+    };
+
+    function finish(): void {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', finish);
+      window.removeEventListener('pointercancel', finish);
+      document.body.style.removeProperty('cursor');
+      document.body.style.removeProperty('user-select');
+      setDraggingWidth(null);
+      if (folded) {
+        setUserPreference('sdlcSidebarCollapsed', true);
+        setRailHovered(false);
+      } else if (latest !== startWidth) {
+        setUserPreference('sdlcSidebarWidth', latest);
+      }
+    }
+
+    // The pointer leaves the handle almost immediately, so the cursor is held on
+    // the body for the length of the drag.
+    document.body.style.setProperty('cursor', 'col-resize');
+    document.body.style.setProperty('user-select', 'none');
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', finish);
+    window.addEventListener('pointercancel', finish);
+  };
+  const railOpen = !railCollapsed || railHovered;
+  const toggleRail = (): void => {
+    const next = !railCollapsed;
+    setUserPreference('sdlcSidebarCollapsed', next);
+    if (next) setRailHovered(false);
+  };
   const [trackName, setTrackName] = useState('');
   const [trackDescription, setTrackDescription] = useState('');
   const [artifactTrack, setArtifactTrack] = useState<{ id: string; name: string } | null>(null);
@@ -280,6 +428,57 @@ export default function SdlcScreen(): ReactElement {
   const [artifactContextLocked, setArtifactContextLocked] = useState(false);
   const [linkDialog, setLinkDialog] = useState(false);
   const [membersDialog, setMembersDialog] = useState(false);
+  const [trackStatusOpen, setTrackStatusOpen] = useState(false);
+  /** Null when not editing; the draft text while the description is being written. */
+  const [descriptionDraft, setDescriptionDraft] = useState<string | null>(null);
+  /** Set when Escape closes the editor, so the blur that follows does not save. */
+  const descriptionAbandoned = useRef(false);
+  const [nameDraft, setNameDraft] = useState<string | null>(null);
+  const nameAbandoned = useRef(false);
+  /**
+   * The open path down the folder tree, below the track. Column n renders the
+   * children of step n, so this array is both the breadcrumb and the set of
+   * live queries.
+   */
+  /** The artifact a single click is previewing, if any. */
+  const [previewCanvasId, setPreviewCanvasId] = useState<string | null>(null);
+  /** The artifact being read in the side panel, if any. */
+  const [readerCanvasId, setReaderCanvasId] = useState<string | null>(null);
+  /** True while the reader plays its exit; it stays mounted until that finishes. */
+  const [readerClosing, setReaderClosing] = useState(false);
+
+  /**
+   * Dismissing has to outlive the click: unmounting on the spot removes the
+   * element before its exit animation can run, which is why closing used to snap
+   * while opening slid.
+   */
+  const closeReader = (): void => {
+    setReaderClosing(true);
+    window.setTimeout(() => {
+      setReaderCanvasId(null);
+      setReaderClosing(false);
+    }, READER_EXIT_MS);
+  };
+  /**
+   * The folder whose conversations the right panel is showing, if any. Folder
+   * discussions share the track's panel rather than opening a surface of their
+   * own, so this is what decides which of the two the panel is bound to.
+   */
+  const [folderDiscussion, setFolderDiscussion] = useState<{ id: string; name: string } | null>(
+    null,
+  );
+  /** Set to the parent a new folder is being created under; null when closed. */
+  const [newFolderParent, setNewFolderParent] = useState<SdlcFinderStep | null>(null);
+  const [newFolderName, setNewFolderName] = useState('');
+  /** Where a new artifact should land; null when the type chooser is closed. */
+  const [newArtifactParent, setNewArtifactParent] = useState<SdlcFinderStep | null>(null);
+  /** A folder a just-created artifact must be filed into, applied after creation. */
+  const [pendingArtifactFolder, setPendingArtifactFolder] = useState<string | null>(null);
+  /** The row currently being dragged in the finder, if any. */
+  const [draggingItem, setDraggingItem] = useState<{
+    type: 'FOLDER' | 'CANVAS';
+    id: string;
+  } | null>(null);
   const [createTicketOpen, setCreateTicketOpen] = useState(false);
   const [relatedSourceId, setRelatedSourceId] = useState<string | null>(null);
   const [linkTargetType, setLinkTargetType] = useState('MESSAGE');
@@ -318,6 +517,7 @@ export default function SdlcScreen(): ReactElement {
             name: string;
             description: string | null;
             status: string;
+            createdBy: string;
             createdAt: number;
             updatedAt: number;
           }>)
@@ -326,6 +526,34 @@ export default function SdlcScreen(): ReactElement {
   );
   const selectedTrackId = routeSearchParams.get('track');
   const selectedTrack = tracks.find(track => track.id === selectedTrackId);
+  // Hooks cannot run inside renderTrack, which is only called on the track page,
+  // so the owner is looked up here and read there.
+  const trackOwner = useUser(selectedTrack?.createdBy ?? '');
+
+  const finderPathByTrack = useUserPreference('sdlcFinderPathByTrack');
+  const finderPath: SdlcFinderStep[] = selectedTrackId
+    ? (finderPathByTrack[selectedTrackId] ?? [])
+    : [];
+  /** Stored per track, so each one remembers where it was left open. */
+  const setFinderPath = (next: SdlcFinderStep[]): void => {
+    if (!selectedTrackId) return;
+    setUserPreference('sdlcFinderPathByTrack', { ...finderPathByTrack, [selectedTrackId]: next });
+  };
+  // The preview is per visit, not per track: an artifact selected last time is
+  // not what you asked to see now. The folder path is remembered; this is not.
+  useEffect(() => {
+    setPreviewCanvasId(null);
+  }, [selectedTrackId]);
+  // What the sidebar shows standing: work in flight, with anything finished or
+  // parked folded behind a toggle rather than dropped.
+  const openTracks = useMemo(
+    () => tracks.filter(track => track.status !== 'COMPLETED' && track.status !== 'ARCHIVED'),
+    [tracks],
+  );
+  const closedTracks = useMemo(
+    () => tracks.filter(track => track.status === 'COMPLETED' || track.status === 'ARCHIVED'),
+    [tracks],
+  );
   const wikiQuery = useQuery({
     queryKey: ['sdlc-wiki-pages', repoId],
     queryFn: async () => {
@@ -467,21 +695,6 @@ export default function SdlcScreen(): ReactElement {
         : [],
     [linkRows],
   );
-  const trackPrdIdsByTrack = useMemo(() => {
-    const byTrack = new Map<string, Set<string>>();
-    for (const link of links) {
-      if (
-        link.sourceType === 'TRACK' &&
-        link.targetType === 'CANVAS' &&
-        link.relationType === 'TRACK_ITEM'
-      ) {
-        const set = byTrack.get(link.sourceId) ?? new Set<string>();
-        set.add(link.targetId);
-        byTrack.set(link.sourceId, set);
-      }
-    }
-    return byTrack;
-  }, [links]);
   // Tickets belonging to a track (TRACK -> TICKET TRACK_ITEM links), propagated
   // from the ticket's source artifact when the ticket is created.
   const trackTicketIdsByTrack = useMemo(() => {
@@ -500,6 +713,22 @@ export default function SdlcScreen(): ReactElement {
     return byTrack;
   }, [links]);
   // canvas id -> its track name (from TRACK -> CANVAS TRACK_ITEM links), for card metadata.
+  /** ticket id -> the artifact it was raised from, for the ticket rows. */
+  const artifactByTicketId = useMemo(() => {
+    const byTicket = new Map<string, string>();
+    for (const link of links) {
+      if (
+        link.sourceType === 'CANVAS' &&
+        link.targetType === 'TICKET' &&
+        link.relationType === 'TICKET'
+      ) {
+        const canvas = canvases.find(item => item.id === link.sourceId);
+        if (canvas) byTicket.set(link.targetId, canvas.title);
+      }
+    }
+    return byTicket;
+  }, [links, canvases]);
+
   const trackByCanvasId = useMemo(() => {
     const nameById = new Map(tracks.map(track => [track.id, track.name]));
     const byCanvas = new Map<string, { id: string; name: string }>();
@@ -507,7 +736,7 @@ export default function SdlcScreen(): ReactElement {
       if (
         link.sourceType === 'TRACK' &&
         link.targetType === 'CANVAS' &&
-        link.relationType === 'TRACK_ITEM'
+        link.relationType === SDLC_TRACK_FLAT_RELATION
       ) {
         const name = nameById.get(link.sourceId);
         if (name) byCanvas.set(link.targetId, { id: link.sourceId, name });
@@ -551,18 +780,71 @@ export default function SdlcScreen(): ReactElement {
   const trackConversationIds = useMemo(
     () =>
       selectedTrackId
+        ? Array.from(
+            new Set(
+              links
+                .filter(
+                  link =>
+                    link.sourceType === 'TRACK' &&
+                    link.sourceId === selectedTrackId &&
+                    link.targetType === 'CONVERSATION' &&
+                    // Both edges count: the track's own discussions, and the flat
+                    // rows folders inside it file so their conversations roll up.
+                    (link.relationType === 'DISCUSSION' ||
+                      link.relationType === SDLC_TRACK_FLAT_RELATION),
+                )
+                .map(link => link.targetId),
+            ),
+          )
+        : [],
+    [links, selectedTrackId],
+  );
+  const folderConversationIds = useMemo(
+    () =>
+      folderDiscussion
         ? links
             .filter(
               link =>
-                link.sourceType === 'TRACK' &&
-                link.sourceId === selectedTrackId &&
+                link.sourceType === 'FOLDER' &&
+                link.sourceId === folderDiscussion.id &&
                 link.targetType === 'CONVERSATION' &&
                 link.relationType === 'DISCUSSION',
             )
             .map(link => link.targetId)
         : [],
-    [links, selectedTrackId],
+    [links, folderDiscussion],
   );
+  /**
+   * Every folder in the hub, once. This replaces the per-open-column lookup the
+   * finder used to run, and is what lets a conversation in the track's list name
+   * the folder it came from without a fetch of its own.
+   */
+  const [hubFolderRows] = useCachedQuery(
+    queries.getSdlcFoldersByChannel({ channelId: channelId || '' }),
+    { enabled: Boolean(channelId) },
+  );
+  const folderById = useMemo(
+    () => new Map((hubFolderRows ?? []).map(row => [row.id, { id: row.id, name: row.name }])),
+    [hubFolderRows],
+  );
+  /** Which folder each conversation was started in, for the list's marker. */
+  const folderIdByConversationId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const link of links) {
+      if (
+        link.sourceType === 'FOLDER' &&
+        link.targetType === 'CONVERSATION' &&
+        link.relationType === 'DISCUSSION'
+      ) {
+        map.set(link.targetId, link.sourceId);
+      }
+    }
+    return map;
+  }, [links]);
+  // A folder belongs to one track, so switching tracks cannot keep its binding.
+  useEffect(() => {
+    setFolderDiscussion(null);
+  }, [selectedTrackId]);
   const relatedTicketIds = useMemo(() => {
     const ids = new Set(linkedTicketIds(links));
     for (const set of trackTicketIdsByTrack.values()) {
@@ -583,35 +865,6 @@ export default function SdlcScreen(): ReactElement {
     { enabled: Boolean(channel?.id) },
   );
   const channelTicketCount = Array.isArray(channelTicketRows) ? channelTicketRows.length : 0;
-  const selectedCanvasConversationLinkIds = useMemo(
-    () =>
-      selectedCanvas
-        ? links.flatMap(link => {
-            if (link.sourceId === selectedCanvas.id && link.targetType === 'CONVERSATION') {
-              return [link.targetId];
-            }
-            if (link.targetId === selectedCanvas.id && link.sourceType === 'CONVERSATION') {
-              return [link.sourceId];
-            }
-            return [];
-          })
-        : [],
-    [links, selectedCanvas],
-  );
-  const [selectedCanvasRelatedConversations] = useCachedQuery(
-    queries.sdlcRelatedConversations({ conversationIds: selectedCanvasConversationLinkIds }),
-  );
-  const relatedConversationChannels = useMemo(
-    () =>
-      new Map(
-        (Array.isArray(selectedCanvasRelatedConversations)
-          ? selectedCanvasRelatedConversations
-          : []
-        ).map(conversation => [conversation.conversationId, conversation.channelId]),
-      ),
-    [selectedCanvasRelatedConversations],
-  );
-  const [chatHeaderActionsEl, setChatHeaderActionsEl] = useState<HTMLElement | null>(null);
   const [renderedConversationId, setRenderedConversationId] = useState<string | null>(null);
   const chatLayout = sdlcChatLayout({
     chatParam: routeSearchParams.get('chat'),
@@ -683,36 +936,34 @@ export default function SdlcScreen(): ReactElement {
     Boolean(discussionOwner && discussionSurface) || Boolean(section === 'tracks' && selectedTrack);
   const showRightPanel = rightPanelMode === 'debugger' || (rightPanelOpen && chatPanelAvailable);
   const chatPanelShowing = rightPanelMode === 'chat' && rightPanelOpen && chatPanelAvailable;
-  const threadOpenInPanel = chatPanelShowing && Boolean(selectedDiscussionConversationId);
   const discussionConversationIds = useMemo(
     () => discussionIdsForOwner(discussionOwner?.canvasId ?? null, links),
     [discussionOwner, links],
   );
+  /**
+   * The folder binding only holds while the track page is what is on screen: an
+   * open artifact owns the panel itself, and leaving the track drops the folder.
+   */
+  const activeFolderDiscussion =
+    folderDiscussion && !discussionOwner && section === 'tracks' && selectedTrack
+      ? folderDiscussion
+      : null;
   const entityLinkScope = useMemo<EntityLinkScope | null>(() => {
     if (discussionOwner) return { sourceType: 'CANVAS', sourceId: discussionOwner.canvasId };
     if (section === 'tracks' && selectedTrack) {
-      return { sourceType: 'TRACK', sourceId: selectedTrack.id };
+      // A folder conversation is filed on the folder and, so the track's list
+      // stays complete, on the track as well.
+      return activeFolderDiscussion
+        ? {
+            sourceType: 'FOLDER',
+            sourceId: activeFolderDiscussion.id,
+            rollUpTrackId: selectedTrack.id,
+          }
+        : { sourceType: 'TRACK', sourceId: selectedTrack.id };
     }
     return null;
-  }, [discussionOwner, section, selectedTrack]);
+  }, [activeFolderDiscussion, discussionOwner, section, selectedTrack]);
   const relatedCanvas = canvases.find(canvas => canvas.id === relatedSourceId);
-  const selectedCanvasRelatedLinks = selectedCanvas
-    ? links.filter(link => {
-        if (link.sourceId !== selectedCanvas.id && link.targetId !== selectedCanvas.id) {
-          return false;
-        }
-        const selectedIsSource = link.sourceId === selectedCanvas.id;
-        const entityId = selectedIsSource ? link.targetId : link.sourceId;
-        const entityType = selectedIsSource ? link.targetType : link.sourceType;
-        const repositoryChannelId = repo ? repo.channelId : null;
-        return shouldShowSdlcRelatedLink({
-          relationType: link.relationType,
-          entityType,
-          entityChannelId: relatedConversationChannels.get(entityId) ?? null,
-          repositoryChannelId,
-        });
-      })
-    : [];
   const state = repoKnowledgeState(repo ? repo.setupExecution : null);
   const setupRunning = isRepoKnowledgeRunning(state.phase);
 
@@ -922,20 +1173,6 @@ export default function SdlcScreen(): ReactElement {
     navigateWithinSdlc(`/sdlc/${channelId}/${section}`, `?${search.toString()}`);
   };
 
-  const openArtifactCanvas = (canvasId: string, event?: ReactMouseEvent): void => {
-    if (!repoId) return;
-    const folder = typeFolders.find(item => item.canvases.some(canvas => canvas.id === canvasId));
-    const search = canvasSearch(canvasId, true);
-    if (folder) search.set('type', folder.id);
-
-    if (shouldOpenInNewWindow(event) && openWindowForCanvas('artifacts', canvasId, search)) {
-      return;
-    }
-
-    setRelatedSourceId(null);
-    navigateWithinSdlc(`/sdlc/${channelId}/artifacts`, `?${search.toString()}`);
-  };
-
   const openWikiPage = (page: SdlcWikiPage): void => {
     if (!repoId) return;
     setRelatedSourceId(null);
@@ -982,8 +1219,49 @@ export default function SdlcScreen(): ReactElement {
 
   const openConversations = useCallback((): void => {
     closeExternalDebugger();
+    // The header button is the track's, so it drops any folder binding.
+    setFolderDiscussion(null);
     setDiscussionUrl({ open: true, conversationId: null });
   }, [closeExternalDebugger, setDiscussionUrl]);
+
+  const openFolderConversations = useCallback(
+    (folder: { id: string; name: string }): void => {
+      closeExternalDebugger();
+      setFolderDiscussion(folder);
+      setDiscussionUrl({ open: true, conversationId: null });
+    },
+    [closeExternalDebugger, setDiscussionUrl],
+  );
+
+  /**
+   * The mark on a conversation in the track's list saying which folder it came
+   * from, and taking you to that folder's conversations. Both halves come from
+   * data the page already holds.
+   */
+  const renderFolderConversationBadge = useCallback(
+    (conversationId: string): ReactNode => {
+      const folderId = folderIdByConversationId.get(conversationId);
+      const name = folderId ? folderById.get(folderId)?.name : undefined;
+      if (!folderId || !name) return null;
+      return (
+        // A floor so it never collapses in the sender's line, a ceiling so a long
+        // name cannot push the timestamp out of it, an ellipsis in between.
+        <button
+          type='button'
+          onClick={() => openFolderConversations({ id: folderId, name })}
+          title={`Conversations in ${name}`}
+          aria-label={`Conversations in ${name}`}
+          className='inline-flex min-w-[3.75rem] max-w-[9rem] shrink items-center gap-1 rounded bg-foreground/[0.06] px-1 py-px text-[10.5px] font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.11] hover:text-foreground'
+          data-track-category='SdlcHub'
+          data-track-name='FolderConversationsOpenedFromList'
+        >
+          <Folder className='size-[11px] shrink-0 fill-primary/25 text-primary/70' />
+          <span className='truncate'>{name}</span>
+        </button>
+      );
+    },
+    [folderById, folderIdByConversationId, openFolderConversations],
+  );
 
   const closeConversations = useCallback((): void => {
     setDiscussionUrl({ open: false, conversationId: null });
@@ -1221,6 +1499,15 @@ export default function SdlcScreen(): ReactElement {
     );
     resetArtifactDialog();
     const newCanvasId = response.data.artifact.canvasId;
+    // Creation always files an artifact at the track's root, so one started from
+    // inside a folder is moved there straight after.
+    if (pendingArtifactFolder && channel) {
+      await moveItemAction(
+        { type: 'CANVAS', id: newCanvasId },
+        { type: 'FOLDER', id: pendingArtifactFolder },
+      );
+      setPendingArtifactFolder(null);
+    }
     setRelatedSourceId(null);
     // Same search as opening an artifact from the list, so a new artifact lands
     // with its discussion open rather than only doing so once reopened.
@@ -1382,241 +1669,6 @@ export default function SdlcScreen(): ReactElement {
     }
   };
 
-  const setTrackStatusAction = async (trackId: string, status: string): Promise<void> => {
-    await runTrackMutation(
-      zero.mutate(
-        mutators.sdlc.updateTrack({
-          trackId,
-          status: status as 'ACTIVE' | 'COMPLETED' | 'ARCHIVED',
-          timestamp: Date.now(),
-        }),
-      ),
-    );
-  };
-
-  const openTrack = (trackId: string | null): void => {
-    if (!repoId) return;
-    navigateWithinSdlc(
-      `/sdlc/${channelId}/tracks`,
-      trackId ? `?track=${encodeURIComponent(trackId)}` : '',
-    );
-  };
-
-  const TRACK_STATUS_STYLES: Record<string, string> = {
-    ACTIVE: 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
-    COMPLETED: 'bg-sky-500/10 text-sky-700 dark:text-sky-300',
-    ARCHIVED: 'bg-muted text-muted-foreground',
-  };
-
-  const renderTracks = (): ReactElement => {
-    if (selectedTrack) {
-      const trackItemIds = trackPrdIdsByTrack.get(selectedTrack.id) ?? new Set<string>();
-      const trackTicketIds = trackTicketIdsByTrack.get(selectedTrack.id) ?? new Set<string>();
-      const trackTypeSections = typeFolders.map(folder => ({
-        folder,
-        canvases: folder.canvases
-          .filter(item => trackItemIds.has(item.id))
-          .sort((left, right) => left.createdAt - right.createdAt),
-      }));
-      const trackTickets = tickets.filter(ticket => trackTicketIds.has(ticket.id));
-      return (
-        <section>
-          {selectedTrack.description ? (
-            <p className='mb-4 text-sm text-muted-foreground'>{selectedTrack.description}</p>
-          ) : null}
-          {trackTypeSections.map((section, index) => (
-            <div key={section.folder.id} className={index > 0 ? 'mt-6' : undefined}>
-              <SectionHeader
-                title={`${section.folder.name} in this track`}
-                description={`${section.folder.name} artifacts grouped under this workstream.`}
-                action={
-                  <Button
-                    onClick={() => {
-                      clearArtifactDialogFields({
-                        track: { id: selectedTrack.id, name: selectedTrack.name },
-                      });
-                      setArtifactDialog({ id: section.folder.id, name: section.folder.name });
-                    }}
-                  >
-                    <Plus />
-                    New {section.folder.name}
-                  </Button>
-                }
-              />
-              {section.canvases.length === 0 ? (
-                <EmptyCard text={`No ${section.folder.name} in this track yet.`} />
-              ) : (
-                <div>
-                  {section.canvases.map(canvas => (
-                    <button
-                      type='button'
-                      key={canvas.id}
-                      className='group mb-1.5 flex w-full items-start gap-3 rounded-xl bg-primary/5 px-3 py-3 text-left transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
-                      onClick={event => openArtifactCanvas(canvas.id, event)}
-                      data-track-category='SdlcHub'
-                      data-track-name='TrackArtifactOpened'
-                      data-track-metadata={JSON.stringify({
-                        canvasId: canvas.id,
-                        folderId: section.folder.id,
-                      })}
-                    >
-                      <span className='grid size-9 shrink-0 place-items-center rounded-lg bg-primary/10 text-primary'>
-                        <FileText size={18} />
-                      </span>
-                      <span className='min-w-0 flex-1'>
-                        <span className='block truncate text-sm font-semibold'>{canvas.title}</span>
-                        <span className='mt-1 flex items-center gap-1.5 text-[11px] text-muted-foreground'>
-                          <span className='font-medium text-primary/80'>{section.folder.name}</span>
-                          <span aria-hidden='true'>·</span>
-                          <span>created {formatRelativeTime(canvas.createdAt)}</span>
-                        </span>
-                      </span>
-                      <ChevronRight className='mt-1 size-4 shrink-0 text-muted-foreground/50 transition-transform group-hover:translate-x-0.5 group-hover:text-foreground' />
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-          ))}
-          <div className='mt-6'>
-            <SectionHeader
-              title='Tickets in this track'
-              description='Implementation tickets created under this workstream.'
-              action={
-                <Button onClick={() => setCreateTicketOpen(true)}>
-                  <Plus />
-                  Create Ticket
-                </Button>
-              }
-            />
-            <div>
-              {trackTickets.length === 0 ? (
-                <EmptyCard text='No tickets in this track yet.' />
-              ) : (
-                trackTickets.map(ticket => (
-                  <button
-                    type='button'
-                    key={ticket.id}
-                    className='group mb-1.5 flex w-full items-start gap-3 rounded-xl bg-primary/5 px-3 py-3 text-left transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
-                    onClick={() => void navigate(`/sdlc/${channelId}/tickets/${ticket.id}`)}
-                    data-track-category='SdlcHub'
-                    data-track-name='TrackTicketOpened'
-                    data-track-metadata={JSON.stringify({ ticketId: ticket.id })}
-                  >
-                    <span className='grid size-9 shrink-0 place-items-center rounded-lg bg-primary/10 text-primary'>
-                      <CircleDot size={18} />
-                    </span>
-                    <span className='min-w-0 flex-1'>
-                      <span className='block truncate text-sm font-semibold'>{ticket.title}</span>
-                      <span className='mt-1 flex items-center gap-1.5 text-[11px] text-muted-foreground'>
-                        <span className='font-medium text-primary/80'>{ticket.xyneId}</span>
-                        <span aria-hidden='true'>·</span>
-                        <span>{ticket.stageName}</span>
-                      </span>
-                    </span>
-                    <ChevronRight className='mt-1 size-4 shrink-0 text-muted-foreground/50 transition-transform group-hover:translate-x-0.5 group-hover:text-foreground' />
-                  </button>
-                ))
-              )}
-            </div>
-          </div>
-        </section>
-      );
-    }
-
-    return (
-      <section>
-        <SectionHeader
-          title='Tracks'
-          description='Workstreams that group PRDs and their conversations.'
-          action={
-            <Button
-              onClick={() => setTrackDialog(true)}
-              data-track-category='SdlcHub'
-              data-track-name='NewTrackOpened'
-            >
-              <Plus />
-              New Track
-            </Button>
-          }
-        />
-        <div className='grid grid-cols-2 gap-4'>
-          {tracks.map(track => {
-            return (
-              <div
-                key={track.id}
-                role='button'
-                tabIndex={0}
-                onClick={event => {
-                  const target = event.target as HTMLElement;
-                  if (target.closest('[data-status-select], [role="listbox"], [role="option"]'))
-                    return;
-                  openTrack(track.id);
-                }}
-                onKeyDown={event => {
-                  const target = event.target as HTMLElement;
-                  if (target.closest('[data-status-select], [role="listbox"], [role="option"]'))
-                    return;
-                  if (event.key === 'Enter' || event.key === ' ') {
-                    event.preventDefault();
-                    openTrack(track.id);
-                  }
-                }}
-                className='group cursor-pointer rounded-xl border bg-background p-5 transition-colors hover:border-primary/35 hover:bg-muted/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
-                data-track-category='SdlcHub'
-                data-track-name='TrackOpened'
-                data-track-metadata={JSON.stringify({ trackId: track.id })}
-              >
-                <div className='flex items-start justify-between'>
-                  <div className='grid size-9 place-items-center rounded-lg bg-primary/10 text-primary'>
-                    <Layers size={18} />
-                  </div>
-                  <div data-status-select=''>
-                    <Select
-                      value={track.status}
-                      onValueChange={value =>
-                        void call(
-                          `track-status-${track.id}`,
-                          () => setTrackStatusAction(track.id, value),
-                          'Track updated',
-                        )
-                      }
-                    >
-                      <SelectTrigger
-                        className={cn(
-                          'h-7 w-auto gap-1 rounded-full border-none px-2.5 text-xs font-medium shadow-none focus:ring-0',
-                          TRACK_STATUS_STYLES[track.status] ?? TRACK_STATUS_STYLES['ACTIVE'],
-                        )}
-                        onClick={event => event.stopPropagation()}
-                        onKeyDown={event => event.stopPropagation()}
-                        data-track-category='SdlcHub'
-                        data-track-name='TrackStatusChanged'
-                      >
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value='ACTIVE'>Active</SelectItem>
-                        <SelectItem value='COMPLETED'>Completed</SelectItem>
-                        <SelectItem value='ARCHIVED'>Archived</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </div>
-                <h3 className='mt-4 truncate font-semibold'>{track.name}</h3>
-                <p className='mt-1 line-clamp-2 min-h-4 text-xs text-muted-foreground'>
-                  {track.description || 'No description yet.'}
-                </p>
-              </div>
-            );
-          })}
-          {tracks.length === 0 && (
-            <EmptyCard text='No tracks yet. Create one to group PRDs and conversations for a workstream.' />
-          )}
-        </div>
-      </section>
-    );
-  };
-
   const activeTrackOptions = tracks
     .filter(track => track.status !== 'ARCHIVED')
     .map(track => ({
@@ -1700,44 +1752,750 @@ export default function SdlcScreen(): ReactElement {
 
   const isDocumentWindow = isSdlcDocumentWindow();
 
-  return (
-    <div className='flex h-full min-w-0 overflow-hidden bg-transparent'>
-      <aside
-        className={cn(
-          'flex shrink-0 flex-col border-r border-sidebar-border-muted bg-sidebar text-sidebar-foreground',
-          selectedWikiPage ||
-            (section === 'baseline' && selectedCanvas) ||
-            (section === 'tracks' && selectedTrack)
-            ? 'w-72'
-            : 'w-[260px]',
-          isDocumentWindow && 'hidden',
-        )}
-        style={{ backdropFilter: 'blur(var(--sidebar-background-blur))' }}
-      >
-        <div className='h-[52px] w-full shrink-0'>
-          <AppNavigator />
-        </div>
-        <div className='border-b border-t border-sidebar-border-muted px-3 py-3'>
-          <div className='flex items-center justify-between gap-2 px-1'>
-            <div className='text-[10.5px] font-semibold uppercase tracking-[0.13em] text-sidebar-foreground/60'>
-              SDLC Hub
+  /**
+   * The page for one track: its artifacts and issues, reached by selecting the
+   * track in the sidebar. The list of tracks that used to sit alongside it is
+   * gone — the sidebar is the list now, so the page only ever shows the one
+   * track that is selected.
+   */
+  const setTrackStatusAction = async (trackId: string, status: string): Promise<void> => {
+    await runTrackMutation(
+      zero.mutate(
+        mutators.sdlc.updateTrack({
+          trackId,
+          status: status as 'ACTIVE' | 'COMPLETED' | 'ARCHIVED',
+          timestamp: Date.now(),
+        }),
+      ),
+    );
+  };
+
+  const renameFolderAction = async (folderId: string, name: string): Promise<void> => {
+    if (!channel) return;
+    await runTrackMutation(
+      zero.mutate(
+        mutators.sdlc.renameSdlcFolder({
+          folderId,
+          channelId: channel.id,
+          name,
+          timestamp: Date.now(),
+        }),
+      ),
+    );
+    // The stored path carries names for the column headers, so a rename has to
+    // reach it too or the breadcrumb keeps the old one until a reload.
+    setFinderPath(finderPath.map(step => (step.id === folderId ? { ...step, name } : step)));
+  };
+
+  const moveItemAction = async (
+    item: { type: 'FOLDER' | 'CANVAS'; id: string },
+    parent: { type: 'TRACK' | 'FOLDER'; id: string },
+  ): Promise<void> => {
+    if (!channel) return;
+    await runTrackMutation(
+      zero.mutate(
+        mutators.sdlc.moveSdlcItem({
+          linkId: uuidv4(),
+          channelId: channel.id,
+          itemType: item.type,
+          itemId: item.id,
+          parentType: parent.type,
+          parentId: parent.id,
+          timestamp: Date.now(),
+        }),
+      ),
+    );
+  };
+
+  const createFolderAction = async (): Promise<void> => {
+    if (!channel || !selectedTrack || !newFolderParent) return;
+    await runTrackMutation(
+      zero.mutate(
+        mutators.sdlc.createSdlcFolder({
+          id: uuidv4(),
+          containmentLinkId: uuidv4(),
+          flatLinkId: uuidv4(),
+          channelId: channel.id,
+          trackId: selectedTrack.id,
+          parentType: newFolderParent.type,
+          parentId: newFolderParent.id,
+          name: newFolderName.trim(),
+          timestamp: Date.now(),
+        }),
+      ),
+    );
+    setNewFolderParent(null);
+    setNewFolderName('');
+  };
+
+  const setTrackNameAction = async (trackId: string, name: string): Promise<void> => {
+    await runTrackMutation(
+      zero.mutate(mutators.sdlc.updateTrack({ trackId, name, timestamp: Date.now() })),
+    );
+  };
+
+  const setTrackDescriptionAction = async (trackId: string, description: string): Promise<void> => {
+    await runTrackMutation(
+      zero.mutate(
+        mutators.sdlc.updateTrack({
+          trackId,
+          // Cleared to null rather than an empty string, so "no description" is
+          // one value and the heading has one thing to test.
+          description: description.length > 0 ? description : null,
+          timestamp: Date.now(),
+        }),
+      ),
+    );
+  };
+
+  const renderTrack = (): ReactElement | null => {
+    if (!selectedTrack) return null;
+    const trackTicketIds = trackTicketIdsByTrack.get(selectedTrack.id) ?? new Set<string>();
+    const trackTickets = tickets.filter(ticket => trackTicketIds.has(ticket.id));
+    const openTicketCount = trackTickets.filter(
+      ticket =>
+        ticket.statusV2 !== TicketStatusV2.COMPLETED &&
+        ticket.statusV2 !== TicketStatusV2.CANCELLED,
+    ).length;
+    const unownedTicketCount = trackTickets.filter(ticket => !ticket.assignedTo).length;
+    const ticketTally = `${openTicketCount} open · ${unownedTicketCount} unowned`;
+    const finderCanvasById = new Map<string, SdlcFinderCanvas>(
+      typeFolders.flatMap(folder =>
+        folder.canvases.map(canvas => [
+          canvas.id,
+          {
+            id: canvas.id,
+            title: canvas.title,
+            typeName: folder.name,
+            createdBy: canvas.createdBy,
+            createdAt: canvas.createdAt,
+            updatedAt: canvas.updatedAt,
+            lastEditedBy: canvas.lastEditedBy ?? undefined,
+            lastEditedAt: canvas.lastEditedAt ?? undefined,
+          } satisfies SdlcFinderCanvas,
+        ]),
+      ),
+    );
+    return (
+      <section>
+        {/* Heading: what this track is, who owns it, and what it holds. */}
+        <div className='mb-6 flex flex-wrap items-start gap-5'>
+          <div className='min-w-[280px] flex-1'>
+            <div className='mb-2 flex items-center gap-3'>
+              <div className='grid size-[30px] shrink-0 place-items-center rounded-lg bg-primary/10'>
+                <Layers className='size-4 text-primary' />
+              </div>
+              {/* Click the name to rename, the same way the description works. */}
+              {nameDraft === null ? (
+                <button
+                  type='button'
+                  onClick={() => setNameDraft(selectedTrack.name)}
+                  className='-mx-1 min-w-0 truncate rounded px-1 text-left text-[26px] font-bold leading-tight tracking-tight transition-colors hover:bg-muted/50'
+                  title='Rename track'
+                  data-track-category='SdlcHub'
+                  data-track-name='TrackNameEditOpened'
+                >
+                  {selectedTrack.name}
+                </button>
+              ) : (
+                <span className='relative inline-flex min-w-0 max-w-full items-center'>
+                  {/* Mirrors the field's text and typography. Character counts
+                      cannot size a proportional face — a space is far narrower
+                      than a `ch`, so the slack piled up as you typed. */}
+                  <span
+                    aria-hidden='true'
+                    data-name-mirror
+                    className='pointer-events-none invisible absolute left-0 top-0 whitespace-pre px-1 text-[26px] font-bold leading-tight tracking-tight'
+                  >
+                    {nameDraft || ' '}
+                  </span>
+                  <input
+                    autoFocus
+                    value={nameDraft}
+                    maxLength={TRACK_NAME_LIMIT}
+                    onChange={event => setNameDraft(event.target.value)}
+                    onFocus={event => {
+                      sizeNameFieldToText(event.currentTarget);
+                      event.target.setSelectionRange(
+                        event.target.value.length,
+                        event.target.value.length,
+                      );
+                    }}
+                    onKeyDown={event => {
+                      if (event.key === 'Escape') {
+                        nameAbandoned.current = true;
+                        setNameDraft(null);
+                      }
+                      // One line, so Enter is the natural way to finish.
+                      if (event.key === 'Enter') event.currentTarget.blur();
+                    }}
+                    onBlur={() => {
+                      if (nameAbandoned.current) {
+                        nameAbandoned.current = false;
+                        return;
+                      }
+                      const next = nameDraft.trim();
+                      setNameDraft(null);
+                      // A track has to be called something; an empty box reverts
+                      // rather than writing a nameless track.
+                      if (next.length > 0 && next !== selectedTrack.name) {
+                        void call(
+                          `track-name-${selectedTrack.id}`,
+                          () => setTrackNameAction(selectedTrack.id, next),
+                          'Track renamed',
+                        );
+                      }
+                    }}
+                    onInput={event => sizeNameFieldToText(event.currentTarget)}
+                    className='-mx-1 min-w-0 max-w-full rounded border-0 bg-muted/40 px-1 text-[26px] font-bold leading-tight tracking-tight text-foreground outline-none ring-0 transition-colors duration-150 focus:bg-muted/60 focus:outline-none motion-reduce:transition-none'
+                    data-track-category='SdlcHub'
+                    data-track-name='TrackNameEdited'
+                  />
+                </span>
+              )}
+              <Popover
+                open={trackStatusOpen}
+                onOpenChange={setTrackStatusOpen}
+                align='start'
+                sideOffset={6}
+                className='w-[168px] p-1'
+                trigger={
+                  <button
+                    type='button'
+                    className='flex shrink-0 items-center gap-1.5 rounded-md bg-muted px-2.5 py-1 text-[11.5px] font-medium text-foreground ring-1 ring-inset ring-border transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                    aria-label={`Track status: ${
+                      TRACK_STATUS_OPTIONS.find(o => o.value === selectedTrack.status)?.label ??
+                      selectedTrack.status
+                    }. Change status`}
+                    data-track-category='SdlcHub'
+                    data-track-name='TrackStatusOpened'
+                  >
+                    <span
+                      className={cn(
+                        'size-1.5 shrink-0 rounded-full',
+                        TRACK_STATUS_DOT[selectedTrack.status] ?? TRACK_STATUS_DOT['ARCHIVED'],
+                      )}
+                      aria-hidden='true'
+                    />
+                    {TRACK_STATUS_OPTIONS.find(o => o.value === selectedTrack.status)?.label ??
+                      selectedTrack.status}
+                    <ChevronDown className='size-3 text-muted-foreground' />
+                  </button>
+                }
+              >
+                {TRACK_STATUS_OPTIONS.map(option => (
+                  <button
+                    key={option.value}
+                    type='button'
+                    onClick={() => {
+                      setTrackStatusOpen(false);
+                      if (option.value !== selectedTrack.status) {
+                        void call(
+                          `track-status-${selectedTrack.id}`,
+                          () => setTrackStatusAction(selectedTrack.id, option.value),
+                          `Track marked ${option.label.toLowerCase()}`,
+                        );
+                      }
+                    }}
+                    className={cn(
+                      'flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left text-[13px] transition-colors hover:bg-muted/60',
+                      option.value === selectedTrack.status && 'font-medium',
+                    )}
+                    data-track-category='SdlcHub'
+                    data-track-name='TrackStatusChanged'
+                    data-track-metadata={JSON.stringify({ status: option.value })}
+                  >
+                    <span className='flex items-center gap-2'>
+                      <span
+                        className={cn(
+                          'size-1.5 shrink-0 rounded-full',
+                          TRACK_STATUS_DOT[option.value],
+                        )}
+                        aria-hidden='true'
+                      />
+                      {option.label}
+                    </span>
+                    {option.value === selectedTrack.status && (
+                      <Check className='size-3.5 text-muted-foreground' />
+                    )}
+                  </button>
+                ))}
+              </Popover>
             </div>
-            {/* Escape hatch for a wedged frame; only meaningful when framed. */}
-            {isFramedSdlcSurface() && (
+
+            {/* Click the text to edit it, blur to save. No chrome: the field
+                sits exactly where the description sits, at the same size, so
+                editing looks like typing over what is already there. */}
+            {descriptionDraft === null ? (
               <button
                 type='button'
-                onClick={requestSdlcFrameReset}
-                title='Reload SDLC Hub — discards this session and starts fresh at the hub root'
-                aria-label='Reload SDLC Hub'
-                className='rounded-md p-1 text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-accent-ring'
+                onClick={() => setDescriptionDraft(selectedTrack.description ?? '')}
+                className='-mx-1 block max-w-[918px] rounded px-1 text-left text-[13.5px] leading-relaxed text-muted-foreground transition-colors hover:bg-muted/50'
                 data-track-category='SdlcHub'
-                data-track-name='FrameReset'
+                data-track-name='TrackDescriptionEditOpened'
               >
-                <RefreshCw className='h-3.5 w-3.5' aria-hidden='true' />
+                {selectedTrack.description ? (
+                  <span className='whitespace-pre-wrap'>{selectedTrack.description}</span>
+                ) : (
+                  <>
+                    No description yet. <span className='text-primary'>Add one</span>
+                  </>
+                )}
               </button>
+            ) : (
+              <div className='max-w-[918px]'>
+                <textarea
+                  autoFocus
+                  rows={1}
+                  value={descriptionDraft}
+                  maxLength={TRACK_DESCRIPTION_LIMIT}
+                  onChange={event => {
+                    setDescriptionDraft(event.target.value);
+                    // Grow with the text rather than scrolling inside a fixed box.
+                    event.target.style.height = 'auto';
+                    event.target.style.height = `${event.target.scrollHeight}px`;
+                  }}
+                  onFocus={event => {
+                    event.target.style.height = 'auto';
+                    event.target.style.height = `${event.target.scrollHeight}px`;
+                    event.target.setSelectionRange(
+                      event.target.value.length,
+                      event.target.value.length,
+                    );
+                  }}
+                  onKeyDown={event => {
+                    if (event.key === 'Escape') {
+                      // Leave without writing; the blur that follows must not save.
+                      descriptionAbandoned.current = true;
+                      setDescriptionDraft(null);
+                    }
+                    if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+                      event.currentTarget.blur();
+                    }
+                  }}
+                  onBlur={() => {
+                    if (descriptionAbandoned.current) {
+                      descriptionAbandoned.current = false;
+                      return;
+                    }
+                    const next = descriptionDraft.trim();
+                    setDescriptionDraft(null);
+                    if (next !== (selectedTrack.description ?? '')) {
+                      void call(
+                        `track-description-${selectedTrack.id}`,
+                        () => setTrackDescriptionAction(selectedTrack.id, next),
+                        'Description saved',
+                      );
+                    }
+                  }}
+                  placeholder='What is this track for?'
+                  className='-mx-1 block w-[calc(100%+0.5rem)] resize-none overflow-hidden rounded border-0 bg-muted/40 px-1 py-0.5 text-[13.5px] leading-relaxed text-foreground outline-none ring-0 transition-[height,background-color] duration-150 ease-out placeholder:text-muted-foreground focus:bg-muted/60 focus:outline-none motion-reduce:transition-none'
+                  data-track-category='SdlcHub'
+                  data-track-name='TrackDescriptionEdited'
+                />
+                {/* Only speaks up near the cap; a counter on every edit is noise. */}
+                {descriptionDraft.length > TRACK_DESCRIPTION_LIMIT - 200 && (
+                  <div className='mt-1 text-[11px] tabular-nums text-muted-foreground'>
+                    {TRACK_DESCRIPTION_LIMIT - descriptionDraft.length} characters left
+                  </div>
+                )}
+              </div>
+            )}
+
+            <div className='mt-3 flex flex-wrap items-center gap-3 text-[12.5px] text-muted-foreground'>
+              {/* The avatar and name both open the shared profile card on hover,
+                  so the owner is reachable from here the way they are anywhere
+                  else a person appears. */}
+              <UserHoverWrapper userId={selectedTrack.createdBy}>
+                <span className='flex cursor-pointer items-center gap-2 transition-colors hover:text-foreground'>
+                  <Avatar userId={selectedTrack.createdBy} size='xs' showActiveStatus={false} />
+                  <span className='truncate'>
+                    {trackOwner ? getUserDisplayName(trackOwner) : 'Unknown'} · owner
+                  </span>
+                </span>
+              </UserHoverWrapper>
+            </div>
+          </div>
+          <div className='flex shrink-0 items-center gap-2'>
+            <Button
+              variant='outline'
+              onClick={() =>
+                setNewFolderParent(
+                  finderPath.at(-1) ?? {
+                    type: 'TRACK',
+                    id: selectedTrack.id,
+                    name: selectedTrack.name,
+                  },
+                )
+              }
+              data-track-category='SdlcHub'
+              data-track-name='NewFolderOpened'
+            >
+              <Plus />
+              New folder
+            </Button>
+            <Button
+              onClick={() =>
+                setNewArtifactParent(
+                  finderPath.at(-1) ?? {
+                    type: 'TRACK',
+                    id: selectedTrack.id,
+                    name: selectedTrack.name,
+                  },
+                )
+              }
+              data-track-category='SdlcHub'
+              data-track-name='NewArtifactOpened'
+            >
+              <Plus />
+              New artifact
+            </Button>
+          </div>
+        </div>
+        {/* The track's contents, browsed a level at a time. Each column is one
+            live query for the children of its parent, so opening a folder costs
+            one fetch and closing it drops one. The column headers name the path,
+            so there is no separate breadcrumb above them. */}
+        <div className='mb-6 overflow-hidden rounded-xl border border-border'>
+          {/* Controls for the browser below, kept out of the columns so a column
+              header stays the name of its level and nothing else. */}
+          <div className='flex items-center gap-3 border-b border-border bg-foreground/[0.03] px-3 py-1.5'>
+            <span className='text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground'>
+              Group by
+            </span>
+            <div className='flex items-center gap-0.5 rounded-md border border-border p-0.5'>
+              {(
+                [
+                  { value: 'none', label: 'None' },
+                  { value: 'type', label: 'Type' },
+                ] as const
+              ).map(option => (
+                <button
+                  key={option.value}
+                  type='button'
+                  onClick={() => setUserPreference('sdlcFinderGroupBy', option.value)}
+                  className={cn(
+                    'rounded px-2 py-0.5 text-[11.5px] font-medium transition-colors',
+                    finderGroupBy === option.value
+                      ? 'bg-foreground/[0.08] text-foreground'
+                      : 'text-muted-foreground hover:text-foreground',
+                  )}
+                  data-track-category='SdlcHub'
+                  data-track-name='FinderGroupByChanged'
+                  data-track-metadata={JSON.stringify({ groupBy: option.value })}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          {/* A fixed height, not a floor: min-h let a column grow with its contents and
+              took the whole card — and the page — with it. Each column scrolls
+              inside this instead, so the page only scrolls when the pointer is
+              somewhere that has nothing of its own to scroll. */}
+          <div className='scrollbar-none flex h-[520px] overflow-x-auto'>
+            {(
+              [
+                { type: 'TRACK', id: selectedTrack.id, name: selectedTrack.name },
+                ...finderPath,
+              ] satisfies SdlcFinderStep[]
+            ).map((step, index, steps) => (
+              <SdlcFinderColumn
+                key={step.id}
+                channelId={channel.id}
+                parent={step}
+                selectedId={steps[index + 1]?.id ?? null}
+                activeSelectionId={previewCanvasId ? null : (finderPath.at(-1)?.id ?? null)}
+                canvasById={finderCanvasById}
+                isLast={index === steps.length - 1}
+                onSelectFolder={folder => {
+                  setPreviewCanvasId(null);
+                  setFinderPath([
+                    ...steps.slice(1, index + 1),
+                    { type: 'FOLDER', id: folder.id, name: folder.name },
+                  ]);
+                }}
+                previewCanvasId={previewCanvasId}
+                onSelectCanvas={canvasId => {
+                  // Selecting a file closes everything to the right of its own
+                  // column: those levels were reached through a folder that is no
+                  // longer what is selected, and the preview belongs immediately
+                  // after the column the file is in.
+                  setFinderPath(steps.slice(1, index + 1));
+                  setPreviewCanvasId(canvasId);
+                }}
+                onOpenCanvas={(canvasId, event) =>
+                  openCanvas(canvasId, event ? { event } : undefined)
+                }
+                onNewFolder={parent => setNewFolderParent(parent)}
+                onNewArtifact={parent => setNewArtifactParent(parent)}
+                onDiscussFolder={openFolderConversations}
+                folderById={folderById}
+                discussingFolderId={
+                  chatPanelShowing && activeFolderDiscussion ? activeFolderDiscussion.id : null
+                }
+                onRenameFolder={(folderId, name) =>
+                  void call(
+                    `sdlc-folder-rename-${folderId}`,
+                    () => renameFolderAction(folderId, name),
+                    'Folder renamed',
+                  )
+                }
+                draggingItem={draggingItem}
+                onDragItem={setDraggingItem}
+                onMoveItem={(item, parent) =>
+                  void call(`sdlc-move-${item.id}`, () => moveItemAction(item, parent), 'Moved')
+                }
+              />
+            ))}
+            {previewCanvasId && finderCanvasById.get(previewCanvasId) && (
+              <SdlcFinderPreview
+                canvas={finderCanvasById.get(previewCanvasId) as SdlcFinderCanvas}
+                onOpen={(canvasId, event) => openCanvas(canvasId, event ? { event } : undefined)}
+                onPreview={setReaderCanvasId}
+              />
             )}
           </div>
-          <div className='mt-2 flex items-center gap-1.5'>
+        </div>
+
+        {/* Tickets under this track, below the browser. A flat list rather than
+            columns: a ticket has no contents to step into. */}
+        <div className='mb-4 flex flex-wrap items-center gap-3'>
+          <span className='text-[10.5px] font-semibold uppercase tracking-[0.14em] text-muted-foreground'>
+            Tickets
+          </span>
+          <span className='text-[11.5px] text-muted-foreground'>{ticketTally}</span>
+          <div className='h-px min-w-[20px] flex-1 bg-border' aria-hidden='true' />
+          <Button
+            size='sm'
+            onClick={() => setCreateTicketOpen(true)}
+            data-track-category='SdlcHub'
+            data-track-name='TrackTicketCreateOpened'
+          >
+            <Plus />
+            Create ticket
+          </Button>
+        </div>
+
+        <div className='mb-6 overflow-hidden rounded-xl border border-border'>
+          {trackTickets.length === 0 ? (
+            <p className='px-4 py-8 text-center text-[12px] text-muted-foreground'>
+              No tickets in this track yet.
+            </p>
+          ) : (
+            trackTickets.map(ticket => (
+              <button
+                key={ticket.id}
+                type='button'
+                // The ticket's own conversation, not just the panel: openConversations
+                // passes a null conversation, which leaves the reader on whichever
+                // thread was last selected rather than the ticket they clicked.
+                onClick={() =>
+                  setDiscussionUrl({
+                    open: true,
+                    conversationId: ticket.conversationId,
+                    // Clicking a ticket is a request to see the ticket, so it
+                    // lands on Details rather than the thread. Details is a
+                    // properties view with no composer — switching to Messages
+                    // brings the reply box back, and the panel remembers that.
+                    selectedTab: 'details',
+                  })
+                }
+                className='flex w-full items-center gap-3 border-b border-border px-3.5 py-2 text-left transition-colors last:border-b-0 hover:bg-foreground/[0.04]'
+                data-track-category='SdlcHub'
+                data-track-name='TrackTicketOpened'
+                data-track-metadata={JSON.stringify({ ticketId: ticket.id })}
+              >
+                <span className='shrink-0 font-mono text-[11px] text-muted-foreground'>
+                  {ticket.xyneId}
+                </span>
+                <span className='min-w-[110px] flex-1 truncate text-[13px] font-medium tracking-[-0.01em]'>
+                  {ticket.title}
+                </span>
+                {/* Where the ticket came from. Only shown when there is one — a
+                    ticket raised on its own has nothing to point at. */}
+                {artifactByTicketId.get(ticket.id) && (
+                  <span className='flex min-w-0 shrink items-center gap-1.5 text-[11px] text-muted-foreground'>
+                    <Link2 className='size-3 shrink-0' />
+                    <span className='truncate'>{artifactByTicketId.get(ticket.id)}</span>
+                  </span>
+                )}
+                {ticket.priority !== TicketPriority.LOW && (
+                  <span
+                    className={cn(
+                      'shrink-0 rounded-full px-2 py-0.5 text-[10.5px] font-medium',
+                      ticket.priority === TicketPriority.HIGH ||
+                        ticket.priority === TicketPriority.CRITICAL
+                        ? 'bg-destructive/15 text-destructive'
+                        : 'bg-foreground/[0.07] text-muted-foreground',
+                    )}
+                  >
+                    {TICKET_PRIORITY_LABEL[ticket.priority]}
+                  </span>
+                )}
+                <span className='shrink-0 rounded-full bg-foreground/[0.07] px-2 py-0.5 text-[10.5px] font-medium text-muted-foreground'>
+                  {ticket.stageName}
+                </span>
+                {ticket.assignedTo ? (
+                  <Avatar userId={ticket.assignedTo} size='xs' showActiveStatus={false} />
+                ) : (
+                  // An unowned ticket is worth seeing at a glance, so the gap
+                  // where an owner would be is drawn rather than left blank.
+                  <span
+                    className='size-5 shrink-0 rounded-full border border-dashed border-border'
+                    title='Unassigned'
+                    aria-label='Unassigned'
+                  />
+                )}
+                <ChevronRight className='size-3.5 shrink-0 text-muted-foreground' />
+              </button>
+            ))
+          )}
+        </div>
+      </section>
+    );
+  };
+  const openTrack = (trackId: string | null): void => {
+    if (!repoId) return;
+    navigateWithinSdlc(
+      `/sdlc/${channelId}/tracks`,
+      trackId ? `?track=${encodeURIComponent(trackId)}` : '',
+    );
+  };
+
+  const sectionNavRows = SECTIONS.map(item => {
+    const Icon = item.icon;
+    return (
+      <div key={item.id} className='mb-0.5'>
+        <button
+          onClick={() => navigateWithinSdlc(`/sdlc/${channelId}/${item.id}`)}
+          className={cn(
+            'flex h-[32px] w-full items-center gap-2.5 rounded-[6px] px-2 text-[13px] text-sidebar-foreground transition-colors',
+            section === item.id ? 'bg-foreground/10 font-medium' : 'hover:bg-foreground/[0.06]',
+          )}
+          data-track-category='SdlcHub'
+          data-track-name='SectionChanged'
+          data-track-metadata={JSON.stringify({ section: item.id, repoId: repo.id })}
+        >
+          <Icon size={15} className='shrink-0 text-sidebar-foreground/70' />
+          <span className='flex-1 truncate text-left'>{item.label}</span>
+          <span className='text-xs tabular-nums text-sidebar-foreground/50'>
+            {item.id === 'wiki'
+              ? section === 'wiki'
+                ? wikiPages.length
+                : ''
+              : item.id === 'baseline'
+                ? baseline.length
+                : item.id === 'tickets'
+                  ? channelTicketCount
+                  : ''}
+          </span>
+        </button>
+      </div>
+    );
+  });
+
+  return (
+    <div className='flex h-full min-w-0 overflow-hidden bg-transparent'>
+      {/* The rail is what the layout reserves; the panel inside is what is seen.
+          While collapsed the panel floats above the page on hover, so widening
+          it costs the content nothing. */}
+      <aside
+        className={cn(
+          // One width for every view. It used to widen for the pages that hung an
+          // extra tree or panel under the lists, but a sidebar that changes size
+          // as you move between pages reads as a glitch, and the content it was
+          // making room for now fits.
+          'relative shrink-0',
+          isDocumentWindow && 'hidden',
+        )}
+        style={{ width: railCollapsed ? SIDEBAR_RAIL_WIDTH : railWidth }}
+        onMouseEnter={() => railCollapsed && setRailHovered(true)}
+        onMouseLeave={() => setRailHovered(false)}
+      >
+        <div
+          className={cn(
+            'flex h-full flex-col overflow-x-hidden border-r border-sidebar-border-muted bg-sidebar text-sidebar-foreground',
+            // No width animation mid-drag: the panel has to track the pointer.
+            draggingWidth === null && 'transition-[width] duration-150',
+            railCollapsed
+              ? cn('absolute inset-y-0 left-0 z-30', railHovered && 'shadow-2xl')
+              : 'w-full',
+          )}
+          style={{
+            backdropFilter: 'blur(var(--sidebar-background-blur))',
+            ...(railCollapsed
+              ? { width: railHovered ? SIDEBAR_HOVER_WIDTH : SIDEBAR_RAIL_WIDTH }
+              : {}),
+          }}
+        >
+          {/* Folded, the rail carries one icon and nothing else — the navigator's
+            own back, forward and refresh controls would not fit at this width and
+            reading them squeezed against the edge was the point of folding away.
+            The row keeps its height either way, so the toggle below it stays on
+            the line it was on rather than jumping up as the sidebar folds. */}
+          <div className='h-[52px] w-full shrink-0 overflow-hidden'>
+            {railOpen && <AppNavigator />}
+          </div>
+          {/* Same 52px and 16px inset as the navigator above. */}
+          <div
+            className={cn(
+              'flex h-[52px] shrink-0 items-center gap-1 border-t border-sidebar-border-muted',
+              railOpen ? 'justify-between px-4' : 'justify-center px-2',
+            )}
+          >
+            <div
+              className={cn(
+                'min-w-0 truncate text-[10.5px] font-semibold uppercase tracking-[0.13em] text-sidebar-foreground/60',
+                !railOpen && 'sr-only',
+              )}
+            >
+              SDLC Hub
+            </div>
+            {/* The toggle sits last so it lands hard against the sidebar's right
+              edge when open, and is the only thing left when folded. */}
+            <div className='flex shrink-0 items-center gap-0.5'>
+              {railOpen && (
+                <button
+                  type='button'
+                  onClick={() => setHubDialog('create')}
+                  title='New hub'
+                  aria-label='New hub'
+                  className='rounded-md p-1 text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-accent-ring'
+                  data-track-category='SdlcHub'
+                  data-track-name='NewHubOpened'
+                >
+                  <Plus className='size-3.5' />
+                </button>
+              )}
+              {/* Escape hatch for a wedged frame; only meaningful when framed. */}
+              {railOpen && isFramedSdlcSurface() && (
+                <button
+                  type='button'
+                  onClick={requestSdlcFrameReset}
+                  title='Reload SDLC Hub — discards this session and starts fresh at the hub root'
+                  aria-label='Reload SDLC Hub'
+                  className='rounded-md p-1 text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-accent-ring'
+                  data-track-category='SdlcHub'
+                  data-track-name='FrameReset'
+                >
+                  <RefreshCw className='h-3.5 w-3.5' aria-hidden='true' />
+                </button>
+              )}
+              <button
+                type='button'
+                onClick={toggleRail}
+                title={railCollapsed ? 'Pin the sidebar open' : 'Collapse to icons'}
+                aria-label={railCollapsed ? 'Pin the sidebar open' : 'Collapse to icons'}
+                className='-mr-1 rounded-md p-1 text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-accent-ring'
+                data-track-category='SdlcHub'
+                data-track-name='SidebarRailToggled'
+              >
+                <PanelLeft className='size-3.5' />
+              </button>
+            </div>
+          </div>
+          <div className={cn('flex items-center gap-1 px-2 pb-2', !railOpen && 'hidden')}>
             <div className='min-w-0 flex-1'>
               <SdlcHubPicker
                 hubs={hubOptions}
@@ -1745,324 +2503,288 @@ export default function SdlcScreen(): ReactElement {
                 onSelect={nextChannelId => void navigate(`/sdlc/${nextChannelId}/overview`)}
               />
             </div>
-            <button
-              type='button'
-              className='grid size-[34px] shrink-0 place-items-center rounded-[8px] border border-sidebar-border-muted bg-foreground/[0.03] text-sidebar-foreground/70 transition-colors hover:bg-foreground/[0.06] hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-accent-ring'
-              onClick={() => setHubDialog('create')}
-              title='New hub'
-              aria-label='New hub'
-              data-track-category='SdlcHub'
-              data-track-name='NewHubOpened'
+          </div>
+          {/* Every list in the sidebar folds to its header and drags against its
+            neighbours — the hub's own pages included, since a reader who lives
+            in one section should be able to put the rest away. Heights are
+            remembered per reader in the preferences machine rather than by the
+            group, so there is one place a sidebar setting lives. */}
+          {railOpen ? (
+            <ResizableGroup
+              orientation='vertical'
+              onLayoutChanged={(_layout, meta) => persistSdlcSectionHeights(meta)}
+              className='min-h-0 flex-1'
             >
-              <Plus className='size-3.5' />
-            </button>
-          </div>
-        </div>
-        <nav className='shrink-0 px-2 pt-2'>
-          {SECTIONS.map(item => {
-            const Icon = item.icon;
-            return (
-              <div key={item.id} className='mb-0.5'>
-                <button
-                  onClick={() => navigateWithinSdlc(`/sdlc/${channelId}/${item.id}`)}
-                  className={cn(
-                    'flex h-[34px] w-full items-center gap-2.5 rounded-[7px] px-2 text-[13.5px] text-sidebar-foreground transition-colors',
-                    section === item.id
-                      ? 'bg-foreground/10 font-medium'
-                      : 'hover:bg-foreground/[0.06]',
-                  )}
-                  data-track-category='SdlcHub'
-                  data-track-name='SectionChanged'
-                  data-track-metadata={JSON.stringify({ section: item.id, repoId: repo.id })}
-                >
-                  <Icon size={16} className='shrink-0 text-sidebar-foreground/70' />
-                  <span className='flex-1 truncate text-left'>{item.label}</span>
-                  <span className='text-xs tabular-nums text-sidebar-foreground/50'>
-                    {item.id === 'wiki'
-                      ? section === 'wiki'
-                        ? wikiPages.length
-                        : ''
-                      : item.id === 'baseline'
-                        ? baseline.length
-                        : item.id === 'tickets'
-                          ? channelTicketCount
-                          : item.id === 'tracks'
-                            ? tracks.filter(track => track.status === 'ACTIVE').length
-                            : ''}
-                  </span>
-                </button>
-              </div>
-            );
-          })}
-
-          <div
-            className='-mx-2 mb-1 mt-3 border-t border-sidebar-border-muted'
-            aria-hidden='true'
-          />
-          <div className='flex items-center justify-between px-2 pb-2.5 pt-3'>
-            <span className='text-[10.5px] font-bold uppercase tracking-[0.13em] text-foreground/45'>
-              Artifacts
-            </span>
-            <button
-              type='button'
-              title='New artifact type'
-              onClick={() => {
-                setTypeName('');
-                setTypeDialogOpen(true);
-              }}
-              className='-mr-[7px] flex size-[22px] items-center justify-center rounded-[5px] text-foreground/45 hover:bg-foreground/[0.06] hover:text-foreground'
-              data-track-category='SdlcHub'
-              data-track-name='NewArtifactTypeClicked'
-            >
-              <Plus size={14} />
-            </button>
-          </div>
-        </nav>
-        <div className='min-h-[108px] flex-[0_1_auto] overflow-y-auto px-2 pb-2'>
-          {typeFolders.map(folder => {
-            const isActive = section === 'artifacts' && activeTypeFolder?.id === folder.id;
-            const isRenaming = renameTypeId === folder.id;
-            return (
-              <div
-                key={folder.id}
-                className='group relative mb-0.5'
-                onMouseEnter={() => setHoveredTypeId(folder.id)}
-                onMouseLeave={() =>
-                  setHoveredTypeId(current => (current === folder.id ? null : current))
-                }
-              >
-                {isRenaming ? (
-                  <div className='flex h-[34px] w-full items-center gap-2.5 px-2'>
-                    <Folder size={16} className='shrink-0 text-sidebar-foreground/70' />
-                    <input
-                      autoFocus
-                      onFocus={event => event.currentTarget.select()}
-                      value={renameTypeName}
-                      onChange={event => setRenameTypeName(event.target.value)}
-                      onBlur={() => void renameArtifactType(folder.id, renameTypeName)}
-                      onKeyDown={event => {
-                        if (event.key === 'Enter')
-                          void renameArtifactType(folder.id, renameTypeName);
-                        if (event.key === 'Escape') {
-                          setRenameTypeId(null);
-                          setRenameTypeName('');
-                        }
-                      }}
-                      className='h-6 min-w-0 flex-1 rounded-[6px] border border-sidebar-accent-ring bg-background px-1.5 text-[13.5px] outline-none'
-                      data-track-category='SdlcHub'
-                      data-track-name='ArtifactTypeRenamed'
-                    />
-                  </div>
-                ) : (
-                  <>
-                    <button
-                      onClick={() =>
-                        navigateWithinSdlc(
-                          `/sdlc/${channelId}/artifacts`,
-                          `?type=${encodeURIComponent(folder.id)}`,
-                        )
-                      }
-                      className={cn(
-                        'flex h-[34px] w-full items-center gap-2.5 rounded-[7px] px-2 text-[13.5px] text-sidebar-foreground transition-colors',
-                        isActive
-                          ? 'bg-foreground/10 font-medium'
-                          : 'group-hover:bg-foreground/[0.06]',
-                      )}
-                      data-track-category='SdlcHub'
-                      data-track-name='SectionChanged'
-                      data-track-metadata={JSON.stringify({ type: folder.id, repoId: repo.id })}
-                    >
-                      <Folder size={16} className='shrink-0 text-sidebar-foreground/70' />
-                      <span className='flex-1 truncate text-left'>{folder.name}</span>
-                      <span className='w-6 text-right text-xs tabular-nums text-sidebar-foreground/50 transition-opacity group-hover:opacity-0'>
-                        {folder.canvases.length}
-                      </span>
-                    </button>
-                    <button
-                      type='button'
-                      title='Rename (F2)'
-                      aria-label={`Rename ${folder.name}`}
-                      onClick={event => {
-                        event.stopPropagation();
-                        setRenameTypeId(folder.id);
-                        setRenameTypeName(folder.name);
-                      }}
-                      className='absolute right-1.5 top-1/2 hidden size-[22px] -translate-y-1/2 items-center justify-center rounded-[5px] text-sidebar-foreground/70 hover:bg-foreground/10 hover:text-sidebar-foreground group-hover:flex'
-                      data-track-category='SdlcHub'
-                      data-track-name='ArtifactTypeRenameStarted'
-                    >
-                      <Pencil size={13} />
-                    </button>
-                  </>
-                )}
-              </div>
-            );
-          })}
-        </div>
-        {section === 'wiki' && selectedWikiPage && (
-          <div className='min-h-0 flex-1 border-t border-sidebar-border-muted'>
-            <SdlcWikiSidebarTree
-              pages={wikiPages}
-              loading={wikiQuery.isLoading}
-              error={wikiQuery.isError}
-              selectedCanvasId={selectedCanvasId}
-              onRetry={() => void wikiQuery.refetch()}
-              onOpen={openWikiPage}
-            />
-          </div>
-        )}
-        {section === 'baseline' && selectedCanvas && (
-          <div className='min-h-0 flex-1 border-t border-sidebar-border-muted'>
-            <SdlcWikiSidebarTree
-              pages={baselineSidebarPages}
-              loading={false}
-              error={false}
-              selectedCanvasId={selectedCanvasId}
-              variant='repo-knowledge'
-              onRetry={() => undefined}
-              onOpen={page => openCanvas(page.canvasId)}
-            />
-          </div>
-        )}
-        {section === 'tracks' && selectedTrack && (
-          <div className='min-h-0 flex-1 overflow-y-auto border-t border-sidebar-border-muted p-3'>
-            <div className='px-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-sidebar-foreground/70'>
-              Tracks
-            </div>
-            <div className='mt-2 space-y-1'>
-              {tracks.map(track => (
-                <button
-                  key={track.id}
-                  type='button'
-                  onClick={() => openTrack(track.id)}
-                  className={cn(
-                    'flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-accent-ring',
-                    track.id === selectedTrack.id
-                      ? 'bg-sidebar-accent/70 font-medium text-sidebar-accent-foreground'
-                      : 'hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground',
-                  )}
-                  data-track-category='SdlcHub'
-                  data-track-name='SidebarTrackOpened'
-                  data-track-metadata={JSON.stringify({ trackId: track.id })}
-                >
-                  <Layers className='size-3.5 shrink-0 text-sidebar-foreground/60' />
-                  <span className='min-w-0 flex-1 truncate'>{track.name}</span>
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
-        {selectedCanvas && section !== 'baseline' && (
-          <div className='max-h-[32vh] min-h-[72px] flex-[0_1_auto] overflow-y-auto border-t border-sidebar-border-muted p-3'>
-            <div className='flex items-center justify-between gap-2 px-1'>
-              <div className='min-w-0'>
-                <div className='text-[11px] font-semibold uppercase tracking-[0.12em] text-sidebar-foreground/70'>
-                  Related
-                </div>
-                <div className='mt-1 truncate text-xs font-medium'>{selectedCanvas.title}</div>
-              </div>
-              <Button
-                variant='ghost'
-                size='iconSm'
-                aria-label='Add related context'
-                title='Add related context'
-                onClick={() => {
-                  setRelatedSourceId(selectedCanvas.id);
-                  setLinkDialog(true);
+              <SdlcSidebarSection id='sdlc-sidebar-hub' title='Hub'>
+                {sectionNavRows}
+              </SdlcSidebarSection>
+              <SdlcSidebarSectionSeparator />
+              <SdlcSidebarSection
+                id='sdlc-sidebar-tracks'
+                title='Tracks'
+                count={openTracks.length}
+                action={{
+                  label: 'New track',
+                  trackName: 'NewTrackOpened',
+                  onClick: () => setTrackDialog(true),
                 }}
               >
-                <Plus />
-              </Button>
-            </div>
-            <div className='mt-3 space-y-1.5'>
-              {selectedCanvasRelatedLinks.map(link => {
-                const selectedIsSource = link.sourceId === selectedCanvas.id;
-                const entityId = selectedIsSource ? link.targetId : link.sourceId;
-                const entityType = selectedIsSource ? link.targetType : link.sourceType;
-                const canvas = canvases.find(item => item.id === entityId);
-                const ticket = tickets.find(item => item.id === entityId);
-                const track = tracks.find(item => item.id === entityId);
-                const pullRequest = tickets
-                  .flatMap(item => item.pullRequests ?? [])
-                  .find(item => item.id === entityId);
-                const label =
-                  canvas?.title ||
-                  (ticket ? `${ticket.xyneId} · ${ticket.title}` : undefined) ||
-                  track?.name ||
-                  (pullRequest ? `PR #${pullRequest.prId}` : undefined) ||
-                  entityId;
-                return (
-                  <div
-                    key={link.id}
-                    className='group flex items-center gap-2 rounded-lg border border-sidebar-border-muted bg-sidebar-accent/20 px-2.5 py-2'
+                {openTracks.map(track => (
+                  <button
+                    key={track.id}
+                    type='button'
+                    onClick={() => openTrack(track.id)}
+                    className={cn(
+                      'mb-0.5 flex h-[32px] w-full items-center gap-2.5 rounded-[6px] px-2 text-[13px] text-sidebar-foreground transition-colors',
+                      selectedTrackId === track.id
+                        ? 'bg-foreground/10 font-medium'
+                        : 'hover:bg-foreground/[0.06]',
+                    )}
+                    title={track.description || track.name}
+                    data-track-category='SdlcHub'
+                    data-track-name='TrackOpened'
+                    data-track-metadata={JSON.stringify({ trackId: track.id })}
                   >
-                    <Network size={13} className='shrink-0 text-sidebar-foreground/60' />
-                    <div className='min-w-0 flex-1'>
-                      <div className='truncate text-xs font-medium'>{label}</div>
-                      <div className='mt-0.5 text-[10px] uppercase tracking-wide text-sidebar-foreground/60'>
-                        {String(entityType).replaceAll('_', ' ')}
-                      </div>
-                    </div>
-                    <Button
-                      variant='ghost'
-                      size='iconSm'
-                      className='opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100'
-                      aria-label='Remove related context'
-                      loading={busy === `unlink-${link.id}`}
-                      onClick={() =>
-                        void call(
-                          `unlink-${link.id}`,
-                          () =>
-                            apiInstance.delete(`/sdlc/repositories/${repo.id}/links/${link.id}`),
-                          'Link removed',
-                        )
+                    <Layers size={15} className='shrink-0 text-sidebar-foreground/70' />
+                    <span className='flex-1 truncate text-left'>{track.name}</span>
+                  </button>
+                ))}
+                {openTracks.length === 0 && (
+                  <p className='px-2 py-3 text-[12.5px] text-sidebar-foreground/50'>
+                    No open tracks yet.
+                  </p>
+                )}
+                {/* Finished work is out of the way but not gone — the same place it
+                  would be looked for. */}
+                {closedTracks.length > 0 && (
+                  <>
+                    <button
+                      type='button'
+                      onClick={() => setShowClosedTracks(!showClosedTracks)}
+                      className='mt-1 w-full px-2 py-1.5 text-left text-[12px] text-sidebar-foreground/45 transition-colors hover:text-sidebar-foreground/70'
+                      data-track-category='SdlcHub'
+                      data-track-name='ClosedTracksToggled'
+                    >
+                      {showClosedTracks
+                        ? 'Hide completed & parked'
+                        : `Show ${closedTracks.length} completed & parked`}
+                    </button>
+                    {showClosedTracks &&
+                      closedTracks.map(track => (
+                        <button
+                          key={track.id}
+                          type='button'
+                          onClick={() => openTrack(track.id)}
+                          className={cn(
+                            'mb-0.5 flex h-[32px] w-full items-center gap-2.5 rounded-[6px] px-2 text-[13px] text-sidebar-foreground/60 transition-colors',
+                            selectedTrackId === track.id
+                              ? 'bg-foreground/10 font-medium'
+                              : 'hover:bg-foreground/[0.06]',
+                          )}
+                          title={track.description || track.name}
+                          data-track-category='SdlcHub'
+                          data-track-name='TrackOpened'
+                          data-track-metadata={JSON.stringify({ trackId: track.id })}
+                        >
+                          <Layers size={15} className='shrink-0 text-sidebar-foreground/50' />
+                          <span className='flex-1 truncate text-left'>{track.name}</span>
+                        </button>
+                      ))}
+                  </>
+                )}
+              </SdlcSidebarSection>
+              <SdlcSidebarSectionSeparator />
+              <SdlcSidebarSection
+                id='sdlc-sidebar-artifacts'
+                title='Artifacts'
+                count={typeFolders.length}
+                action={{
+                  label: 'New artifact type',
+                  trackName: 'NewArtifactTypeClicked',
+                  onClick: () => {
+                    setTypeName('');
+                    setTypeDialogOpen(true);
+                  },
+                }}
+              >
+                {typeFolders.map(folder => {
+                  const isActive = section === 'artifacts' && activeTypeFolder?.id === folder.id;
+                  const isRenaming = renameTypeId === folder.id;
+                  return (
+                    <div
+                      key={folder.id}
+                      className='group relative mb-0.5'
+                      onMouseEnter={() => setHoveredTypeId(folder.id)}
+                      onMouseLeave={() =>
+                        setHoveredTypeId(current => (current === folder.id ? null : current))
                       }
                     >
-                      <Trash2 />
-                    </Button>
-                  </div>
-                );
-              })}
-              {selectedCanvasRelatedLinks.length === 0 && (
-                <div className='rounded-lg border border-dashed border-sidebar-border-muted px-3 py-4 text-center text-xs text-sidebar-foreground/60'>
-                  No related context
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-        <div className='mt-auto border-t border-sidebar-border-muted p-4 text-xs text-sidebar-foreground'>
-          <div className='space-y-1'>
-            {repo.project && (
-              <button
-                type='button'
-                onClick={() => void navigate(`/listProjects/${repo.project!.id}`)}
-                className='flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left transition-colors hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-accent-ring'
-                aria-label={`Open project ${repo.project.name}`}
-                data-track-category='SdlcHub'
-                data-track-name='ProjectOpened'
-                data-track-metadata={JSON.stringify({ projectId: repo.project.id })}
+                      {isRenaming ? (
+                        <div className='flex h-[32px] w-full items-center gap-2.5 px-2'>
+                          <Folder size={15} className='shrink-0 text-sidebar-foreground/70' />
+                          <input
+                            autoFocus
+                            onFocus={event => event.currentTarget.select()}
+                            value={renameTypeName}
+                            onChange={event => setRenameTypeName(event.target.value)}
+                            onBlur={() => void renameArtifactType(folder.id, renameTypeName)}
+                            onKeyDown={event => {
+                              if (event.key === 'Enter')
+                                void renameArtifactType(folder.id, renameTypeName);
+                              if (event.key === 'Escape') {
+                                setRenameTypeId(null);
+                                setRenameTypeName('');
+                              }
+                            }}
+                            className='h-6 min-w-0 flex-1 rounded-[6px] border border-sidebar-accent-ring bg-background px-1.5 text-[13.5px] outline-none'
+                            data-track-category='SdlcHub'
+                            data-track-name='ArtifactTypeRenamed'
+                          />
+                        </div>
+                      ) : (
+                        <>
+                          <button
+                            onClick={() =>
+                              navigateWithinSdlc(
+                                `/sdlc/${channelId}/artifacts`,
+                                `?type=${encodeURIComponent(folder.id)}`,
+                              )
+                            }
+                            className={cn(
+                              'flex h-[32px] w-full items-center gap-2.5 rounded-[6px] px-2 text-[13px] text-sidebar-foreground transition-colors',
+                              isActive
+                                ? 'bg-foreground/10 font-medium'
+                                : 'group-hover:bg-foreground/[0.06]',
+                            )}
+                            data-track-category='SdlcHub'
+                            data-track-name='SectionChanged'
+                            data-track-metadata={JSON.stringify({
+                              type: folder.id,
+                              repoId: repo.id,
+                            })}
+                          >
+                            <Folder size={15} className='shrink-0 text-sidebar-foreground/70' />
+                            <span className='flex-1 truncate text-left'>{folder.name}</span>
+                            <span className='w-6 text-right text-xs tabular-nums text-sidebar-foreground/50 transition-opacity group-hover:opacity-0'>
+                              {folder.canvases.length}
+                            </span>
+                          </button>
+                          <button
+                            type='button'
+                            title='Rename (F2)'
+                            aria-label={`Rename ${folder.name}`}
+                            onClick={event => {
+                              event.stopPropagation();
+                              setRenameTypeId(folder.id);
+                              setRenameTypeName(folder.name);
+                            }}
+                            className='absolute right-1.5 top-1/2 hidden size-[22px] -translate-y-1/2 items-center justify-center rounded-[5px] text-sidebar-foreground/70 hover:bg-foreground/10 hover:text-sidebar-foreground group-hover:flex'
+                            data-track-category='SdlcHub'
+                            data-track-name='ArtifactTypeRenameStarted'
+                          >
+                            <Pencil size={13} />
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  );
+                })}
+              </SdlcSidebarSection>
+              <SdlcSidebarSectionSeparator />
+              <SdlcSidebarSection
+                id='sdlc-sidebar-repositories'
+                title='Repositories'
+                count={channelRepos.length}
+                action={{
+                  label: 'Add a repository',
+                  trackName: 'HubRepositoriesOpened',
+                  onClick: () => setHubDialog('manage'),
+                }}
               >
-                <Boxes className='size-4 shrink-0 text-sidebar-foreground/65' />
-                <span className='min-w-0 flex-1'>
-                  <span className='block text-[10px] uppercase tracking-wide text-sidebar-foreground/55'>
-                    Project
-                  </span>
-                  <span className='block truncate font-medium'>{repo.project.name}</span>
-                </span>
-                <ChevronRight className='size-3.5 shrink-0 text-sidebar-foreground/55' />
-              </button>
-            )}
-            <SdlcHubRepositories
-              repositories={channelRepos}
-              onManage={() => setHubDialog('manage')}
+                {channelRepos.map(repository => (
+                  <a
+                    key={repository.id}
+                    href={repository.canonicalUrl || repository.url}
+                    target='_blank'
+                    rel='noreferrer'
+                    className='mb-0.5 flex h-[32px] w-full items-center gap-2.5 rounded-[7px] px-2 text-[13px] text-sidebar-foreground transition-colors hover:bg-foreground/[0.06]'
+                    data-track-category='SdlcHub'
+                    data-track-name='HubRepositoryOpened'
+                  >
+                    <GitBranch size={15} className='shrink-0 text-sidebar-foreground/70' />
+                    <span className='min-w-0 flex-1 truncate text-left'>{repository.name}</span>
+                    <ExternalLink size={12} className='shrink-0 text-sidebar-foreground/45' />
+                  </a>
+                ))}
+                {channelRepos.length === 0 && (
+                  <p className='px-2 py-3 text-[12.5px] text-sidebar-foreground/50'>
+                    No repositories yet.
+                  </p>
+                )}
+              </SdlcSidebarSection>
+              {/* Slack. Panels have to fill the group, so without something here to
+                take the leftover height the group refuses to collapse the last
+                open section — every section closed is a perfectly reasonable
+                thing to want, and this is what allows it.
+  
+                It claims the whole group by default so that the leftover is *its*
+                to give up: with no size of its own it was allotted nothing, and
+                the sections above grew to fill the sidebar instead of keeping the
+                heights they were told to take. */}
+              <Panel id='sdlc-sidebar-slack' minSize='0px' defaultSize='100%' />
+            </ResizableGroup>
+          ) : null}
+          {section === 'wiki' && selectedWikiPage && (
+            <div className='min-h-0 flex-1 border-t border-sidebar-border-muted'>
+              <SdlcWikiSidebarTree
+                pages={wikiPages}
+                loading={wikiQuery.isLoading}
+                error={wikiQuery.isError}
+                selectedCanvasId={selectedCanvasId}
+                onRetry={() => void wikiQuery.refetch()}
+                onOpen={openWikiPage}
+              />
+            </div>
+          )}
+          {section === 'baseline' && selectedCanvas && (
+            <div className='min-h-0 flex-1 border-t border-sidebar-border-muted'>
+              <SdlcWikiSidebarTree
+                pages={baselineSidebarPages}
+                loading={false}
+                error={false}
+                selectedCanvasId={selectedCanvasId}
+                variant='repo-knowledge'
+                onRetry={() => undefined}
+                onOpen={page => openCanvas(page.canvasId)}
+              />
+            </div>
+          )}
+        </div>
+        {!railCollapsed && (
+          <div
+            role='separator'
+            aria-orientation='vertical'
+            aria-label='Resize sidebar'
+            onPointerDown={startRailResize}
+            className='group absolute inset-y-0 -right-1 z-40 w-2 cursor-col-resize'
+            data-track-category='SdlcHub'
+            data-track-name='SidebarResized'
+          >
+            <div
+              className={cn(
+                'pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-gradient-to-b from-transparent via-primary to-transparent transition-opacity duration-150',
+                draggingWidth === null ? 'opacity-0 group-hover:opacity-70' : 'opacity-100',
+              )}
+              aria-hidden='true'
             />
           </div>
-        </div>
+        )}
       </aside>
 
       <div className='flex min-w-0 flex-1 flex-col overflow-hidden'>
-        <header className='z-10 flex h-16 shrink-0 items-center justify-between gap-4 border-b bg-background/95 px-5 backdrop-blur'>
+        {/* Same 52px band as the sidebar's navigator and hub rows, so the page
+            title sits on the line the sidebar headers already establish. */}
+        <header className='z-10 flex h-[52px] shrink-0 items-center justify-between gap-4 border-b bg-background/95 px-5 backdrop-blur'>
           <div className='flex min-w-0 items-center gap-2'>
             {selectedCanvasId ? (
               <>
@@ -2085,19 +2807,9 @@ export default function SdlcScreen(): ReactElement {
                 </h1>
               </>
             ) : section === 'tracks' && selectedTrack ? (
-              <>
-                <button
-                  type='button'
-                  onClick={() => openTrack(null)}
-                  className='shrink-0 text-sm text-muted-foreground transition-colors hover:text-foreground'
-                  data-track-category='SdlcHub'
-                  data-track-name='TrackDetailBack'
-                >
-                  Tracks
-                </button>
-                <ChevronRight size={15} className='shrink-0 text-muted-foreground' />
-                <h1 className='truncate font-semibold'>{selectedTrack.name}</h1>
-              </>
+              // Tracks left the nav, so the lookup below cannot name this page.
+              // There is no list to go back to either, so the track names itself.
+              <h1 className='truncate font-semibold'>{selectedTrack.name}</h1>
             ) : (
               <h1 className='font-semibold'>
                 {section === 'artifacts'
@@ -2148,72 +2860,68 @@ export default function SdlcScreen(): ReactElement {
             >
               <Users className='size-4' />
             </Button>
-            <div
-              className={cn(
-                'grid transition-[grid-template-columns] duration-300 ease-out',
-                threadOpenInPanel ? 'grid-cols-[0fr]' : 'grid-cols-[1fr]',
-              )}
-            >
-              <div className='flex min-w-0 items-center gap-1.5 overflow-hidden pl-1.5 [&_button]:!size-7 [&_button]:!rounded-lg'>
-                {chatPanelAvailable && repo.channelId ? (
-                  <CallTriggerModal
-                    channelId={repo.channelId}
-                    {...(repo.channel?.scopeType && { scopeType: repo.channel.scopeType })}
-                    channelName={repo.name}
-                    participantCount={repo.channel?.channelStats?.participantCount ?? 0}
-                    callDisplayName={repo.name}
-                    isMember={Boolean(
-                      repo.channel?.participants?.some(
-                        participant => participant.userId === auth.userID,
-                      ),
-                    )}
-                    {...((): { sdlcLink?: SdlcCallLink } => {
-                      if (discussionOwner) {
-                        return {
-                          sdlcLink: {
-                            ownerType: 'CANVAS',
-                            ownerId: discussionOwner.canvasId,
-                          },
-                        };
-                      }
-                      if (section === 'tracks' && selectedTrack) {
-                        return {
-                          sdlcLink: {
-                            ownerType: 'TRACK',
-                            ownerId: selectedTrack.id,
-                          },
-                        };
-                      }
-                      return {};
-                    })()}
-                  />
-                ) : null}
-                {chatPanelAvailable && repo.channelId ? (
-                  <Button
-                    size='icon'
-                    variant='ghost'
-                    aria-label='Create ticket'
-                    title='Create ticket'
-                    onClick={() => setCreateTicketOpen(true)}
-                    data-track-category='SdlcHub'
-                    data-track-name='HeaderCreateTicketClicked'
-                  >
-                    <TicketToken size={16} />
-                  </Button>
-                ) : null}
+            <div className='flex min-w-0 items-center gap-1.5 overflow-hidden pl-1.5 [&_button]:!size-7 [&_button]:!rounded-lg'>
+              {chatPanelAvailable && repo.channelId ? (
+                <CallTriggerModal
+                  channelId={repo.channelId}
+                  {...(repo.channel?.scopeType && { scopeType: repo.channel.scopeType })}
+                  channelName={repo.name}
+                  participantCount={repo.channel?.channelStats?.participantCount ?? 0}
+                  callDisplayName={repo.name}
+                  isMember={Boolean(
+                    repo.channel?.participants?.some(
+                      participant => participant.userId === auth.userID,
+                    ),
+                  )}
+                  {...((): { sdlcLink?: SdlcCallLink } => {
+                    if (discussionOwner) {
+                      return {
+                        sdlcLink: {
+                          ownerType: 'CANVAS',
+                          ownerId: discussionOwner.canvasId,
+                        },
+                      };
+                    }
+                    if (section === 'tracks' && selectedTrack) {
+                      return {
+                        sdlcLink: {
+                          ownerType: 'TRACK',
+                          ownerId: selectedTrack.id,
+                        },
+                      };
+                    }
+                    return {};
+                  })()}
+                />
+              ) : null}
+              {chatPanelAvailable && repo.channelId ? (
                 <Button
                   size='icon'
                   variant='ghost'
-                  aria-label='Ask AI'
-                  title='Ask AI'
-                  onClick={() => openSdlcAssistant()}
+                  aria-label='Create ticket'
+                  title='Create ticket'
+                  onClick={() => setCreateTicketOpen(true)}
                   data-track-category='SdlcHub'
-                  data-track-name='HeaderAskAiClicked'
+                  data-track-name='HeaderCreateTicketClicked'
                 >
-                  <XyneAIStar />
+                  <TicketToken size={16} />
                 </Button>
-              </div>
+              ) : null}
+              <Button
+                size='icon'
+                variant='ghost'
+                aria-label='Ask AI'
+                title='Ask AI'
+                onClick={() => openSdlcAssistant()}
+                data-track-category='SdlcHub'
+                data-track-name='HeaderAskAiClicked'
+              >
+                <XyneAIStar />
+              </Button>
             </div>
+            {/* Closes the right panel, and only that. Its label and action never
+                depend on whether a thread is open, so the bar does not change
+                under the reader — the thread's own cross lives in the panel. */}
             <div
               className={cn(
                 'grid transition-[grid-template-columns] duration-300 ease-out',
@@ -2221,33 +2929,14 @@ export default function SdlcScreen(): ReactElement {
               )}
             >
               <div className='flex min-w-0 items-center overflow-hidden'>
-                <div
-                  className={cn(
-                    'grid transition-[grid-template-columns] duration-300 ease-out',
-                    threadOpenInPanel ? 'grid-cols-[1fr]' : 'grid-cols-[0fr]',
-                  )}
-                >
-                  <div className='flex min-w-0 items-center overflow-hidden'>
-                    <div
-                      ref={setChatHeaderActionsEl}
-                      className='ml-1.5 flex items-center [&>div]:animate-in [&>div]:fade-in [&>div]:duration-300 [&>div]:!gap-1.5'
-                    />
-                  </div>
-                </div>
                 <Button
                   size='icon'
                   variant='ghost'
-                  aria-label={threadOpenInPanel ? 'Close thread' : 'Close chat'}
-                  title={threadOpenInPanel ? 'Close thread' : 'Close chat'}
+                  aria-label='Close chat'
+                  title='Close chat'
                   className='ml-1.5 size-7 rounded-lg'
                   tabIndex={chatPanelShowing ? 0 : -1}
-                  onClick={() => {
-                    if (selectedDiscussionConversationId) {
-                      selectDiscussionConversation(null);
-                    } else {
-                      closeConversations();
-                    }
-                  }}
+                  onClick={closeConversations}
                 >
                   <X className='size-4' />
                 </Button>
@@ -2341,6 +3030,8 @@ export default function SdlcScreen(): ReactElement {
                       ) : null}
                     </section>
                   )}
+
+                  {section === 'tracks' && renderTrack()}
 
                   {section === 'baseline' && (
                     <section>
@@ -2462,7 +3153,6 @@ export default function SdlcScreen(): ReactElement {
                     ) : (
                       <EmptyCard text='Select an artifact type from the sidebar.' />
                     ))}
-                  {section === 'tracks' && renderTracks()}
                   {section === 'tickets' && repo.channelId && (
                     <div className='relative h-[calc(100vh-8rem)] min-h-[36rem]'>
                       <KanbanBoardScreen channelId={repo.channelId} />
@@ -2497,7 +3187,26 @@ export default function SdlcScreen(): ReactElement {
                       selectedConversationId={renderedConversationId}
                       onSelectConversation={selectDiscussionConversation}
                       onAskAI={openSdlcAssistant}
-                      headerActionsContainer={chatHeaderActionsEl}
+                      title={discussionOwner.title}
+                    />
+                  ) : activeFolderDiscussion && repo.channelId ? (
+                    <SdlcChatPanel
+                      key={`folder-${activeFolderDiscussion.id}`}
+                      channelId={repo.channelId}
+                      discussion={{
+                        repoId: repo.id,
+                        ownerType: 'FOLDER',
+                        ownerId: activeFolderDiscussion.id,
+                      }}
+                      conversationIds={folderConversationIds}
+                      selectedConversationId={renderedConversationId}
+                      onSelectConversation={selectDiscussionConversation}
+                      onAskAI={openSdlcAssistant}
+                      title={activeFolderDiscussion.name}
+                      scopeHeader={{
+                        name: activeFolderDiscussion.name,
+                        onExit: () => setFolderDiscussion(null),
+                      }}
                     />
                   ) : section === 'tracks' && selectedTrack && repo.channelId ? (
                     <SdlcChatPanel
@@ -2512,7 +3221,8 @@ export default function SdlcScreen(): ReactElement {
                       selectedConversationId={renderedConversationId}
                       onSelectConversation={selectDiscussionConversation}
                       onAskAI={openSdlcAssistant}
-                      headerActionsContainer={chatHeaderActionsEl}
+                      title={selectedTrack.name}
+                      renderConversationBadge={renderFolderConversationBadge}
                     />
                   ) : null}
                 </EntityLinkContext.Provider>
@@ -3057,6 +3767,196 @@ export default function SdlcScreen(): ReactElement {
             </Button>
           </div>
         </form>
+      </Dialog>
+
+      <Dialog
+        open={newFolderParent !== null}
+        onOpenChange={open => {
+          if (!open) {
+            setNewFolderParent(null);
+            setNewFolderName('');
+          }
+        }}
+        title='New folder'
+      >
+        <form
+          className='p-6'
+          onSubmit={event => {
+            event.preventDefault();
+            void call('sdlc-folder', createFolderAction, 'Folder created');
+          }}
+        >
+          <h2 className='text-lg font-semibold'>New folder</h2>
+          <p className='mt-1 text-sm text-muted-foreground'>
+            {newFolderParent?.type === 'TRACK'
+              ? `Groups artifacts at the top of ${newFolderParent.name}.`
+              : `Nested inside ${newFolderParent?.name ?? ''}.`}
+          </p>
+          <label htmlFor='sdlc-folder-name' className='mt-5 block text-sm font-medium'>
+            Name
+          </label>
+          <Input
+            id='sdlc-folder-name'
+            autoFocus
+            value={newFolderName}
+            onChange={event => setNewFolderName(event.target.value)}
+            className='mt-2 h-10'
+            placeholder='e.g. Hub split, Approved, Archive'
+            maxLength={TRACK_NAME_LIMIT}
+          />
+          <div className='mt-6 flex justify-end gap-2'>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => {
+                setNewFolderParent(null);
+                setNewFolderName('');
+              }}
+              data-track-category='SdlcHub'
+              data-track-name='NewFolderCancelled'
+            >
+              Cancel
+            </Button>
+            <Button
+              type='submit'
+              loading={busy === 'sdlc-folder'}
+              disabled={!newFolderName.trim()}
+              data-track-category='SdlcHub'
+              data-track-name='NewFolderCreated'
+            >
+              <Plus />
+              Create folder
+            </Button>
+          </div>
+        </form>
+      </Dialog>
+
+      {/* Reading an artifact without leaving the browser. Two thirds of the width,
+          so the columns stay visible and the reader is still a comfortable
+          measure. */}
+      {readerCanvasId && (
+        <div className='fixed inset-0 z-50 flex' role='dialog' aria-modal='true'>
+          <button
+            type='button'
+            aria-label='Close preview'
+            onClick={closeReader}
+            className={cn(
+              'flex-1 bg-black/50 backdrop-blur-sm duration-200',
+              readerClosing ? 'animate-out fade-out' : 'animate-in fade-in',
+            )}
+            data-track-category='SdlcHub'
+            data-track-name='ArtifactReaderDismissed'
+          />
+          <div
+            className={cn(
+              'flex h-full w-2/3 min-w-[520px] flex-col border-l border-border bg-background shadow-2xl duration-200 ease-out motion-reduce:animate-none',
+              readerClosing ? 'animate-out slide-out-to-right' : 'animate-in slide-in-from-right',
+            )}
+          >
+            <div className='flex h-[52px] shrink-0 items-center gap-2 border-b border-border px-4'>
+              <span className='min-w-0 flex-1 truncate text-[13px] font-semibold'>
+                {canvases.find(canvas => canvas.id === readerCanvasId)?.title ?? 'Artifact'}
+              </span>
+              {/* Icons: this bar sits directly above the canvas's own toolbar, and
+                  two worded buttons made the two rows compete. */}
+              <button
+                type='button'
+                onClick={event => {
+                  const id = readerCanvasId;
+                  closeReader();
+                  openCanvas(id, { event });
+                }}
+                title='Open in a new window'
+                aria-label='Open in a new window'
+                className='rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+                data-track-category='SdlcHub'
+                data-track-name='ArtifactReaderOpenedInWindow'
+              >
+                <ExternalLink className='size-4' />
+              </button>
+              <button
+                type='button'
+                onClick={() => {
+                  const id = readerCanvasId;
+                  closeReader();
+                  openCanvas(id);
+                }}
+                title='Open the artifact'
+                aria-label='Open the artifact'
+                className='rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+                data-track-category='SdlcHub'
+                data-track-name='ArtifactReaderOpened'
+              >
+                <Maximize2 className='size-4' />
+              </button>
+              <button
+                type='button'
+                onClick={closeReader}
+                aria-label='Close'
+                className='-mr-1 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+                data-track-category='SdlcHub'
+                data-track-name='ArtifactReaderClosed'
+              >
+                <X className='size-4' />
+              </button>
+            </div>
+            <div className='min-h-0 flex-1 overflow-hidden'>
+              <StableCanvasScreen
+                key={readerCanvasId}
+                canvasId={readerCanvasId}
+                showAskAiAction={false}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      <Dialog
+        open={newArtifactParent !== null}
+        onOpenChange={open => {
+          if (!open) setNewArtifactParent(null);
+        }}
+        title='New artifact'
+      >
+        <div className='p-6'>
+          <h2 className='text-lg font-semibold'>New artifact</h2>
+          <p className='mt-1 text-sm text-muted-foreground'>
+            {newArtifactParent?.type === 'FOLDER'
+              ? `Choose a type. It will be filed in ${newArtifactParent.name}.`
+              : 'Choose a type to create.'}
+          </p>
+          <div className='mt-4 space-y-1'>
+            {typeFolders.map(folder => (
+              <button
+                key={folder.id}
+                type='button'
+                onClick={() => {
+                  const parent = newArtifactParent;
+                  setNewArtifactParent(null);
+                  setPendingArtifactFolder(parent?.type === 'FOLDER' ? parent.id : null);
+                  if (selectedTrack) {
+                    clearArtifactDialogFields({
+                      track: { id: selectedTrack.id, name: selectedTrack.name },
+                    });
+                  }
+                  setArtifactDialog({ id: folder.id, name: folder.name });
+                }}
+                className='flex w-full items-center gap-2.5 rounded-lg border border-border px-3 py-2.5 text-left text-sm transition-colors hover:bg-muted'
+                data-track-category='SdlcHub'
+                data-track-name='NewArtifactTypeChosen'
+                data-track-metadata={JSON.stringify({ typeId: folder.id })}
+              >
+                <FileText className='size-4 shrink-0 text-muted-foreground' />
+                {folder.name}
+              </button>
+            ))}
+            {typeFolders.length === 0 && (
+              <p className='py-4 text-center text-sm text-muted-foreground'>
+                No artifact types yet.
+              </p>
+            )}
+          </div>
+        </div>
       </Dialog>
 
       <Dialog open={linkDialog} onOpenChange={setLinkDialog} title='Link context'>

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -82,7 +82,6 @@ import { Dialog } from '../../components/ui/Dialog/Dialog';
 import Input from '../../components/ui/Input';
 import Textarea from '../../components/ui/Textarea';
 import { Panel, ResizableGroup, Separator } from '../../components/ui/Resizable/Resizable';
-import {} from '../../components/ui/Select';
 import { v4 as uuidv4 } from 'uuid';
 import { useCachedQuery } from '../../hooks/useCachedQuery';
 import { useZero } from '../../hooks/useZero';
@@ -1446,6 +1445,9 @@ export default function SdlcScreen(): ReactElement {
   const resetArtifactDialog = (): void => {
     setArtifactDialog(null);
     clearArtifactDialogFields();
+    // Cancelling used to leave the folder behind, so the next artifact created
+    // anywhere on the page was silently filed into it.
+    setPendingArtifactFolder(null);
   };
 
   const relatedArtifactsForPayload = (): Array<{ canvasId: string; title: string }> =>
@@ -1497,16 +1499,17 @@ export default function SdlcScreen(): ReactElement {
         ...(relatedCanvasIds.length > 0 && { relatedCanvasIds }),
       },
     );
+    // Read before the reset clears it; the move below is what consumes it.
+    const fileIntoFolder = pendingArtifactFolder;
     resetArtifactDialog();
     const newCanvasId = response.data.artifact.canvasId;
     // Creation always files an artifact at the track's root, so one started from
     // inside a folder is moved there straight after.
-    if (pendingArtifactFolder && channel) {
+    if (fileIntoFolder && channel) {
       await moveItemAction(
         { type: 'CANVAS', id: newCanvasId },
-        { type: 'FOLDER', id: pendingArtifactFolder },
+        { type: 'FOLDER', id: fileIntoFolder },
       );
-      setPendingArtifactFolder(null);
     }
     setRelatedSourceId(null);
     // Same search as opening an artifact from the list, so a new artifact lands
@@ -1889,7 +1892,13 @@ export default function SdlcScreen(): ReactElement {
               {nameDraft === null ? (
                 <button
                   type='button'
-                  onClick={() => setNameDraft(selectedTrack.name)}
+                  onClick={() => {
+                    // Escape unmounts the input, and React fires no blur for an
+                    // unmounted element — so the guard is armed here rather than
+                    // cleared on the way out, where it would leak into this edit.
+                    nameAbandoned.current = false;
+                    setNameDraft(selectedTrack.name);
+                  }}
                   className='-mx-1 min-w-0 truncate rounded px-1 text-left text-[26px] font-bold leading-tight tracking-tight transition-colors hover:bg-muted/50'
                   title='Rename track'
                   data-track-category='SdlcHub'
@@ -2029,7 +2038,11 @@ export default function SdlcScreen(): ReactElement {
             {descriptionDraft === null ? (
               <button
                 type='button'
-                onClick={() => setDescriptionDraft(selectedTrack.description ?? '')}
+                onClick={() => {
+                  // Armed here for the same reason as the name editor above.
+                  descriptionAbandoned.current = false;
+                  setDescriptionDraft(selectedTrack.description ?? '');
+                }}
                 className='-mx-1 block max-w-[918px] rounded px-1 text-left text-[13.5px] leading-relaxed text-muted-foreground transition-colors hover:bg-muted/50'
                 data-track-category='SdlcHub'
                 data-track-name='TrackDescriptionEditOpened'

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -1506,10 +1506,7 @@ export default function SdlcScreen(): ReactElement {
     // Creation always files an artifact at the track's root, so one started from
     // inside a folder is moved there straight after.
     if (fileIntoFolder && channel) {
-      await moveItemAction(
-        { type: 'CANVAS', id: newCanvasId },
-        { type: 'FOLDER', id: fileIntoFolder },
-      );
+      await fileNewArtifactIntoFolder(newCanvasId, fileIntoFolder);
     }
     setRelatedSourceId(null);
     // Same search as opening an artifact from the list, so a new artifact lands
@@ -1788,6 +1785,29 @@ export default function SdlcScreen(): ReactElement {
     // The stored path carries names for the column headers, so a rename has to
     // reach it too or the breadcrumb keeps the old one until a reload.
     setFinderPath(finderPath.map(step => (step.id === folderId ? { ...step, name } : step)));
+  };
+
+  /**
+   * Filing a just-created artifact. It was created over HTTP, so its containment
+   * edge reaches the Zero client by replication — usually a moment after this
+   * runs, and moveSdlcItem refuses a move it cannot find an edge for. Waiting for
+   * the row beats reporting a failure the reader can do nothing about; only that
+   * one refusal is retried, since every other is a real answer.
+   */
+  const fileNewArtifactIntoFolder = async (canvasId: string, folderId: string): Promise<void> => {
+    const attempts = 10;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      try {
+        await moveItemAction({ type: 'CANVAS', id: canvasId }, { type: 'FOLDER', id: folderId });
+        return;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : '';
+        if (attempt === attempts || !message.includes('Item is not filed anywhere')) {
+          throw error;
+        }
+        await new Promise(resolve => setTimeout(resolve, 150));
+      }
+    }
   };
 
   const moveItemAction = async (

--- a/apps/dashboard/src/routes/SdlcScreen/sdlcChatPolicy.ts
+++ b/apps/dashboard/src/routes/SdlcScreen/sdlcChatPolicy.ts
@@ -1,5 +1,3 @@
-import type { SdlcEntityType, SdlcRelationType } from '@xyne/shared';
-
 export type SdlcChatTab = 'conversations' | 'ai';
 export type SdlcRightPanelMode = 'closed' | 'chat' | 'debugger';
 
@@ -97,14 +95,3 @@ export const shouldCloseInvalidSdlcConversationDeepLink = (input: {
   input.discussionOpen &&
   Boolean(input.selectedConversationId) &&
   !input.discussionContextResolved;
-
-export const shouldShowSdlcRelatedLink = (input: {
-  relationType: SdlcRelationType;
-  entityType: SdlcEntityType;
-  entityChannelId?: string | null;
-  repositoryChannelId?: string | null;
-}): boolean => {
-  if (input.relationType === 'DISCUSSION') return false;
-  if (input.entityType !== 'CONVERSATION') return true;
-  return Boolean(input.entityChannelId && input.entityChannelId !== input.repositoryChannelId);
-};

--- a/apps/dashboard/src/services/ticketService.ts
+++ b/apps/dashboard/src/services/ticketService.ts
@@ -15,7 +15,7 @@ export interface CreateTicketRequest {
   boardId?: string;
   sourceConversationId?: string;
   sourceMessageId?: string;
-  entityLinkContext?: { sourceType: 'CANVAS' | 'TRACK'; sourceId: string };
+  entityLinkContext?: { sourceType: 'CANVAS' | 'TRACK' | 'FOLDER'; sourceId: string };
 }
 
 export interface CreateTicketResponse {

--- a/apps/dashboard/src/utils/electronApp.ts
+++ b/apps/dashboard/src/utils/electronApp.ts
@@ -217,7 +217,10 @@ export interface CreateTicketPopoutDraft {
   tab?: string | null | undefined;
   sourceConversationId?: string | null | undefined;
   sourceMessageId?: string | null | undefined;
-  entityLinkContext?: { sourceType: 'CANVAS' | 'TRACK'; sourceId: string } | null | undefined;
+  entityLinkContext?:
+    | { sourceType: 'CANVAS' | 'TRACK' | 'FOLDER'; sourceId: string }
+    | null
+    | undefined;
   initialMessageId?: string | null | undefined;
   parentTicketId?: string | null | undefined;
   isFromSubTicket?: boolean | undefined;

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 import packageJson from './package.json';
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { createRequire } from 'module';
 
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'));
@@ -15,7 +15,7 @@ const ortDistDir = path.dirname(
   })
 );
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ command, mode }) => {
   // Vite puts .env values on import.meta.env, not process.env, so this file
   // cannot see them without loading explicitly. process.env last so a shell value
   // still wins and existing invocations are unchanged.
@@ -28,6 +28,16 @@ export default defineConfig(({ mode }) => {
   const appBasePath = env.VITE_APP_BASE_PATH || '/';
   const isSdlcSurface = env.VITE_XYNE_SURFACE === 'sdlc';
   const devPort = Number(env.VITE_DEV_PORT) || (isSdlcSurface ? 5175 : 5173);
+
+  // Dev only: resolve @xyne/shared to its TypeScript source rather than to the
+  // dist/ its exports map points at. Built output is a dependency Vite neither
+  // watches nor invalidates, so rebuilding the package changed nothing until the
+  // server was restarted — and with two dev servers, restarting one and not the
+  // other served two different versions of the same module. Source is inside the
+  // module graph, so an edit to the package is an HMR update like any other.
+  // Builds are untouched and keep resolving through the package's exports.
+  const sharedSrc = path.resolve(__dirname, '../../packages/shared/src');
+  const isDev = command === 'serve';
 
   // Dev only: the main server stands in for the edge, so the iframe is same-origin
   // exactly as in prod. No rewriting, mirroring the deployed setup.
@@ -62,6 +72,27 @@ export default defineConfig(({ mode }) => {
     ...(isSdlcSurface ? { cacheDir: 'node_modules/.vite-sdlc' } : {}),
     plugins: [
       react(),
+      // The package's own relative imports name built files ("./types.js"), which
+      // exist only as .ts in source. Rewrite those, and only those.
+      ...(isDev
+        ? [
+            {
+              name: 'xyne-shared-source-specifiers',
+              enforce: 'pre' as const,
+              resolveId(source: string, importer: string | undefined): string | null {
+                if (!importer || !source.startsWith('.') || !source.endsWith('.js')) {
+                  return null;
+                }
+                if (!importer.startsWith(sharedSrc)) return null;
+                const base = path.resolve(path.dirname(importer), source.slice(0, -3));
+                for (const candidate of [`${base}.ts`, `${base}.tsx`, `${base}/index.ts`]) {
+                  if (existsSync(candidate)) return candidate;
+                }
+                return null;
+              },
+            },
+          ]
+        : []),
       {
         name: 'version-file',
         // Emit version.json through Rollup so Vite writes it into the build's outDir itself.
@@ -174,6 +205,7 @@ export default defineConfig(({ mode }) => {
     },
     resolve: {
       alias: {
+        ...(isDev ? { '@xyne/shared': sharedSrc } : {}),
         '@': path.resolve(__dirname, './src'),
         '@/lib': path.resolve(__dirname, './src/shared/lib'),
         '@/components': path.resolve(__dirname, './src/shared/components'),

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -29,13 +29,6 @@ export default defineConfig(({ command, mode }) => {
   const isSdlcSurface = env.VITE_XYNE_SURFACE === 'sdlc';
   const devPort = Number(env.VITE_DEV_PORT) || (isSdlcSurface ? 5175 : 5173);
 
-  // Dev only: resolve @xyne/shared to its TypeScript source rather than to the
-  // dist/ its exports map points at. Built output is a dependency Vite neither
-  // watches nor invalidates, so rebuilding the package changed nothing until the
-  // server was restarted — and with two dev servers, restarting one and not the
-  // other served two different versions of the same module. Source is inside the
-  // module graph, so an edit to the package is an HMR update like any other.
-  // Builds are untouched and keep resolving through the package's exports.
   const sharedSrc = path.resolve(__dirname, '../../packages/shared/src');
   const isDev = command === 'serve';
 
@@ -72,8 +65,6 @@ export default defineConfig(({ command, mode }) => {
     ...(isSdlcSurface ? { cacheDir: 'node_modules/.vite-sdlc' } : {}),
     plugins: [
       react(),
-      // The package's own relative imports name built files ("./types.js"), which
-      // exist only as .ts in source. Rewrite those, and only those.
       ...(isDev
         ? [
             {

--- a/apps/electron/src/window/manager.ts
+++ b/apps/electron/src/window/manager.ts
@@ -206,18 +206,22 @@ function applyWindowPolicy(win: BrowserWindow): void {
 
       const currentAppUrl = new URL(config.FRONTEND_URL);
       const currentUrl = win.webContents.getURL();
-      const currentUrlObj = new URL(currentUrl || '');
+      // A window that has not loaded anything yet returns '', and new URL('')
+      // throws. That threw the whole handler into the catch below before it
+      // reached the external-link branch, so the first navigation of a brand new
+      // window — every standalone window the app opens — escaped that routing.
+      const currentUrlObj = currentUrl ? new URL(currentUrl) : null;
 
       // Allow in-app navigation (same origin as configured frontend or current page)
       if (
         navUrlObj.origin === currentAppUrl.origin ||
-        navUrlObj.origin === currentUrlObj.origin
+        navUrlObj.origin === currentUrlObj?.origin
       ) {
         return;
       }
 
       // Mirror the mTLS branch from setWindowOpenHandler
-      if (currentUrlObj.origin === config.MTLS_FRONTEND_URL) {
+      if (currentUrlObj?.origin === config.MTLS_FRONTEND_URL) {
         event.preventDefault();
         shell.openExternal(navUrl);
         notifyExternalOpen(navUrl);

--- a/apps/electron/src/window/manager.ts
+++ b/apps/electron/src/window/manager.ts
@@ -206,10 +206,6 @@ function applyWindowPolicy(win: BrowserWindow): void {
 
       const currentAppUrl = new URL(config.FRONTEND_URL);
       const currentUrl = win.webContents.getURL();
-      // A window that has not loaded anything yet returns '', and new URL('')
-      // throws. That threw the whole handler into the catch below before it
-      // reached the external-link branch, so the first navigation of a brand new
-      // window — every standalone window the app opens — escaped that routing.
       const currentUrlObj = currentUrl ? new URL(currentUrl) : null;
 
       // Allow in-app navigation (same origin as configured frontend or current page)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -44,6 +44,8 @@ export {
   parseSubTicketsMd,
   serializeSubTicketsMd,
   SUB_TICKETS_MD_LIMIT,
+} from './utils/activityMetadataParser';
+export type {
   TicketCardSummary,
   SubTicketsMdData,
 } from './utils/activityMetadataParser';

--- a/packages/shared/src/sdlc.ts
+++ b/packages/shared/src/sdlc.ts
@@ -117,6 +117,7 @@ export const SDLC_ENTITY_TYPES = [
   "REPOSITORY",
   "WORKFLOW_EXECUTION",
   "TRACK",
+  "FOLDER",
 ] as const;
 
 export const sdlcEntityTypeSchema = z.enum(SDLC_ENTITY_TYPES);
@@ -135,8 +136,47 @@ export const SDLC_MEMBERSHIP_RELATION = "REPOSITORY";
  */
 export const SDLC_TRACK_MEMBERSHIP_RELATION = "TRACK";
 
-/** Structure, not content. Every read of the content graph excludes these. */
+/**
+ * The parent -> child edge: a TRACK or FOLDER on the source side, the thing it
+ * holds on the target. Shares its name with track membership because a root-level
+ * item's containment edge *is* its track membership; nesting only changes which
+ * parent is on the source side.
+ */
+export const SDLC_CONTAINMENT_RELATION = "TRACK_ITEM";
+
+/**
+ * What the folder tree renders. Tickets ride the same relationType from a track
+ * but belong to their own section, so the tree filters rather than assuming
+ * everything a track holds is a tree node.
+ */
+export const SDLC_TREE_TARGET_TYPES = ["FOLDER", "CANVAS"] as const;
+
+/**
+ * A TRACK -> item edge kept alongside the containment edge, so "everything in
+ * this track" is one indexed lookup rather than a walk down the folder tree.
+ * Derived: written and removed with the item it mirrors, never on its own.
+ */
+export const SDLC_TRACK_FLAT_RELATION = "TRACK_ITEM_SECONDARY";
+
+/**
+ * Edges no user may write or delete through the generic link API. Derived or
+ * structural: the app maintains them with the thing they describe.
+ */
 export const SDLC_STRUCTURAL_RELATIONS = [
+  SDLC_MEMBERSHIP_RELATION,
+  SDLC_TRACK_MEMBERSHIP_RELATION,
+  SDLC_TRACK_FLAT_RELATION,
+] as const;
+
+/**
+ * Edges a hub's link graph leaves out: they place things in the hub rather than
+ * relate them, so readers of the graph would double-count them.
+ *
+ * Narrower than SDLC_STRUCTURAL_RELATIONS on purpose. The flat track edge is not
+ * user-writable, but the client does need to read it — excluding it here is what
+ * made a track's artifact count read zero.
+ */
+export const SDLC_HUB_GRAPH_EXCLUDED_RELATIONS = [
   SDLC_MEMBERSHIP_RELATION,
   SDLC_TRACK_MEMBERSHIP_RELATION,
 ] as const;
@@ -164,7 +204,7 @@ export type SdlcRelationType = z.infer<typeof sdlcRelationTypeSchema>;
 export const sdlcDiscussionSchema = z
   .object({
     repoId: z.string().min(1),
-    ownerType: z.enum(["CANVAS", "TRACK"]),
+    ownerType: z.enum(["CANVAS", "TRACK", "FOLDER"]),
     ownerId: z.string().min(1),
     surfaceType: z.enum(["CANVAS", "TICKET", "PULL_REQUEST"]).optional(),
     surfaceId: z.string().min(1).optional(),
@@ -184,13 +224,25 @@ export const sdlcDiscussionSchema = z
 export type SdlcDiscussion = z.infer<typeof sdlcDiscussionSchema>;
 
 export const entityLinkContextSchema = z.object({
-  sourceType: z.enum(["CANVAS", "TRACK"]),
+  sourceType: z.enum(["CANVAS", "TRACK", "FOLDER"]),
   sourceId: z.string().min(1),
   linkId: z.string().min(1),
+  /**
+   * A folder's conversation is filed on its track as well, so the track's list
+   * shows everything discussed anywhere inside it. The flat relation, not a
+   * second DISCUSSION row: DISCUSSION has to stay one per conversation or
+   * resolveInheritedOwner picks between owners arbitrarily.
+   */
+  trackRollUp: z
+    .object({ trackId: z.string().min(1), linkId: z.string().min(1) })
+    .optional(),
 });
 export type EntityLinkContextInput = z.infer<typeof entityLinkContextSchema>;
 
-export const entityLinkOwnerSchema = entityLinkContextSchema.omit({ linkId: true });
+export const entityLinkOwnerSchema = entityLinkContextSchema.omit({
+  linkId: true,
+  trackRollUp: true,
+});
 export type EntityLinkOwner = z.infer<typeof entityLinkOwnerSchema>;
 
 export const SDLC_TRACK_STATUSES = ["ACTIVE", "COMPLETED", "ARCHIVED"] as const;

--- a/packages/shared/src/zero/acl/core/query-acl-factory.ts
+++ b/packages/shared/src/zero/acl/core/query-acl-factory.ts
@@ -125,6 +125,7 @@ import {
   ViewAccessACL,
   StageApproversACL,
   SurfaceLinksACL,
+  SdlcFoldersACL,
   SurfaceNudgeCountsACL,
   SurfaceNudgesACL,
   ToolsACL,
@@ -283,6 +284,8 @@ export class QueryACLFactory {
         return new SdlcEntityLinksACL(ctx) as BaseQueryACL<TTable>;
       case 'sdlc_artifacts':
         return new SdlcArtifactsACL(ctx) as BaseQueryACL<TTable>;
+      case 'sdlc_folders':
+        return new SdlcFoldersACL(ctx) as BaseQueryACL<TTable>;
       case 'sdlc_tracks':
         return new SdlcTracksACL(ctx) as BaseQueryACL<TTable>;
       case 'saved_user_configurations':

--- a/packages/shared/src/zero/acl/tables/canvas-participants-acl.ts
+++ b/packages/shared/src/zero/acl/tables/canvas-participants-acl.ts
@@ -9,7 +9,7 @@ export class CanvasParticipantsACL extends BaseQueryACL<'canvas_participants'> {
   constructor(ctx: Context) {
     super(ctx, 'canvas_participants');
   }
-​
+
   canSelect<TReturn>(query: Query<'canvas_participants', Schema, TReturn>): Query<'canvas_participants', Schema, TReturn> {
     if (isGuestContext(this.ctx)) {
       return query.where(({ exists, cmp, or }) =>

--- a/packages/shared/src/zero/acl/tables/index.ts
+++ b/packages/shared/src/zero/acl/tables/index.ts
@@ -45,6 +45,7 @@ export { ReactionsACL } from './reactions-acl';
 export { ReposACL } from './repos-acl';
 export { SdlcEntityLinksACL } from './sdlc-entity-links-acl';
 export { SdlcArtifactsACL } from './sdlc-artifacts-acl';
+export * from './sdlc-folders-acl';
 export { SdlcTracksACL } from './sdlc-tracks-acl';
 export { RecurringCallParticipantsACL } from './recurring-call-participants-acl';
 export { RolesACL } from './roles-acl';

--- a/packages/shared/src/zero/acl/tables/sdlc-folders-acl.ts
+++ b/packages/shared/src/zero/acl/tables/sdlc-folders-acl.ts
@@ -1,0 +1,32 @@
+import type { Query } from '@rocicorp/zero';
+import type { Context, Schema } from '../../schema';
+import { BaseQueryACL } from '../core/base-acl';
+import { denyGuestSelect, isGuestContext } from '../core/guest-acl-utils';
+
+export class SdlcFoldersACL extends BaseQueryACL<'sdlc_folders'> {
+  constructor(ctx: Context) {
+    super(ctx, 'sdlc_folders');
+  }
+
+  canSelect<TReturn>(
+    query: Query<'sdlc_folders', Schema, TReturn>,
+  ): Query<'sdlc_folders', Schema, TReturn> {
+    if (isGuestContext(this.ctx)) {
+      return denyGuestSelect(query, 'id');
+    }
+
+    // A folder carries no scope column; the edge that places it in a track is
+    // what places it in a hub, so visibility follows that edge's channel — the
+    // same shape as SdlcTracksACL. Any edge will do: a folder always has exactly
+    // one containment edge, and it cannot be reached without it.
+    return query
+      .where('workspaceId', '=', this.ctx.workspaceId)
+      .whereExists('sdlcEntityLinks', (link) =>
+        link.whereExists('channel', (channel) =>
+          channel.whereExists('participants', (participant) =>
+            participant.where('userId', '=', this.ctx.userID),
+          ),
+        ),
+      );
+  }
+}

--- a/packages/shared/src/zero/acl/tables/sdlc-folders-acl.ts
+++ b/packages/shared/src/zero/acl/tables/sdlc-folders-acl.ts
@@ -15,10 +15,6 @@ export class SdlcFoldersACL extends BaseQueryACL<'sdlc_folders'> {
       return denyGuestSelect(query, 'id');
     }
 
-    // A folder carries no scope column; the edge that places it in a track is
-    // what places it in a hub, so visibility follows that edge's channel — the
-    // same shape as SdlcTracksACL. Any edge will do: a folder always has exactly
-    // one containment edge, and it cannot be reached without it.
     return query
       .where('workspaceId', '=', this.ctx.workspaceId)
       .whereExists('sdlcEntityLinks', (link) =>

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -90,7 +90,9 @@ import {
 import { resolveCanvasHierarchy } from '../utils/canvasHierarchy.js';
 import {
   SDLC_MEMBERSHIP_RELATION,
+  SDLC_CONTAINMENT_RELATION,
   SDLC_STRUCTURAL_RELATIONS,
+  SDLC_TRACK_FLAT_RELATION,
   SDLC_TRACK_MEMBERSHIP_RELATION,
   createSdlcLinkSchema,
   entityLinkContextSchema,
@@ -1879,6 +1881,22 @@ export const mutators = defineMutators({
             createdBy: ctx.userID,
             createdAt: now,
           });
+          // A folder's discussion is filed on its track too, so the track's
+          // conversation list is everything discussed anywhere inside it.
+          if (entityLinkContext.trackRollUp) {
+            await tx.mutate.sdlc_entity_links.insert({
+              id: entityLinkContext.trackRollUp.linkId,
+              workspaceId: ctx.workspaceId,
+              channelId,
+              sourceType: 'TRACK',
+              sourceId: entityLinkContext.trackRollUp.trackId,
+              targetType: 'CONVERSATION',
+              targetId: conversationId,
+              relationType: SDLC_TRACK_FLAT_RELATION,
+              createdBy: ctx.userID,
+              createdAt: now,
+            });
+          }
         }
 
         await tx.mutate.messages.insert({
@@ -8142,6 +8160,190 @@ export const mutators = defineMutators({
           throw new Error('Structural SDLC edges are not deleted through the link API');
         }
         await tx.mutate.sdlc_entity_links.delete({ id: linkId });
+      },
+    ),
+
+    /**
+     * A folder, and the two edges that place it.
+     *
+     * The containment edge is the tree: its source is the parent, a TRACK at the
+     * root or a FOLDER below it. The flat edge always points from the track, so
+     * "everything in this track" stays one indexed lookup however deep the
+     * folder sits. Both are written here so the pair cannot drift.
+     */
+    /**
+     * Move an item to another parent inside the same track.
+     *
+     * A move is a delete and an insert, never an update: entity links are
+     * immutable by ACL. Both happen here so an item cannot end up with two
+     * parents or none. The flat track edge is untouched — the item stays in the
+     * same track, which is the whole point of keeping that edge separate.
+     */
+    /** Rename a folder. Its placement and contents are untouched. */
+    renameSdlcFolder: defineMutator(
+      z.object({
+        folderId: z.string(),
+        channelId: z.string(),
+        name: z.string().trim().min(1).max(120),
+        timestamp: z.number(),
+      }),
+      async ({ tx, ctx, args }) => {
+        const participant = await tx.run(
+          zql.channel_participants
+            .where('channelId', args.channelId)
+            .where('userId', ctx.userID)
+            .one(),
+        );
+        if (!participant) {
+          throw new Error('Hub membership required');
+        }
+        const folder = await tx.run(zql.sdlc_folders.where('id', args.folderId).one());
+        if (!folder) {
+          throw new Error('Folder not found');
+        }
+        await tx.mutate.sdlc_folders.update({
+          id: args.folderId,
+          name: args.name,
+          updatedAt: args.timestamp,
+        });
+      },
+    ),
+
+    moveSdlcItem: defineMutator(
+      z.object({
+        linkId: z.string(),
+        channelId: z.string(),
+        itemType: z.enum(['FOLDER', 'CANVAS']),
+        itemId: z.string(),
+        parentType: z.enum(['TRACK', 'FOLDER']),
+        parentId: z.string(),
+        timestamp: z.number(),
+      }),
+      async ({ tx, ctx, args }) => {
+        const participant = await tx.run(
+          zql.channel_participants
+            .where('channelId', args.channelId)
+            .where('userId', ctx.userID)
+            .one(),
+        );
+        if (!participant) {
+          throw new Error('Hub membership required');
+        }
+        if (args.itemType === 'FOLDER' && args.itemId === args.parentId) {
+          throw new Error('A folder cannot contain itself');
+        }
+        const existing = await tx.run(
+          zql.sdlc_entity_links
+            .where('channelId', args.channelId)
+            .where('relationType', SDLC_CONTAINMENT_RELATION)
+            .where('targetType', args.itemType)
+            .where('targetId', args.itemId)
+            .one(),
+        );
+        if (!existing) {
+          throw new Error('Item is not filed anywhere');
+        }
+        if (existing.sourceId === args.parentId) {
+          return;
+        }
+        // Walk up from the new parent: dropping a folder inside its own subtree
+        // would detach that subtree from the track with nothing pointing at it.
+        if (args.itemType === 'FOLDER') {
+          let cursor: string | null = args.parentType === 'FOLDER' ? args.parentId : null;
+          for (let depth = 0; cursor && depth < 64; depth += 1) {
+            if (cursor === args.itemId) {
+              throw new Error('A folder cannot be moved inside itself');
+            }
+            const parentEdge = await tx.run(
+              zql.sdlc_entity_links
+                .where('channelId', args.channelId)
+                .where('relationType', SDLC_CONTAINMENT_RELATION)
+                .where('targetType', 'FOLDER')
+                .where('targetId', cursor)
+                .one(),
+            );
+            cursor = parentEdge?.sourceType === 'FOLDER' ? parentEdge.sourceId : null;
+          }
+        }
+        await tx.mutate.sdlc_entity_links.delete({ id: existing.id });
+        await tx.mutate.sdlc_entity_links.insert({
+          id: args.linkId,
+          workspaceId: ctx.workspaceId,
+          channelId: args.channelId,
+          sourceType: args.parentType,
+          sourceId: args.parentId,
+          targetType: args.itemType,
+          targetId: args.itemId,
+          relationType: SDLC_CONTAINMENT_RELATION,
+          createdBy: ctx.userID,
+          createdAt: args.timestamp,
+        });
+      },
+    ),
+
+    createSdlcFolder: defineMutator(
+      z.object({
+        id: z.string(),
+        containmentLinkId: z.string(),
+        flatLinkId: z.string(),
+        channelId: z.string(),
+        trackId: z.string(),
+        parentType: z.enum(['TRACK', 'FOLDER']),
+        parentId: z.string(),
+        name: z.string().trim().min(1).max(120),
+        timestamp: z.number(),
+      }),
+      async ({ tx, ctx, args }) => {
+        const participant = await tx.run(
+          zql.channel_participants
+            .where('channelId', args.channelId)
+            .where('userId', ctx.userID)
+            .one(),
+        );
+        if (!participant) {
+          throw new Error('Hub membership required');
+        }
+        // A folder nests under a folder in the same track, never a stray id.
+        if (args.parentType === 'FOLDER') {
+          const parent = await tx.run(zql.sdlc_folders.where('id', args.parentId).one());
+          if (!parent) {
+            throw new Error('Parent folder not found');
+          }
+        } else if (args.parentId !== args.trackId) {
+          throw new Error('A root folder belongs to the track it is created in');
+        }
+        await tx.mutate.sdlc_folders.insert({
+          id: args.id,
+          workspaceId: ctx.workspaceId,
+          name: args.name,
+          createdBy: ctx.userID,
+          createdAt: args.timestamp,
+          updatedAt: args.timestamp,
+        });
+        await tx.mutate.sdlc_entity_links.insert({
+          id: args.containmentLinkId,
+          workspaceId: ctx.workspaceId,
+          channelId: args.channelId,
+          sourceType: args.parentType,
+          sourceId: args.parentId,
+          targetType: 'FOLDER',
+          targetId: args.id,
+          relationType: SDLC_CONTAINMENT_RELATION,
+          createdBy: ctx.userID,
+          createdAt: args.timestamp,
+        });
+        await tx.mutate.sdlc_entity_links.insert({
+          id: args.flatLinkId,
+          workspaceId: ctx.workspaceId,
+          channelId: args.channelId,
+          sourceType: 'TRACK',
+          sourceId: args.trackId,
+          targetType: 'FOLDER',
+          targetId: args.id,
+          relationType: SDLC_TRACK_FLAT_RELATION,
+          createdBy: ctx.userID,
+          createdAt: args.timestamp,
+        });
       },
     ),
 

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -1881,8 +1881,6 @@ export const mutators = defineMutators({
             createdBy: ctx.userID,
             createdAt: now,
           });
-          // A folder's discussion is filed on its track too, so the track's
-          // conversation list is everything discussed anywhere inside it.
           if (entityLinkContext.trackRollUp) {
             await tx.mutate.sdlc_entity_links.insert({
               id: entityLinkContext.trackRollUp.linkId,
@@ -8197,10 +8195,6 @@ export const mutators = defineMutators({
         if (!participant) {
           throw new Error('Hub membership required');
         }
-        // Membership was checked against the channelId the caller sent, so the
-        // folder has to actually be in that hub — its flat placement edge is what
-        // says which one. Without this, being in any hub let you rename a folder
-        // in any other.
         const placement = await tx.run(
           zql.sdlc_entity_links
             .where('channelId', args.channelId)
@@ -8244,10 +8238,6 @@ export const mutators = defineMutators({
         if (args.itemType === 'FOLDER' && args.itemId === args.parentId) {
           throw new Error('A folder cannot contain itself');
         }
-        // Containment moves; the flat edge does not. So the destination has to be
-        // in the same track, or the two would disagree about where the item lives
-        // and the finder would show it under a tree its track edge never names.
-        // Resolving the parent's track also proves the parent exists in this hub.
         const parentTrackId =
           args.parentType === 'TRACK'
             ? args.parentId
@@ -8291,8 +8281,6 @@ export const mutators = defineMutators({
         if (existing.sourceId === args.parentId) {
           return;
         }
-        // Walk up from the new parent: dropping a folder inside its own subtree
-        // would detach that subtree from the track with nothing pointing at it.
         if (args.itemType === 'FOLDER') {
           let cursor: string | null = args.parentType === 'FOLDER' ? args.parentId : null;
           for (let depth = 0; cursor && depth < 64; depth += 1) {
@@ -8348,11 +8336,6 @@ export const mutators = defineMutators({
         if (!participant) {
           throw new Error('Hub membership required');
         }
-        // A folder nests under a folder in the same track, never a stray id.
-        // The track has to be one of this hub's. Its placement edge is the only
-        // thing that says so — sdlc_tracks carries no scope column — and without
-        // this the flat edge below could name a track in another hub, which
-        // resolveFolderTrackId would then report for every downstream decision.
         const trackEdge = await tx.run(
           zql.sdlc_entity_links
             .where('channelId', args.channelId)
@@ -8365,8 +8348,6 @@ export const mutators = defineMutators({
           throw new Error('Track not found in this hub');
         }
         if (args.parentType === 'FOLDER') {
-          // Existence is not enough: a parent from another track would put the
-          // folder in a tree its own flat edge never mentions.
           const parentTrack = await tx.run(
             zql.sdlc_entity_links
               .where('channelId', args.channelId)

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -8197,9 +8197,21 @@ export const mutators = defineMutators({
         if (!participant) {
           throw new Error('Hub membership required');
         }
-        const folder = await tx.run(zql.sdlc_folders.where('id', args.folderId).one());
-        if (!folder) {
-          throw new Error('Folder not found');
+        // Membership was checked against the channelId the caller sent, so the
+        // folder has to actually be in that hub — its flat placement edge is what
+        // says which one. Without this, being in any hub let you rename a folder
+        // in any other.
+        const placement = await tx.run(
+          zql.sdlc_entity_links
+            .where('channelId', args.channelId)
+            .where('sourceType', 'TRACK')
+            .where('targetType', 'FOLDER')
+            .where('targetId', args.folderId)
+            .where('relationType', SDLC_TRACK_FLAT_RELATION)
+            .one(),
+        );
+        if (!placement) {
+          throw new Error('Folder not found in this hub');
         }
         await tx.mutate.sdlc_folders.update({
           id: args.folderId,
@@ -8231,6 +8243,39 @@ export const mutators = defineMutators({
         }
         if (args.itemType === 'FOLDER' && args.itemId === args.parentId) {
           throw new Error('A folder cannot contain itself');
+        }
+        // Containment moves; the flat edge does not. So the destination has to be
+        // in the same track, or the two would disagree about where the item lives
+        // and the finder would show it under a tree its track edge never names.
+        // Resolving the parent's track also proves the parent exists in this hub.
+        const parentTrackId =
+          args.parentType === 'TRACK'
+            ? args.parentId
+            : ((
+                await tx.run(
+                  zql.sdlc_entity_links
+                    .where('channelId', args.channelId)
+                    .where('sourceType', 'TRACK')
+                    .where('targetType', 'FOLDER')
+                    .where('targetId', args.parentId)
+                    .where('relationType', SDLC_TRACK_FLAT_RELATION)
+                    .one(),
+                )
+              )?.sourceId ?? null);
+        if (!parentTrackId) {
+          throw new Error('Destination folder not found in this hub');
+        }
+        const itemTrackEdge = await tx.run(
+          zql.sdlc_entity_links
+            .where('channelId', args.channelId)
+            .where('sourceType', 'TRACK')
+            .where('targetType', args.itemType)
+            .where('targetId', args.itemId)
+            .where('relationType', SDLC_TRACK_FLAT_RELATION)
+            .one(),
+        );
+        if (!itemTrackEdge || itemTrackEdge.sourceId !== parentTrackId) {
+          throw new Error('An item can only be moved within its own track');
         }
         const existing = await tx.run(
           zql.sdlc_entity_links
@@ -8304,10 +8349,35 @@ export const mutators = defineMutators({
           throw new Error('Hub membership required');
         }
         // A folder nests under a folder in the same track, never a stray id.
+        // The track has to be one of this hub's. Its placement edge is the only
+        // thing that says so — sdlc_tracks carries no scope column — and without
+        // this the flat edge below could name a track in another hub, which
+        // resolveFolderTrackId would then report for every downstream decision.
+        const trackEdge = await tx.run(
+          zql.sdlc_entity_links
+            .where('channelId', args.channelId)
+            .where('targetType', 'TRACK')
+            .where('targetId', args.trackId)
+            .where('relationType', SDLC_TRACK_MEMBERSHIP_RELATION)
+            .one(),
+        );
+        if (!trackEdge) {
+          throw new Error('Track not found in this hub');
+        }
         if (args.parentType === 'FOLDER') {
-          const parent = await tx.run(zql.sdlc_folders.where('id', args.parentId).one());
-          if (!parent) {
-            throw new Error('Parent folder not found');
+          // Existence is not enough: a parent from another track would put the
+          // folder in a tree its own flat edge never mentions.
+          const parentTrack = await tx.run(
+            zql.sdlc_entity_links
+              .where('channelId', args.channelId)
+              .where('sourceType', 'TRACK')
+              .where('targetType', 'FOLDER')
+              .where('targetId', args.parentId)
+              .where('relationType', SDLC_TRACK_FLAT_RELATION)
+              .one(),
+          );
+          if (!parentTrack || parentTrack.sourceId !== args.trackId) {
+            throw new Error('Parent folder belongs to another track');
           }
         } else if (args.parentId !== args.trackId) {
           throw new Error('A root folder belongs to the track it is created in');

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -3994,17 +3994,6 @@ export const queries = defineQueries({
         .related('ticket');
     },
   ),
-  sdlcRelatedConversations: defineQuery(
-    z.object({ conversationIds: z.array(z.string()) }),
-    ({ args: { conversationIds } }) =>
-      zql.conversations.where(helpers =>
-        helpers.cmp(
-          'conversationId',
-          'IN',
-          conversationIds.length > 0 ? conversationIds : ['__no_sdlc_related_conversation__'],
-        ),
-      ),
-  ),
   getAllForms: defineQuery(() => {
     return zql.forms
       .related('formFields', q => q.related('globalField'))

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -18,7 +18,11 @@ import {
 import { z } from 'zod';
 import {
   SDLC_MEMBERSHIP_RELATION,
+  SDLC_CONTAINMENT_RELATION,
+  SDLC_HUB_GRAPH_EXCLUDED_RELATIONS,
   SDLC_STRUCTURAL_RELATIONS,
+  SDLC_TREE_TARGET_TYPES,
+  SDLC_TRACK_FLAT_RELATION,
   SDLC_TRACK_MEMBERSHIP_RELATION,
 } from '../sdlc';
 import {
@@ -3795,7 +3799,47 @@ export const queries = defineQueries({
       )
       .one(),
   ),
+  /**
+   * One level of a track's folder tree: the things directly inside `parentId`.
+   *
+   * Containment is an edge, so this is the same query at every depth — only the
+   * parent changes, from the TRACK at the root to a FOLDER below it. Covered by
+   * the (sourceType, sourceId, relationType) index.
+   *
+   * The entities themselves are fetched separately by id: sourceId and targetId
+   * are polymorphic, so no relation covers them. The targetType filter keeps the
+   * tree to things it can render — TRACK -> TICKET edges share this relationType
+   * and are not part of the folder tree.
+   */
+  getSdlcFolderChildren: defineQuery(
+    z.object({
+      channelId: z.string(),
+      parentType: z.enum(['TRACK', 'FOLDER']),
+      parentId: z.string(),
+    }),
+    ({ args: { channelId, parentType, parentId } }) =>
+      zql.sdlc_entity_links
+        .where('channelId', channelId)
+        .where('relationType', SDLC_CONTAINMENT_RELATION)
+        .where('sourceType', parentType)
+        .where('sourceId', parentId)
+        .where(helpers => helpers.cmp('targetType', 'IN', [...SDLC_TREE_TARGET_TYPES]))
+        .orderBy('createdAt', 'asc'),
+  ),
   /** A hub's tracks. Tracks carry no scope column; the CHANNEL -> TRACK edge places them. */
+  /**
+   * Every folder in a hub, in one subscription. Folders carry no scope column,
+   * so the flat TRACK -> FOLDER edge places them — the same shape getSdlcTracks
+   * uses. One query for the hub beats one per open finder column, and it is what
+   * lets a conversation say which folder it belongs to without a second fetch.
+   */
+  getSdlcFoldersByChannel: defineQuery(
+    z.object({ channelId: z.string() }),
+    ({ args: { channelId } }) =>
+      zql.sdlc_folders.whereExists('sdlcEntityLinks', link =>
+        link.where('channelId', channelId).where('relationType', SDLC_TRACK_FLAT_RELATION),
+      ),
+  ),
   getSdlcTracks: defineQuery(z.object({ channelId: z.string() }), ({ args: { channelId } }) =>
     zql.sdlc_tracks
       .whereExists('sdlcEntityLinks', link =>
@@ -3820,7 +3864,20 @@ export const queries = defineQueries({
   getSdlcLinks: defineQuery(z.object({ channelId: z.string() }), ({ args: { channelId } }) =>
     zql.sdlc_entity_links
       .where('channelId', channelId)
-      .where(helpers => helpers.cmp('relationType', 'NOT IN', [...SDLC_STRUCTURAL_RELATIONS]))
+      .where(helpers =>
+        helpers.cmp('relationType', 'NOT IN', [...SDLC_HUB_GRAPH_EXCLUDED_RELATIONS]),
+      )
+      // The flat edge is worth syncing for artifacts and conversations, which
+      // readers here resolve back to a track. Its FOLDER rows are the largest
+      // group in the graph and no reader touches them — the finder gets folders
+      // from getSdlcFoldersByChannel, which matches this edge server-side. Cut by
+      // target rather than by a whitelist, so a new flat target still arrives.
+      .where(helpers =>
+        helpers.or(
+          helpers.cmp('relationType', '!=', SDLC_TRACK_FLAT_RELATION),
+          helpers.cmp('targetType', '!=', 'FOLDER'),
+        ),
+      )
       .orderBy('createdAt', 'asc'),
   ),
   sdlcTicketsByIds: defineQuery(

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -3867,11 +3867,6 @@ export const queries = defineQueries({
       .where(helpers =>
         helpers.cmp('relationType', 'NOT IN', [...SDLC_HUB_GRAPH_EXCLUDED_RELATIONS]),
       )
-      // The flat edge is worth syncing for artifacts and conversations, which
-      // readers here resolve back to a track. Its FOLDER rows are the largest
-      // group in the graph and no reader touches them — the finder gets folders
-      // from getSdlcFoldersByChannel, which matches this edge server-side. Cut by
-      // target rather than by a whitelist, so a new flat target still arrives.
       .where(helpers =>
         helpers.or(
           helpers.cmp('relationType', '!=', SDLC_TRACK_FLAT_RELATION),

--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -1514,6 +1514,17 @@ export const sdlcArtifactTable = table('sdlc_artifacts')
   .primaryKey('artifactId');
 
 // Tracks carry no scope column: the CHANNEL -> TRACK edge in sdlc_entity_links places them.
+export const sdlcFolderTable = table('sdlc_folders')
+  .columns({
+    workspaceId: string(),
+    id: string(),
+    name: string(),
+    createdBy: string(),
+    createdAt: number(),
+    updatedAt: number(),
+  })
+  .primaryKey('id');
+
 export const sdlcTrackTable = table('sdlc_tracks')
   .columns({
     workspaceId: string(),
@@ -3454,6 +3465,15 @@ export const sdlcArtifactTableRelationships = relationships(sdlcArtifactTable, (
   }),
 }));
 
+export const sdlcFolderTableRelationships = relationships(sdlcFolderTable, ({ many }) => ({
+  // Edges pointing here. targetId is polymorphic, so readers filter by relationType.
+  sdlcEntityLinks: many({
+    sourceField: ['id'],
+    destField: ['targetId'],
+    destSchema: sdlcEntityLinkTable,
+  }),
+}));
+
 export const sdlcTrackTableRelationships = relationships(sdlcTrackTable, ({ many }) => ({
   // Edges pointing here. targetId is polymorphic, so readers filter by relationType.
   sdlcEntityLinks: many({
@@ -4858,6 +4878,7 @@ export const schema = createSchema({
     repoTable,
     sdlcEntityLinkTable,
     sdlcArtifactTable,
+    sdlcFolderTable,
     sdlcTrackTable,
     emailTable,
     emailDraftTable,
@@ -4958,6 +4979,7 @@ export const schema = createSchema({
     repoTableRelationships,
     sdlcEntityLinkTableRelationships,
     sdlcArtifactTableRelationships,
+    sdlcFolderTableRelationships,
     sdlcTrackTableRelationships,
     messageTableRelationships,
     messageArtifactTableRelationships,
@@ -5130,6 +5152,7 @@ export type Email = Row<typeof schema.tables.emails>;
 export type Repo = Row<typeof schema.tables.repos>;
 export type SdlcEntityLink = Row<typeof schema.tables.sdlc_entity_links>;
 export type SdlcArtifact = Row<typeof schema.tables.sdlc_artifacts>;
+export type SdlcFolder = Row<typeof schema.tables.sdlc_folders>;
 export type SdlcTrack = Row<typeof schema.tables.sdlc_tracks>;
 export type EmailDraft = Row<typeof schema.tables.email_drafts>;
 export type ConversationLabel = Row<typeof schema.tables.conversation_labels>;

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -13,6 +13,7 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
+    "isolatedModules": true,
     "sourceMap": true,
     "types": ["node", "react", "uuid"]
   },


### PR DESCRIPTION
## What

A Finder-style folder browser on the track page, and conversations that can belong to a folder rather than only to a track or an artifact.

## How placement works

`sdlc_folders` carries a name and nothing else. Where a folder sits — a track's root or inside another folder — is a `TRACK|FOLDER -> FOLDER|CANVAS` edge in `sdlc_entity_links`, the same arrangement `sdlc_tracks` already uses via its `CHANNEL -> TRACK` edge. Keeping placement in the edge rather than in columns leaves nesting and the set of things a folder can hold open, and makes one query serve every level of the tree.

Every track item also gets a flat `TRACK -> item` edge. Once an item is filed into a folder its containment edge points at the folder, so "everything in this track" would otherwise find nothing — ticket creation resolves a track through this edge, and without it a ticket raised from a nested artifact loses its track.

**Requires a data migration on existing rows** (see below).

## Folder conversations

Two edges per conversation:

- `FOLDER -> CONVERSATION` (`DISCUSSION`) — the owner
- `TRACK -> CONVERSATION` (`TRACK_ITEM_SECONDARY`) — so the track's list stays complete

The flat relation rather than a second `DISCUSSION` row: `resolveInheritedOwner` picks the single `DISCUSSION` edge, and two would make the owner arbitrary. The server validates a folder owner through its flat edge and rejects a roll-up naming any track but that folder's own.

`sdlcNavTarget.conversationLocation` gains a `FOLDER` branch — without it a mention in a folder conversation resolves to nothing and the notification navigates nowhere.

## Panel changes

The chat panel draws its own sticky bar and hosts the thread's overflow menu, so opening a conversation no longer changes the page header. Threads with no ticket get the tabbed layout too, which lands as Messages and Files.

## Dev tooling

`@xyne/shared` resolves to source rather than `dist` **in dev only** — editing the package becomes an HMR update instead of a rebuild plus a restart of two Vite servers. Builds still resolve through the package exports, unchanged.

That surfaced two latent defects this fixes: a zero-width space in `canvas-participants-acl.ts` that `tsc` accepted and esbuild would not parse, and two type re-exports in a value export list. `isolatedModules` is now on for the package so neither can return.

## Migration

One migration in this PR: `20260909120000_sdlc_folders` — `CREATE TABLE` plus a `workspaceId` index. Additive, no backfill.

**A separate data migration must run on existing rows**, deliberately kept out of this PR and run on the backend. It writes the flat `TRACK -> item` edge for every existing `TRACK -> CANVAS|FOLDER` / `TRACK_ITEM` edge. It is idempotent and safe to run ahead of the deploy, since nothing reads that relation until this lands.

Without it, `linkCreatedEntities` finds no flat edge for pre-existing artifacts and silently skips the `TRACK -> TICKET` row — so tickets raised from any artifact that exists today would not appear in their track's list. This is not limited to artifacts that get moved into folders.

## Verification

Run against this branch with the local DB migrated to its schema:

- finder renders, folder conversations open in the right panel, roll-up appears in the track's list with a folder marker that navigates back to that folder
- both edges confirmed in the database on send
- ticket-bearing thread shows Messages / Details / Files; ticket-less shows Messages / Files
- page header identical across list, folder and thread states

Green: dashboard typecheck + lint + build, backend typecheck + build, gitleaks, workspaceId guard, Zero/Prisma column parity, schema-migration validation, enum guard.

cmd+click into a standalone window verified in a dev Electron build against this branch — a new window opens and renders the artifact. (`shouldOpenInNewWindow` is gated on `isElectronApp()`, so no browser test can reach it.)

## Note for review

This is the `release-20260909` port. The original work was authored on the `release-20260904` line, and XYNE-61736 has since moved SDLC deep-link resolution to the server. The client-side re-navigation this branch inherited (`ticketDiscussion`, `canvasSectionFix`, `deepLinkedTrackId`) is dropped here rather than reinstated, and the removed `?ticket=` drawer is not brought back — the track ticket list reads the ticket from the conversation row, so its behaviour is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPBJtAza2gBg54qfRDv3t7
