### PR TITLE
feat: XYNE-62988 filter activity by a specific user or agent

### DIFF
--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -3096,8 +3096,9 @@ export const queries: AnyQueryRegistry = defineQueries({
       classification: z.array(z.nativeEnum(ActivityClassification)).optional(),
       isRead: z.boolean().optional(),
       actorTypes: z.array(z.nativeEnum(UserType)).optional(),
+      actorId: z.string().optional(),
     }),
-    ({ args: { limit, start, types, classification, isRead, actorTypes } }) => {
+    ({ args: { limit, start, types, classification, isRead, actorTypes, actorId } }) => {
       let query = zql.activities;
 
       if (types.length > 0) {
@@ -3120,7 +3121,9 @@ export const queries: AnyQueryRegistry = defineQueries({
       // reach through the `actor` relationship. Must stay in step with the client
       // definition in packages/shared/src/zero/queries.ts — this is the copy the
       // server actually executes via handleQueryRequest.
-      if (actorTypes && actorTypes.length > 0) {
+      if (actorId) {
+        query = query.where('actorId', actorId);
+      } else if (actorTypes && actorTypes.length > 0) {
         query = query.whereExists('actor', (actor: any) =>
           actor.where('userType', 'IN', actorTypes)
         );

--- a/apps/dashboard/src/components/Activity/ActivityActorPicker.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityActorPicker.tsx
@@ -1,0 +1,136 @@
+import { ReactElement, ReactNode, useCallback, useMemo, useState } from 'react';
+import { UserType } from '@xyne/shared';
+import { CheckTickSingle, SearchDefault, UserUser02 } from '@xyne/icons';
+import { Popover } from '../ui/Popover/Popover';
+import Avatar from '../ui/Avatar/Avatar';
+import { useActiveUsers } from '../../hooks/useUsers';
+import { getUserDisplayName, matchesUserQuery } from '../../utils/userDisplayName';
+import { cn } from '../../utils/classNames';
+
+interface ActivityActorPickerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  userTypes: UserType[];
+  selectedUserId: string | null;
+  onSelect: (userId: string | null) => void;
+  anyoneLabel: string;
+  searchPlaceholder: string;
+  trigger: ReactNode;
+}
+
+const ROW_CLASS =
+  'flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-sm text-foreground transition-colors hover:bg-foreground/[6%] focus-visible:outline-none focus-visible:bg-foreground/[6%]';
+
+export const ActivityActorPicker = ({
+  open,
+  onOpenChange,
+  userTypes,
+  selectedUserId,
+  onSelect,
+  anyoneLabel,
+  searchPlaceholder,
+  trigger,
+}: ActivityActorPickerProps): ReactElement => {
+  const [query, setQuery] = useState('');
+  const users = useActiveUsers();
+
+  const candidates = useMemo(
+    () =>
+      users
+        .filter(user => userTypes.includes(user.userType))
+        .filter(user => matchesUserQuery(user, query))
+        .sort((a, b) => getUserDisplayName(a).localeCompare(getUserDisplayName(b))),
+    [users, userTypes, query],
+  );
+
+  const handleOpenChange = useCallback(
+    (next: boolean): void => {
+      if (!next) setQuery('');
+      onOpenChange(next);
+    },
+    [onOpenChange],
+  );
+
+  const handleSelect = useCallback(
+    (userId: string | null): void => {
+      onSelect(userId);
+      handleOpenChange(false);
+    },
+    [onSelect, handleOpenChange],
+  );
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={handleOpenChange}
+      trigger={trigger}
+      side='bottom'
+      align='start'
+      sideOffset={6}
+      className='w-[300px] rounded-xl border-border p-1.5 shadow-lg'
+    >
+      <div className='flex items-center gap-2 rounded-lg bg-foreground/[6%] px-2.5 py-2'>
+        <SearchDefault size={14} className='shrink-0 text-muted-foreground' />
+        <input
+          value={query}
+          onChange={event => setQuery(event.target.value)}
+          placeholder={searchPlaceholder}
+          aria-label={searchPlaceholder}
+          className='min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground'
+          data-track-category='ACTIVITY'
+          data-track-name='ACTOR_FILTER_SEARCH'
+          data-testid='activity-actor-picker-search'
+        />
+      </div>
+
+      <div className='mt-1 max-h-[280px] overflow-y-auto'>
+        <button
+          type='button'
+          onClick={() => handleSelect(null)}
+          className={ROW_CLASS}
+          data-track-category='ACTIVITY'
+          data-track-name='ACTOR_FILTER_PICK'
+          data-track-metadata={JSON.stringify({ actor_id: null })}
+          data-testid='activity-actor-picker-anyone'
+        >
+          <span className='flex size-[30px] shrink-0 items-center justify-center rounded-full border border-dashed border-foreground/30'>
+            <UserUser02 size={14} className='text-muted-foreground' />
+          </span>
+          <span className='min-w-0 flex-1 truncate text-left'>{anyoneLabel}</span>
+          {selectedUserId === null && (
+            <CheckTickSingle size={14} className='shrink-0 text-primary' />
+          )}
+        </button>
+
+        {candidates.length > 0 && <div className='my-1 h-px bg-border' />}
+
+        {candidates.map(user => (
+          <button
+            key={user.id}
+            type='button'
+            onClick={() => handleSelect(user.id)}
+            className={ROW_CLASS}
+            data-track-category='ACTIVITY'
+            data-track-name='ACTOR_FILTER_PICK'
+            data-track-metadata={JSON.stringify({ actor_id: user.id })}
+            data-testid={`activity-actor-picker-option-${user.id}`}
+          >
+            <Avatar userId={user.id} size='rg' className='shrink-0' />
+            <span className='min-w-0 flex-1 truncate text-left'>{getUserDisplayName(user)}</span>
+            {selectedUserId === user.id && (
+              <CheckTickSingle size={14} className='shrink-0 text-primary' />
+            )}
+          </button>
+        ))}
+
+        {candidates.length === 0 && query.trim().length > 0 && (
+          <div
+            className={cn(ROW_CLASS, 'justify-center text-muted-foreground hover:bg-transparent')}
+          >
+            No results
+          </div>
+        )}
+      </div>
+    </Popover>
+  );
+};

--- a/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
@@ -21,6 +21,7 @@ import type { ActivityWithRelated } from '../../../types/activity';
 import { ActivityClassification, UserType } from '@xyne/shared';
 import { Bot, ChevronUp, UserUser02 } from '@xyne/icons';
 import { ActivityActorPicker } from '../ActivityActorPicker';
+import { ActivityEmptyIcon } from '../../icons';
 import Avatar from '../../ui/Avatar/Avatar';
 import { useUsersById } from '../../../hooks/useUsers';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
@@ -1339,7 +1340,7 @@ const ActivityListView = (): ReactElement => {
             <div className='flex-1 h-full overflow-hidden flex items-center justify-center'>
               {isOnIndexRoute ? (
                 <div className='flex flex-col items-center justify-center p-8 text-center'>
-                  <NotificationBellOn className='text-muted-foreground mb-4' size={64} />
+                  <ActivityEmptyIcon className='mb-6' />
                   <h3
                     className='text-xl font-medium text-foreground mb-2'
                     data-testid='select-activity-heading'

--- a/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
@@ -19,7 +19,11 @@ import * as Switch from '@radix-ui/react-switch';
 import { cn } from '../../../utils/classNames';
 import type { ActivityWithRelated } from '../../../types/activity';
 import { ActivityClassification, UserType } from '@xyne/shared';
-import { Bot, UserUser02 } from '@xyne/icons';
+import { Bot, ChevronUp, UserUser02 } from '@xyne/icons';
+import { ActivityActorPicker } from '../ActivityActorPicker';
+import Avatar from '../../ui/Avatar/Avatar';
+import { useUsersById } from '../../../hooks/useUsers';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
 import { groupActivities, insertDateSeparators, type ActivityFeedItem } from '../activityGrouping';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { Skeleton } from '../../ui/Skeleton';
@@ -133,10 +137,24 @@ const ACTOR_FILTER_OPTIONS: Array<{
   value: ActorFilter;
   label: string;
   icon?: ComponentType<{ size?: number; className?: string }>;
+  anyoneLabel?: string;
+  searchPlaceholder?: string;
 }> = [
   { value: 'all', label: 'All' },
-  { value: 'user', label: 'User', icon: UserUser02 },
-  { value: 'agent', label: 'Agent', icon: Bot },
+  {
+    value: 'user',
+    label: 'User',
+    icon: UserUser02,
+    anyoneLabel: 'Anyone',
+    searchPlaceholder: 'Search people',
+  },
+  {
+    value: 'agent',
+    label: 'Agent',
+    icon: Bot,
+    anyoneLabel: 'Any agent',
+    searchPlaceholder: 'Search agents',
+  },
 ];
 
 const TABS: TabConfig[] = [
@@ -236,6 +254,9 @@ const ActivityListView = (): ReactElement => {
     const stored = window.localStorage.getItem('activity_actor_filter');
     return stored === 'all' || stored === 'user' || stored === 'agent' ? stored : 'all';
   });
+  const [actorUserId, setActorUserId] = useState<string | null>(null);
+  const [actorPickerOpen, setActorPickerOpen] = useState(false);
+  const usersById = useUsersById();
 
   const [showUnreadOnly, setShowUnreadOnly] = useState<boolean>(() => {
     const unread = window.localStorage.getItem('activity_unread_toggle');
@@ -303,6 +324,8 @@ const ActivityListView = (): ReactElement => {
 
   const handleActorFilterChange = useCallback((next: ActorFilter): void => {
     setActorFilter(next);
+    setActorUserId(null);
+    setActorPickerOpen(false);
     window.localStorage.setItem('activity_actor_filter', next);
   }, []);
 
@@ -399,7 +422,7 @@ const ActivityListView = (): ReactElement => {
     setHasMore(true);
     setIsLoading(true);
     activityLoadStartTimeRef.current = Date.now();
-  }, [activeTab, showUnreadOnly, actorFilter]);
+  }, [activeTab, showUnreadOnly, actorFilter, actorUserId]);
 
   const getClassificationFilter = (tab: ActivityTab): ActivityClassification[] | undefined => {
     switch (tab) {
@@ -424,8 +447,17 @@ const ActivityListView = (): ReactElement => {
         classification: classificationFilter,
         ...(showUnreadOnly ? { isRead: false } : {}),
         ...(ACTOR_FILTER_TYPES[actorFilter] ? { actorTypes: ACTOR_FILTER_TYPES[actorFilter] } : {}),
+        ...(actorUserId ? { actorId: actorUserId } : {}),
       }),
-    [PAGE_SIZE, fetchCursor, currentTypes, classificationFilter, showUnreadOnly, actorFilter],
+    [
+      PAGE_SIZE,
+      fetchCursor,
+      currentTypes,
+      classificationFilter,
+      showUnreadOnly,
+      actorFilter,
+      actorUserId,
+    ],
   );
 
   const [activitiesPage, activitiesDetails, activitiesMeta] = useCachedQuery(activitiesQuery, {
@@ -958,15 +990,21 @@ const ActivityListView = (): ReactElement => {
                 const isActive = option.value === actorFilter;
                 const Icon = option.icon;
                 const showLabel = isActive || !Icon;
+                const actorTypes = ACTOR_FILTER_TYPES[option.value];
+                const isPickable = isActive && actorTypes !== undefined;
+                const pickedActor =
+                  isPickable && actorUserId ? usersById.get(actorUserId) : undefined;
 
-                return (
+                const button = (
                   <button
                     key={option.value}
                     type='button'
                     role='radio'
                     aria-checked={isActive}
                     aria-label={option.label}
-                    onClick={() => handleActorFilterChange(option.value)}
+                    onClick={() => {
+                      if (!isPickable) handleActorFilterChange(option.value);
+                    }}
                     className={cn(
                       'flex items-center rounded-[10px] pl-2 pr-2.5 py-1',
                       'transition-[background-color,color,box-shadow] duration-300 ease-in-out',
@@ -980,7 +1018,11 @@ const ActivityListView = (): ReactElement => {
                     data-track-metadata={JSON.stringify({ filter_value: option.value })}
                     data-testid={`activity-actor-filter-${option.value}`}
                   >
-                    {Icon && <Icon size={14} className='shrink-0' />}
+                    {pickedActor ? (
+                      <Avatar userId={pickedActor.id} size='xs' className='shrink-0' />
+                    ) : (
+                      Icon && <Icon size={14} className='shrink-0' />
+                    )}
                     <span
                       className={cn(
                         'grid overflow-hidden transition-[grid-template-columns,opacity,margin] duration-300 ease-in-out',
@@ -990,11 +1032,36 @@ const ActivityListView = (): ReactElement => {
                           : 'grid-cols-[0fr] opacity-0 ml-0',
                       )}
                     >
-                      <span className='min-w-0 overflow-hidden whitespace-nowrap text-xs font-medium tracking-[-0.28px]'>
-                        {option.label}
+                      <span className='min-w-0 max-w-[120px] overflow-hidden text-ellipsis whitespace-nowrap text-xs font-medium tracking-[-0.28px]'>
+                        {pickedActor ? getUserDisplayName(pickedActor) : option.label}
                       </span>
                     </span>
+                    {isPickable && (
+                      <ChevronUp
+                        size={12}
+                        className={cn(
+                          'ml-1 shrink-0 transition-transform duration-200 ease-in-out',
+                          !actorPickerOpen && 'rotate-180',
+                        )}
+                      />
+                    )}
                   </button>
+                );
+
+                if (!isPickable || !actorTypes) return button;
+
+                return (
+                  <ActivityActorPicker
+                    key={option.value}
+                    open={actorPickerOpen}
+                    onOpenChange={setActorPickerOpen}
+                    userTypes={actorTypes}
+                    selectedUserId={actorUserId}
+                    onSelect={setActorUserId}
+                    anyoneLabel={option.anyoneLabel ?? 'Anyone'}
+                    searchPlaceholder={option.searchPlaceholder ?? 'Search'}
+                    trigger={button}
+                  />
                 );
               })}
             </div>

--- a/apps/dashboard/src/components/Chat/DirectMessages/DmsPage.tsx
+++ b/apps/dashboard/src/components/Chat/DirectMessages/DmsPage.tsx
@@ -885,8 +885,17 @@ const DmsPage = (): ReactElement => {
           <div className='flex-1 flex flex-col bg-background relative h-full rounded-2xl'>
             <div className='flex-1 h-full overflow-hidden flex items-center justify-center'>
               {isOnIndexRoute ? (
-                <div className='max-w-full max-h-full flex items-center justify-center'>
-                  <DirectMessagesIcon />
+                <div className='flex flex-col items-center justify-center p-8 text-center'>
+                  <DirectMessagesIcon className='mb-6' />
+                  <h3
+                    className='text-xl font-medium text-foreground mb-2'
+                    data-testid='select-conversation-heading'
+                  >
+                    Select a conversation
+                  </h3>
+                  <p className='text-muted-foreground max-w-md'>
+                    Choose a direct message from the list to read it here
+                  </p>
                 </div>
               ) : (
                 <div className='w-full h-full'>

--- a/apps/dashboard/src/components/icons/ActivityEmptyIcon.tsx
+++ b/apps/dashboard/src/components/icons/ActivityEmptyIcon.tsx
@@ -1,0 +1,60 @@
+import { ReactElement } from 'react';
+
+const ActivityEmptyIcon = ({ className }: { className?: string }): ReactElement => {
+  return (
+    <svg
+      width={124}
+      height={75}
+      viewBox='0 0 260 158'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      className={className}
+      aria-hidden='true'
+      focusable='false'
+    >
+      <rect
+        x={8}
+        y={40}
+        width={242}
+        height={102}
+        rx={12}
+        className='fill-muted'
+        transform='rotate(-3.9 129 91)'
+      />
+
+      <g filter='url(#activity-empty-card-shadow)'>
+        <rect
+          x={6}
+          y={2}
+          width={248}
+          height={124}
+          rx={12}
+          className='fill-background stroke-border'
+          strokeWidth={1.5}
+        />
+      </g>
+
+      <rect x={27} y={25} width={86} height={11} rx={5.5} className='fill-border' />
+
+      <rect x={27} y={73} width={22} height={29} rx={3} className='fill-border' />
+      <rect x={59} y={55} width={22} height={47} rx={3} className='fill-border' />
+      <rect x={91} y={81} width={22} height={21} rx={3} className='fill-border' />
+      <rect x={123} y={62} width={22} height={40} rx={3} className='fill-border' />
+
+      <defs>
+        <filter
+          id='activity-empty-card-shadow'
+          x={-10}
+          y={-6}
+          width={280}
+          height={160}
+          filterUnits='userSpaceOnUse'
+        >
+          <feDropShadow dx={0} dy={2} stdDeviation={3} floodColor='#000' floodOpacity={0.05} />
+        </filter>
+      </defs>
+    </svg>
+  );
+};
+
+export default ActivityEmptyIcon;

--- a/apps/dashboard/src/components/icons/DirectMessagesIcon.tsx
+++ b/apps/dashboard/src/components/icons/DirectMessagesIcon.tsx
@@ -1,82 +1,44 @@
 import { ReactElement } from 'react';
 
-const DirectMessagesIcon = (): ReactElement => {
+const DirectMessagesIcon = ({ className }: { className?: string }): ReactElement => {
   return (
     <svg
-      width={335}
-      height={339}
-      viewBox='0 0 335 339'
+      width={176}
+      height={89}
+      viewBox='0 0 348 176'
       fill='none'
       xmlns='http://www.w3.org/2000/svg'
+      className={className}
+      aria-hidden='true'
+      focusable='false'
     >
-      {/* BACK BUBBLE */}
-      <g filter='url(#filter0)'>
+      <rect x={4} y={4} width={213} height={111} rx={18} className='fill-muted' />
+      <path d='M34 106 L64 106 L44 131 Q38 136 35 128 Z' className='fill-muted' />
+
+      <g filter='url(#dm-empty-bubble-shadow)'>
         <path
-          d='M141.727 3.39957C73.7802 3.39957 18.6978 54.5665 18.6978 117.684C18.6978 136.128 23.4051 153.551 31.7593 168.976L20.1675 238.146C19.0991 244.523 25.3025 249.685 31.3794 247.476L96.2417 223.901C110.312 229.104 125.66 231.968 141.727 231.968C209.674 231.968 264.755 180.801 264.755 117.684C264.755 54.5666 209.674 3.39976 141.727 3.39957Z'
-          fill='url(#paint0)'
+          d='M128 38 L324 38 A20 20 0 0 1 344 58 L344 135 A20 20 0 0 1 324 155 L304 155 L295 167 Q290 172 286 167 L264 155 L128 155 A20 20 0 0 1 108 135 L108 58 A20 20 0 0 1 128 38 Z'
+          className='fill-background stroke-border'
+          strokeWidth={1.5}
+          strokeLinejoin='round'
         />
       </g>
 
-      {/* FRONT BUBBLE */}
-      <g filter='url(#filter1)'>
-        <path
-          d='M201.014 47.5627C264.805 47.5628 316.518 95.6 316.518 154.857C316.518 172.173 312.099 188.53 304.256 203.011L315.138 267.95C316.141 273.937 310.318 278.784 304.612 276.71L243.717 254.576C230.507 259.462 216.098 262.151 201.014 262.151C137.223 262.151 85.5098 214.113 85.5098 154.857C85.5098 95.6 137.223 47.5627 201.014 47.5627Z'
-          fill='#B9DDFF'
-          fillOpacity={0.9}
-        />
-      </g>
-
-      {/* DOTS */}
-
-      <circle cx='161.946' cy='156.838' r='11.3239' fill='white' />
-
-      <circle cx='201.013' cy='156.838' r='11.3239' fill='white' />
-
-      <circle cx='240.081' cy='156.838' r='11.3239' fill='white' />
+      <circle cx={195} cy={96} r={7} className='fill-border' />
+      <circle cx={226} cy={96} r={7} className='fill-border' />
+      <circle cx={257} cy={96} r={7} className='fill-border' />
 
       <defs>
-        {/* BACK SHADOW */}
-        <filter id='filter0' x='0' y='0' width='335' height='339' filterUnits='userSpaceOnUse'>
-          <feOffset dy='2.83298' />
-          <feGaussianBlur stdDeviation='3.11628' />
-          <feColorMatrix
-            type='matrix'
-            values='0 0 0 0 0
-                        0 0 0 0 0
-                        0 0 0 0 0
-                        0 0 0 0.06 0'
-          />
-          <feBlend mode='normal' in2='BackgroundImageFix' result='effect1' />
-          <feBlend mode='normal' in='SourceGraphic' in2='effect1' />
-        </filter>
-
-        {/* FRONT SHADOW */}
-        <filter id='filter1' x='0' y='0' width='335' height='339' filterUnits='userSpaceOnUse'>
-          <feOffset dy='2.6597' />
-          <feGaussianBlur stdDeviation='2.92567' />
-          <feColorMatrix
-            type='matrix'
-            values='0 0 0 0 0
-                        0 0 0 0 0
-                        0 0 0 0 0
-                        0 0 0 0.06 0'
-          />
-          <feBlend mode='normal' in2='BackgroundImageFix' result='effect1' />
-          <feBlend mode='normal' in='SourceGraphic' in2='effect1' />
-        </filter>
-
-        {/* GRADIENT */}
-        <linearGradient
-          id='paint0'
-          x1='193.777'
-          y1='56.9048'
-          x2='5.21857'
-          y2='122.136'
-          gradientUnits='userSpaceOnUse'
+        <filter
+          id='dm-empty-bubble-shadow'
+          x={90}
+          y={26}
+          width={270}
+          height={160}
+          filterUnits='userSpaceOnUse'
         >
-          <stop stopColor='#7FC0FB' />
-          <stop offset='1' stopColor='#4088F4' />
-        </linearGradient>
+          <feDropShadow dx={0} dy={2} stdDeviation={4} floodColor='#000' floodOpacity={0.06} />
+        </filter>
       </defs>
     </svg>
   );

--- a/apps/dashboard/src/components/icons/index.ts
+++ b/apps/dashboard/src/components/icons/index.ts
@@ -4,3 +4,4 @@ export { default as HomeIcon } from './HomeIcon';
 export { default as Inbox } from './Inbox';
 export { default as JuspayIcon } from './JuspayIcon';
 export { default as DirectMessagesIcon } from './DirectMessagesIcon';
+export { default as ActivityEmptyIcon } from './ActivityEmptyIcon';

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -2522,8 +2522,9 @@ export const queries = defineQueries({
       classification: z.array(z.nativeEnum(ActivityClassification)).optional(),
       isRead: z.boolean().optional(),
       actorTypes: z.array(z.nativeEnum(UserType)).optional(),
+      actorId: z.string().optional(),
     }),
-    ({ args: { limit, start, types, classification, isRead, actorTypes } }) => {
+    ({ args: { limit, start, types, classification, isRead, actorTypes, actorId } }) => {
       let query = zql.activities;
 
       if (types.length > 0) {
@@ -2546,7 +2547,9 @@ export const queries = defineQueries({
       // reach through the `actor` relationship. Filtering here rather than on the
       // client keeps `limit` meaningful — a client-side filter would page over all
       // activities and hand back short or empty pages.
-      if (actorTypes && actorTypes.length > 0) {
+      if (actorId) {
+        query = query.where('actorId', actorId);
+      } else if (actorTypes && actorTypes.length > 0) {
         query = query.whereExists('actor', (actor: any) =>
           actor.where('userType', 'IN', actorTypes),
         );


### PR DESCRIPTION
POT - https://drive.google.com/file/d/1AMzF_Sv-6UUbIZVMly-sjkkfcvxmTtrF/view?usp=sharing

## What

The Activity header's `All / User / Agent` control only filtered by actor *kind* (`UserType.USER` vs `[BOT, APP]`). This adds a per-person filter: clicking the already-active **User** or **Agent** pill opens a searchable single-select picker, narrowing the feed to one actor. "Anyone" / "Any agent" restores the existing kind filter, and switching segments clears the selection.

## How

**`packages/shared/src/zero/queries.ts`** and **`apps/backend/src/zero/queries.ts`** — optional `actorId` arg on `userActivitiesPaginatedV2`, added to **both** copies of the query registry: the dashboard imports the shared one, while the backend copy is what the server actually executes via `handleQueryRequest`. It supersedes `actorTypes` rather than stacking on it, so a picked actor is a scalar `where('actorId', …)` against the existing `@@index([actorId])` instead of a redundant `whereExists` join through the `actor` relation. Filtering stays in the query (not client-side) so `limit` keeps its meaning and pages don't come back short.

**`ActivityActorPicker.tsx`** (new) — the popover: search box, an "Anyone" / "Any agent" reset row, then `Avatar` + name rows with a check on the selection. Candidates come from `useActiveUsers()` filtered by `userTypes` and searched with the shared `matchesUserQuery` (the matcher cmd+K and the DM pickers already use). Bot and app users are stored with `status: ACTIVE`, so one hook covers both kinds.

**`ActivityListView.tsx`** — the active pickable segment becomes the popover trigger and grows a chevron; with a person picked, the pill swaps its icon and label for that actor's avatar and name. Radix owns open/close on the trigger, so the button's own `onClick` only fires when the segment *isn't* pickable — otherwise both handlers would fire and cancel each other out.

## Notes for review

- **Selection is session-only.** The `All/User/Agent` choice keeps its existing `localStorage` persistence, but the picked actor resets on reload. Persisting it would let a stale or deleted user id silently empty the feed, and would flash the filter off and back on during user hydration.
- **The picker list is alphabetical.** The design mock's ordering mirrors the feed's actor order; happy to rank recently-seen actors first if that was intentional.
- **Tab badge counts are unchanged.** "All 7", "@ 2" etc. come from a separate unfiltered `userUnreadActivities` query, so they don't narrow with the picked actor — already true of the existing User/Agent filter, so no regression here.

## Testing

- `@xyne/shared` builds clean; `tsc --noEmit` passes on the dashboard
- backend `tsc --noEmit` surfaces only a pre-existing baseline error in `src/database/acl/acl-factory.ts`, which is byte-identical to `main` and untouched here
- eslint clean on all touched files (remaining `filter_value` naming warnings in `ActivityListView.tsx` are pre-existing — baseline count matches)
- prettier clean on the dashboard files. `apps/backend/src/zero/queries.ts` is not prettier-formatted at baseline on `main`, so it was left alone rather than reformatting ~3.4k lines; the added lines match the surrounding style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gFwJ9cfzFmNWWEmvhr7so