### PR TITLE
feat: add device-aware mobile notification routing

### DIFF
--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -538,6 +538,8 @@ export const userPreferenceTable = table("user_preferences")
     enterSendsMessage: boolean(),
     allowThreadBroadcastMentions: boolean(),
     showThreadTags: boolean(),
+    mobileRoutingMode: string(),
+    desktopInactivityThresholdMinutes: number(),
     globalDesktopNotificationLevel: string().optional(),
     globalMobileNotificationLevel: string().optional(),
     threadReplyNotificationsEnabled: boolean(),

--- a/apps/backend/prisma/migrations/20260910130000_add_mobile_routing_preferences/migration.sql
+++ b/apps/backend/prisma/migrations/20260910130000_add_mobile_routing_preferences/migration.sql
@@ -1,0 +1,4 @@
+-- Device-aware mobile notification routing (Slack-style)
+-- WHEN_DESKTOP_INACTIVE: suppress mobile push while the user is active on desktop
+ALTER TABLE "user_preferences" ADD COLUMN "mobileRoutingMode" TEXT NOT NULL DEFAULT 'WHEN_DESKTOP_INACTIVE';
+ALTER TABLE "user_preferences" ADD COLUMN "desktopInactivityThresholdMinutes" INTEGER NOT NULL DEFAULT 5;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -931,6 +931,8 @@ model UserPreference {
   enterSendsMessage        Boolean  @default(true) // true: Enter sends, false: Shift+Enter sends
   allowThreadBroadcastMentions Boolean @default(false) // Allow @channel/@here in thread replies
   showThreadTags           Boolean  @default(false) // Render thread classification chips in chat; opt-in
+  mobileRoutingMode            String   @default("WHEN_DESKTOP_INACTIVE") // When to route notifications to mobile (WHEN_DESKTOP_INACTIVE | ALWAYS)
+  desktopInactivityThresholdMinutes Int  @default(5) // Minutes of desktop inactivity before mobile notifications resume
 
   // Global notification settings
   globalDesktopNotificationLevel  String?            // Default level for all channels (desktop)

--- a/apps/backend/src/services/notificationService.ts
+++ b/apps/backend/src/services/notificationService.ts
@@ -22,6 +22,7 @@ import { serializeInitialMessageMd,
   isDeskChannelType,
   type InitialMessageSummary,
   ChannelScopeType,
+  MobileRoutingMode,
   NotificationDeliveryMethod,
   NotificationType, MessageType, NotificationStatus, UserStatus, ActivityClassification, TicketStatusV2 } from '@xyne/shared';
 import { activityService } from '@/services/activity/activityService';
@@ -191,6 +192,79 @@ interface UserPreferences {
 }
 
 class NotificationService {
+  // Device-aware mobile routing: per-user preference cache (short TTL so SQL
+  // edits and cross-device changes converge quickly).
+  private mobileRoutingPrefCache = new Map<
+    string,
+    { mode: MobileRoutingMode; thresholdMinutes: number; fetchedAt: number }
+  >();
+  private static readonly MOBILE_ROUTING_PREF_CACHE_TTL_MS = 30_000;
+
+  private async getMobileRoutingPreference(userId: string): Promise<{
+    mode: MobileRoutingMode;
+    thresholdMinutes: number;
+  }> {
+    const cached = this.mobileRoutingPrefCache.get(userId);
+    if (
+      cached &&
+      Date.now() - cached.fetchedAt <
+        NotificationService.MOBILE_ROUTING_PREF_CACHE_TTL_MS
+    ) {
+      return { mode: cached.mode, thresholdMinutes: cached.thresholdMinutes };
+    }
+    try {
+      const pref = await runAsSystem(() =>
+        prisma.userPreference.findUnique({
+          where: { userId },
+          select: {
+            mobileRoutingMode: true,
+            desktopInactivityThresholdMinutes: true,
+          },
+        }),
+      );
+      const entry = {
+        mode: (pref?.mobileRoutingMode as MobileRoutingMode) ?? MobileRoutingMode.WHEN_DESKTOP_INACTIVE,
+        thresholdMinutes: pref?.desktopInactivityThresholdMinutes ?? 5,
+        fetchedAt: Date.now(),
+      };
+      this.mobileRoutingPrefCache.set(userId, entry);
+      return { mode: entry.mode, thresholdMinutes: entry.thresholdMinutes };
+    } catch (error) {
+      logger.error(
+        '[NOTIFICATION-SERVICE] Failed to load mobile routing preference, failing open',
+        { userId, error },
+      );
+      return {
+        mode: MobileRoutingMode.WHEN_DESKTOP_INACTIVE,
+        thresholdMinutes: 5,
+      };
+    }
+  }
+
+  /**
+   * Device-aware mobile routing (Slack-style): suppress the mobile push when
+   * the recipient is active on desktop AND their preference is
+   * WHEN_DESKTOP_INACTIVE. ALWAYS never suppresses. Fail-open on errors.
+   */
+  private async shouldSuppressMobilePush(userId: string): Promise<boolean> {
+    try {
+      const pref = await this.getMobileRoutingPreference(userId);
+      if (pref.mode !== MobileRoutingMode.WHEN_DESKTOP_INACTIVE) {
+        return false;
+      }
+      return await websocketService.isUserActiveOnDesktop(
+        userId,
+        pref.thresholdMinutes,
+      );
+    } catch (error) {
+      logger.error(
+        '[NOTIFICATION-SERVICE] shouldSuppressMobilePush failed, failing open',
+        { userId, error },
+      );
+      return false;
+    }
+  }
+
   /**
    * Helper to create a granular notification entry for a specific session (Mobile or Web)
    */
@@ -915,13 +989,22 @@ class NotificationService {
           try {
             const sessions = await fcmPushService.getActiveSessionsWithTokens(userId);
 
-            // Resolve the tenant ONCE — see createFCMNotification.
-            const sessionData: NotificationData = {
-              ...data,
-              workspaceId: data.workspaceId ?? (await resolveWorkspaceIdFromModel(prisma, 'user', { id: userId })),
-            };
+            // Device-aware mobile routing: skip mobile push (queueing only —
+            // the notification/inbox records stay intact) while the user is
+            // active on desktop and their preference is WHEN_DESKTOP_INACTIVE.
+            const suppressMobilePush = await this.shouldSuppressMobilePush(userId);
+            if (suppressMobilePush) {
+              logger.info(
+                `[NOTIFICATION-SERVICE] Suppressed mobile push for user ${userId} (active on desktop, ${sessions.length} sessions skipped)`,
+              );
+            }
+            for (const session of suppressMobilePush ? [] : sessions) {
+              // Resolve the tenant ONCE — see createFCMNotification.
+              const sessionData: NotificationData = {
+                ...data,
+                workspaceId: data.workspaceId ?? (await resolveWorkspaceIdFromModel(prisma, 'user', { id: userId })),
+              };
 
-            for (const session of sessions) {
               const deliveryMethod = session.platform === 'ios'
                 ? NotificationDeliveryMethod.IOS
                 : NotificationDeliveryMethod.ANDROID;

--- a/apps/backend/src/services/redisService.ts
+++ b/apps/backend/src/services/redisService.ts
@@ -169,6 +169,31 @@ class RedisService {
     return await this.redis.smembers(key);
   }
 
+  // Device-aware mobile routing: timestamp (epoch ms) of the user's last
+  // desktop activity. Updated when a web/electron socket connects or emits.
+  // Guards fail open (no-op / null) so notification delivery never breaks.
+  async setDesktopActiveAt(userId: string): Promise<void> {
+    if (!this.redis) return;
+
+    const key = `user:${userId}:desktopActiveAt`;
+    await this.redis.set(key, String(Date.now()), 'EX', 86400);
+  }
+
+  async getDesktopActiveAt(userId: string): Promise<number | null> {
+    if (!this.redis) return null;
+
+    const key = `user:${userId}:desktopActiveAt`;
+    const value = await this.redis.get(key);
+    return value ? Number(value) : null;
+  }
+
+  async getSocketPlatform(userId: string, socketId: string): Promise<string | null> {
+    if (!this.redis) return null;
+
+    const platformKey = `user:${userId}:socket:${socketId}:platform`;
+    return await this.redis.get(platformKey);
+  }
+
   // Cross-workspace broadcast registry. Keyed on orgMemberId — the person-level
   // identity that stays constant across per-workspace User rows.
   async addOrgMemberConnection(orgMemberId: string, socketId: string, platform: string = 'web'): Promise<void> {

--- a/apps/backend/src/services/websocketService.ts
+++ b/apps/backend/src/services/websocketService.ts
@@ -224,6 +224,40 @@ class WebSocketService {
     return 'web';
   }
 
+  /**
+   * Device-aware mobile routing: is the user currently active on a desktop
+   * client (web/electron)? True when they hold at least one live desktop
+   * socket AND their last desktop activity is within the inactivity threshold.
+   * Fail-open: errors resolve to false (deliver the mobile notification).
+   */
+  async isUserActiveOnDesktop(
+    userId: string,
+    inactivityThresholdMinutes = 5,
+  ): Promise<boolean> {
+    try {
+      const connections = await redisService.getUserConnections(userId);
+      if (connections.length === 0) return false;
+
+      const thresholdMs = inactivityThresholdMinutes * 60 * 1000;
+      for (const socketId of connections) {
+        const platform = await redisService.getSocketPlatform(userId, socketId);
+        if (platform === 'web' || platform === 'electron') {
+          const desktopActiveAt = await redisService.getDesktopActiveAt(userId);
+          if (desktopActiveAt !== null && Date.now() - desktopActiveAt < thresholdMs) {
+            return true;
+          }
+        }
+      }
+      return false;
+    } catch (error) {
+      logger.error('isUserActiveOnDesktop failed, failing open (not active)', {
+        userId,
+        error,
+      });
+      return false;
+    }
+  }
+
   private async handleConnection(socket: AuthenticatedSocket): Promise<void> {
     const { userId, userEmail, userName } = socket;
 
@@ -240,6 +274,12 @@ class WebSocketService {
 
     // Add user connection to Redis with platform info
     await redisService.addUserConnection(userId, socket.id, platform);
+
+    // Device-aware mobile routing: mark desktop presence so mobile pushes can
+    // be suppressed while the user is at their desk (web/electron clients).
+    if (platform === 'web' || platform === 'electron') {
+      await redisService.setDesktopActiveAt(userId);
+    }
 
     socket.join(`user:${userId}`);
 

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -12,6 +12,7 @@ import {
   CallOrigin,
   InvitationResponse,
   MeetingStatus,
+  MobileRoutingMode,
   NotificationLevel,
   Schema,
   ChannelScopeType,
@@ -15695,6 +15696,49 @@ export function createMutators(
               channelWideMentionsEnabled: true,
               notificationKeywords: '[]',
               showThreadTags: false,
+              createdAt: timestamp,
+              updatedAt: timestamp,
+            });
+          }
+        },
+      ),
+      setMobileRoutingPreference: defineMutator(
+        z.object({
+          id: z.string(),
+          mobileRoutingMode: z.nativeEnum(MobileRoutingMode).optional(),
+          desktopInactivityThresholdMinutes: z.number().int().min(1).max(120).optional(),
+          timestamp: z.number(),
+        }),
+        async ({ tx, args: { id, mobileRoutingMode, desktopInactivityThresholdMinutes, timestamp } }) => {
+          const fields = {
+            ...(mobileRoutingMode !== undefined && { mobileRoutingMode }),
+            ...(desktopInactivityThresholdMinutes !== undefined && { desktopInactivityThresholdMinutes }),
+          };
+          const existing = await tx.run(
+            zql.user_preferences.where('userId', authData.sub).one(),
+          );
+          if (existing) {
+            await tx.mutate.user_preferences.update({
+              id: existing.id,
+              ...fields,
+              updatedAt: timestamp,
+            });
+          } else {
+            await tx.mutate.user_preferences.insert({
+              workspaceId: authData.workspaceId,
+              id,
+              userId: authData.sub,
+              channelSortOrder: ChannelSortOrder.RECENCY,
+              enterSendsMessage: true,
+              allowThreadBroadcastMentions: false,
+              globalDesktopNotificationLevel: NotificationLevel.MENTIONS_ONLY,
+              globalMobileNotificationLevel: NotificationLevel.MENTIONS_ONLY,
+              threadReplyNotificationsEnabled: true,
+              channelWideMentionsEnabled: true,
+              notificationKeywords: '[]',
+              showThreadTags: false,
+              mobileRoutingMode: mobileRoutingMode ?? MobileRoutingMode.WHEN_DESKTOP_INACTIVE,
+              desktopInactivityThresholdMinutes: desktopInactivityThresholdMinutes ?? 5,
               createdAt: timestamp,
               updatedAt: timestamp,
             });

--- a/apps/dashboard/src/components/Settings/MobileRoutingCard.tsx
+++ b/apps/dashboard/src/components/Settings/MobileRoutingCard.tsx
@@ -1,0 +1,111 @@
+import { FC } from 'react';
+import { RadioGroup, Radio } from '../ui/RadioGroup';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '../ui/dropdown-menu';
+import { Button } from '../ui/Button/Button';
+import { useGlobalNotificationSettings } from '../../hooks/useGlobalNotificationSettings';
+import { MobileRoutingMode } from '@xyne/shared';
+
+const THRESHOLD_OPTIONS = [1, 2, 3, 5, 10, 15, 30, 60, 120];
+
+/**
+ * Device-aware mobile notification routing (Slack-style): choose when
+ * notifications reach mobile devices. While you're active on desktop,
+ * WHEN_DESKTOP_INACTIVE skips the mobile push (no duplicate buzz); ALWAYS
+ * delivers to every device regardless of desktop activity.
+ */
+export const MobileRoutingCard: FC = () => {
+  const { mobileRoutingMode, desktopInactivityThresholdMinutes, update } =
+    useGlobalNotificationSettings();
+
+  // Radio values are local UI keys; map to the persisted enum + threshold.
+  const radioValue =
+    mobileRoutingMode === MobileRoutingMode.ALWAYS
+      ? 'always'
+      : desktopInactivityThresholdMinutes <= 1
+        ? 'as_soon_as_inactive'
+        : 'after_x_minutes';
+
+  return (
+    <div
+      data-testid='mobile-routing-card'
+      className='p-3 rounded-lg border border-border bg-muted/30 space-y-3'
+    >
+      <div>
+        <p className='text-sm font-medium text-foreground'>
+          When I&apos;m not active on desktop
+        </p>
+        <p className='text-xs text-muted-foreground mt-0.5'>
+          While you&apos;re active on desktop, mobile notifications are skipped so
+          your devices don&apos;t both buzz. Choose when mobile notifications resume.
+        </p>
+      </div>
+      <RadioGroup
+        value={radioValue}
+        onChange={value => {
+          if (value === 'always') {
+            update({ mobileRoutingMode: MobileRoutingMode.ALWAYS });
+          } else if (value === 'as_soon_as_inactive') {
+            update({
+              mobileRoutingMode: MobileRoutingMode.WHEN_DESKTOP_INACTIVE,
+              desktopInactivityThresholdMinutes: 1,
+            });
+          } else {
+            update({
+              mobileRoutingMode: MobileRoutingMode.WHEN_DESKTOP_INACTIVE,
+              desktopInactivityThresholdMinutes:
+                desktopInactivityThresholdMinutes <= 1
+                  ? 5
+                  : desktopInactivityThresholdMinutes,
+            });
+          }
+        }}
+      >
+        <Radio value='as_soon_as_inactive' data-track-category='PREFERENCES' data-track-name='SET_MOBILE_ROUTING_AS_SOON_AS_INACTIVE'>
+          As soon as I&apos;m inactive
+        </Radio>
+        <Radio value='after_x_minutes' data-track-category='PREFERENCES' data-track-name='SET_MOBILE_ROUTING_AFTER_X_MINUTES'>
+          After{' '}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                data-testid='mobile-routing-threshold-trigger'
+                variant='outline'
+                size='sm'
+                className='h-6 px-2 mx-1 text-xs'
+              >
+                {desktopInactivityThresholdMinutes <= 1 ? 5 : desktopInactivityThresholdMinutes}{' '}
+                minutes
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='start' data-track-category='PREFERENCES' data-track-name='SET_MOBILE_ROUTING_THRESHOLD'>
+              {THRESHOLD_OPTIONS.map(minutes => (
+                <DropdownMenuItem
+                  key={minutes}
+                  onClick={() =>
+                    update({
+                      mobileRoutingMode: MobileRoutingMode.WHEN_DESKTOP_INACTIVE,
+                      desktopInactivityThresholdMinutes: minutes,
+                    })
+                  }
+                >
+                  {minutes} {minutes === 1 ? 'minute' : 'minutes'}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>{' '}
+          of inactivity
+        </Radio>
+        <Radio value='always' data-track-category='PREFERENCES' data-track-name='SET_MOBILE_ROUTING_ALWAYS'>
+          Always send me mobile notifications
+        </Radio>
+      </RadioGroup>
+    </div>
+  );
+};
+
+export default MobileRoutingCard;

--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -64,6 +64,7 @@ import { VoiceSignatureModal } from '../VoiceSignatureModal/VoiceSignatureModal'
 import HuddleIcon from '../../icons/HuddleIcon';
 import { useGlobalNotificationSettings } from '../../../hooks/useGlobalNotificationSettings';
 import { useNotificationKeywords } from '../../../hooks/useNotificationKeywords';
+import { MobileRoutingCard } from '../MobileRoutingCard';
 import { Badge } from '../../ui/Badge/Badge';
 
 import { usePreferencesState, type PreferencesState } from '../../../hooks/usePreferencesState';
@@ -383,6 +384,9 @@ const NotificationsSection: FC<{ state: PreferencesState }> = () => {
           </div>
         </div>
       </div>
+
+      {/* Device-aware mobile routing */}
+      <MobileRoutingCard />
 
       {/* Toggle settings */}
       <div className='space-y-2'>

--- a/apps/dashboard/src/hooks/useGlobalNotificationSettings.ts
+++ b/apps/dashboard/src/hooks/useGlobalNotificationSettings.ts
@@ -2,18 +2,22 @@ import { useSelector } from '@xstate/react';
 import { useZero } from './useZero';
 import { mutators } from '../zero/mutators';
 import { stateMachineActor } from '../machines/stateMachine';
-import { NotificationLevel } from '@xyne/shared';
+import { NotificationLevel, MobileRoutingMode } from '@xyne/shared';
 
 export interface GlobalNotificationSettings {
   globalDesktopNotificationLevel: NotificationLevel;
   globalMobileNotificationLevel: NotificationLevel;
   threadReplyNotificationsEnabled: boolean;
   channelWideMentionsEnabled: boolean;
+  mobileRoutingMode: MobileRoutingMode;
+  desktopInactivityThresholdMinutes: number;
   update: (fields: {
     globalDesktopNotificationLevel?: NotificationLevel;
     globalMobileNotificationLevel?: NotificationLevel;
     threadReplyNotificationsEnabled?: boolean;
     channelWideMentionsEnabled?: boolean;
+    mobileRoutingMode?: MobileRoutingMode;
+    desktopInactivityThresholdMinutes?: number;
   }) => void;
 }
 
@@ -27,20 +31,49 @@ export const useGlobalNotificationSettings = (): GlobalNotificationSettings => {
     userPreference?.globalMobileNotificationLevel ?? NotificationLevel.MENTIONS_ONLY;
   const threadReplyNotificationsEnabled = userPreference?.threadReplyNotificationsEnabled ?? true;
   const channelWideMentionsEnabled = userPreference?.channelWideMentionsEnabled ?? true;
+  const mobileRoutingMode =
+    userPreference?.mobileRoutingMode ?? MobileRoutingMode.WHEN_DESKTOP_INACTIVE;
+  const desktopInactivityThresholdMinutes =
+    userPreference?.desktopInactivityThresholdMinutes ?? 5;
 
   const update = (fields: {
     globalDesktopNotificationLevel?: NotificationLevel;
     globalMobileNotificationLevel?: NotificationLevel;
     threadReplyNotificationsEnabled?: boolean;
     channelWideMentionsEnabled?: boolean;
+    mobileRoutingMode?: MobileRoutingMode;
+    desktopInactivityThresholdMinutes?: number;
   }): void => {
-    void zero.mutate(
-      mutators.userPreference.setGlobalNotificationSettings({
-        id: userPreference?.id ?? crypto.randomUUID(),
-        ...fields,
-        timestamp: Date.now(),
-      }),
-    );
+    const {
+      mobileRoutingMode: newMode,
+      desktopInactivityThresholdMinutes: newThreshold,
+      ...globalFields
+    } = fields;
+    if (
+      newMode !== undefined ||
+      newThreshold !== undefined ||
+      Object.keys(globalFields).length > 0
+    ) {
+      void zero.mutate(
+        mutators.userPreference.setGlobalNotificationSettings({
+          id: userPreference?.id ?? crypto.randomUUID(),
+          ...globalFields,
+          timestamp: Date.now(),
+        }),
+      );
+    }
+    if (newMode !== undefined || newThreshold !== undefined) {
+      void zero.mutate(
+        mutators.userPreference.setMobileRoutingPreference({
+          id: userPreference?.id ?? crypto.randomUUID(),
+          ...(newMode !== undefined && { mobileRoutingMode: newMode }),
+          ...(newThreshold !== undefined && {
+            desktopInactivityThresholdMinutes: newThreshold,
+          }),
+          timestamp: Date.now(),
+        }),
+      );
+    }
   };
 
   return {
@@ -48,6 +81,8 @@ export const useGlobalNotificationSettings = (): GlobalNotificationSettings => {
     globalMobileNotificationLevel,
     threadReplyNotificationsEnabled,
     channelWideMentionsEnabled,
+    mobileRoutingMode,
+    desktopInactivityThresholdMinutes,
     update,
   };
 };

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -13,6 +13,7 @@ import {
   ChannelAddUserPolicy,
   ChannelSortOrder,
   ChannelFilterMode,
+  MobileRoutingMode,
   ConversationParticipation,
   TicketStatusV2,
   MailboxState,
@@ -9696,6 +9697,51 @@ export const mutators = defineMutators({
             allowThreadBroadcastMentions: false,
             globalDesktopNotificationLevel: NotificationLevel.MENTIONS_ONLY,
             globalMobileNotificationLevel: NotificationLevel.MENTIONS_ONLY,
+            threadReplyNotificationsEnabled: true,
+            channelWideMentionsEnabled: true,
+            notificationKeywords: '[]',
+            showThreadTags: false,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          });
+        }
+      },
+    ),
+    setMobileRoutingPreference: defineMutator(
+      z.object({
+        id: z.string(),
+        mobileRoutingMode: z.nativeEnum(MobileRoutingMode).optional(),
+        desktopInactivityThresholdMinutes: z.number().int().min(1).max(120).optional(),
+        timestamp: z.number(),
+      }),
+      async ({
+        tx,
+        ctx,
+        args: { id, mobileRoutingMode, desktopInactivityThresholdMinutes, timestamp },
+      }) => {
+        const fields = {
+          ...(mobileRoutingMode !== undefined && { mobileRoutingMode }),
+          ...(desktopInactivityThresholdMinutes !== undefined && { desktopInactivityThresholdMinutes }),
+        };
+        const existing = await tx.run(
+          zql.user_preferences.where('userId', ctx.userID).one(),
+        );
+        if (existing) {
+          await tx.mutate.user_preferences.update({
+            id: existing.id,
+            ...fields,
+            updatedAt: timestamp,
+          });
+        } else {
+          await tx.mutate.user_preferences.insert({
+            workspaceId: ctx.workspaceId,
+            id,
+            userId: ctx.userID,
+            channelSortOrder: ChannelSortOrder.RECENCY,
+            enterSendsMessage: true,
+            allowThreadBroadcastMentions: false,
+            mobileRoutingMode: mobileRoutingMode ?? MobileRoutingMode.WHEN_DESKTOP_INACTIVE,
+            desktopInactivityThresholdMinutes: desktopInactivityThresholdMinutes ?? 5,
             threadReplyNotificationsEnabled: true,
             channelWideMentionsEnabled: true,
             notificationKeywords: '[]',

--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -58,6 +58,7 @@ import {
   IngestionStatus,
   InvitationResponse,
   LinkVisibility,
+  MobileRoutingMode,
   LookupType,
   MailboxState,
   MessageArtifactStatus,
@@ -635,6 +636,9 @@ export const userPreferenceTable = table('user_preferences')
     channelWideMentionsEnabled: boolean(),      // Receive @channel and @here notifications
     notificationKeywords: string().optional(), // Stringified JSON array of keywords (max 50, each <= 80 chars)
     showThreadTags: boolean(), // Render thread classification chips in chat; opt-in
+    // Device-aware mobile routing
+    mobileRoutingMode: enumeration<MobileRoutingMode>().optional(), // When to route notifications to mobile
+    desktopInactivityThresholdMinutes: number().optional(), // Desktop-inactivity threshold before mobile routing resumes (minutes)
     createdAt: number(),
     updatedAt: number(),
   })

--- a/packages/shared/src/zero/types.ts
+++ b/packages/shared/src/zero/types.ts
@@ -687,6 +687,13 @@ export enum NotificationLevel {
   NONE = "NONE",
 }
 
+// Device-aware mobile routing: when should notifications reach mobile devices?
+// @ts-ignore TS1294
+export enum MobileRoutingMode {
+  WHEN_DESKTOP_INACTIVE = "WHEN_DESKTOP_INACTIVE",
+  ALWAYS = "ALWAYS",
+}
+
 // @ts-ignore TS1294
 export enum CanvasVisibility {
   PUBLIC = 'PUBLIC',


### PR DESCRIPTION
Slack-style mobile push suppression: when a user is active on desktop, mobile pushes are suppressed; when they go inactive for N minutes (or always, per preference), mobile pushes resume.

## What changes
- `user_preferences`: new columns `mobileRoutingMode` (WHEN_DESKTOP_INACTIVE | ALWAYS) and `desktopInactivityThresholdMinutes` (1–120, default 5) — prisma migration `20260910130000_add_mobile_routing_preferences`
- `websocketService`: records per-connection platform and `desktopActiveAt` in redis on desktop (web/electron) socket connect
- `notificationService`: consults the routing preference (30s cache) and skips `queueMobilePush` when the user is desktop-active; inbox items and desktop notifications are unaffected; all checks fail open
- `MobileRoutingCard` preferences UI: as-soon-as-inactive / after X minutes / always, with a threshold dropdown ([1,2,3,5,10,15,30,60,120])
- Zero mutator `setMobileRoutingPreference` (shared client copy + backend registry)

## Files touched
- `packages/shared/src/zero/{types,schema,mutators}.ts`
- `apps/backend/prisma/schema.prisma` + migration
- `apps/backend/src/services/{redisService,websocketService,notificationService}.ts`
- `apps/backend/src/zero/mutators.ts`
- `apps/dashboard/src/hooks/useGlobalNotificationSettings.ts`
- `apps/dashboard/src/components/Settings/MobileRoutingCard.tsx` (new) + `Preferences/Preferences.tsx`
- `apps/backend/prisma/generated/zero/schema.ts` (user_preferences hunk only)

## Verification
- `tsc --noEmit` clean on backend and dashboard
- Proof of Testing: 10/10 scenario checks pass (TC1–TC6 UI persistence incl. reload; TC7 suppression on fresh desktop presence; TC8 delivery when offline; TC9 delivery after 10-min inactivity > 5-min threshold; TC10 ALWAYS override delivers while desktop-active). Walkthrough video + screenshots attached to the originating Spaces thread.