### PR TITLE
feat: XYNE-59714 integrated workflow-sdk public endoint authentication

### DIFF
--- a/apps/backend/prisma/migrations/20260903000000_workflows_app_permissions/migration.sql
+++ b/apps/backend/prisma/migrations/20260903000000_workflows_app_permissions/migration.sql
@@ -1,0 +1,32 @@
+-- Registers the workflows app permissions in every environment.
+--
+-- `scripts/seed-app-permissions.ts` holds the canonical scope list, but it only runs from
+-- setup.sh and start-services.sh — both local, both on .env.local. Nothing runs it on
+-- deploy, so the rows have to arrive as a migration. Keep the two in sync: a scope added
+-- to that script needs a migration like this one to reach a deployed environment.
+--
+-- `type` is plain text rather than the AppPermissionType enum, which
+-- 20260804120002_enums_to_text_batch2 converted the column to and then dropped.
+INSERT INTO "public"."available_app_permissions" ("id", "name", "type", "description", "createdAt")
+SELECT
+  'workflows-read-permission',
+  'workflows',
+  'READ',
+  'Read workflows, folders and execution history from apps',
+  NOW()
+WHERE NOT EXISTS (
+  SELECT 1 FROM "public"."available_app_permissions"
+  WHERE "name" = 'workflows' AND "type" = 'READ'
+);
+
+INSERT INTO "public"."available_app_permissions" ("id", "name", "type", "description", "createdAt")
+SELECT
+  'workflows-write-permission',
+  'workflows',
+  'WRITE',
+  'Create, update and trigger workflows from apps',
+  NOW()
+WHERE NOT EXISTS (
+  SELECT 1 FROM "public"."available_app_permissions"
+  WHERE "name" = 'workflows' AND "type" = 'WRITE'
+);

--- a/apps/backend/scripts/seed-app-permissions.ts
+++ b/apps/backend/scripts/seed-app-permissions.ts
@@ -20,6 +20,8 @@ const APP_PERMISSION_SCOPES = [
   { scope: 'tickets:write', description: 'Create and update tickets from apps' },
   { scope: 'usergroups:read', description: 'Read user groups from apps' },
   { scope: 'users:read', description: 'Read user profile information from apps' },
+  { scope: 'workflows:read', description: 'Read workflows, folders and execution history from apps' },
+  { scope: 'workflows:write', description: 'Create, update and trigger workflows from apps' },
 ];
 
 async function main() {

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -47,7 +47,7 @@ import userAssignmentStateRoutes from '@/routes/userAssignmentState';
 import { UserManagementController } from '@/controllers/userManagementController';
 import { registerAllWorkflows } from '@/workflows';
 import workflowRoutes from '@/routes/workflows';
-import { workflowsRouter } from '@/workflowsV2/router';
+import { workflowsRouter, workflowsTriggerRouter } from '@/workflowsV2/router';
 import { configSyncService } from '@/services/configSyncService';
 import { websocketService } from '@/services/websocketService';
 import { redisService } from '@/services/redisService';
@@ -374,7 +374,11 @@ export class App {
 
     this.app.use('/api/automation-webhooks', webhookLimiter, automationWebhookRoutes);
 
-    // this.app.use('/api/workflows-v2', webhookLimiter, workflowsPublicRouter);
+    // Registers only the app-token trigger route, which must precede the session
+    // middleware: an app JWT is signed with the app's own secret, which
+    // authMiddleware.authenticate cannot verify. Every other /api/workflows-v2 request
+    // falls through to the authenticated mount below.
+    this.app.use('/api/workflows-v2', workflowsTriggerRouter);
 
     // Claw MCP route (user + app auth) — must be before /api/query
     this.app.use('/api/query/claw', authenticateUserOrApp, pythonQueryRoutes);

--- a/apps/backend/src/apps/controllers/appResourceController.ts
+++ b/apps/backend/src/apps/controllers/appResourceController.ts
@@ -1,0 +1,119 @@
+import { type Request, type Response } from 'express';
+import { repositories } from '@/database/repositories';
+import { appResourceAccessService } from '@/services/appResourceAccessService';
+import { attachableResourceFor, type AttachableResource } from '../core/attachableResources';
+import { logger } from '@/utils/logger';
+
+type Resolved = { install: { id: string }; resource: AttachableResource };
+
+export class AppResourceController {
+  /** Scoped through the owning user's workspace, as the permission routes do — another
+   *  workspace's install is a 404, not a 403. */
+  private async resolve(req: Request, res: Response): Promise<Resolved | null> {
+    const { installedAppId, resourceType } = req.params;
+    const workspaceId = req.user?.workspaceId;
+    if (!installedAppId || !resourceType || !workspaceId) {
+      res.status(400).json({ error: 'installedAppId, resourceType and workspace are required' });
+      return null;
+    }
+
+    const resource = attachableResourceFor(resourceType);
+    if (!resource) {
+      res.status(404).json({ error: `Unknown resource type "${resourceType}"` });
+      return null;
+    }
+
+    const install = await repositories.installedApps.findFirst({
+      where: { id: installedAppId, user: { workspaceId } },
+    });
+    if (!install) {
+      res.status(404).json({ error: 'Installed app not found in this workspace' });
+      return null;
+    }
+
+    return { install, resource };
+  }
+
+  /** `describe` also filters, so a grant whose target was deleted drops out of the UI. */
+  private async currentItems(
+    installedAppId: string,
+    workspaceId: string,
+    resource: AttachableResource,
+  ): Promise<{ id: string; name: string }[]> {
+    const ids = await appResourceAccessService.listAttachedIds({
+      workspaceId,
+      installedAppId,
+      entityType: resource.entityType,
+    });
+    return ids.length ? resource.describe(ids, workspaceId) : [];
+  }
+
+  listAttached = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const resolved = await this.resolve(req, res);
+      if (!resolved) return;
+      const { install, resource } = resolved;
+      const items = await this.currentItems(install.id, req.user!.workspaceId, resource);
+      res.json({ resourceType: resource.kind, items });
+    } catch (error) {
+      logger.error('Error listing attached resources:', error);
+      res.status(500).json({ error: 'Failed to list attached resources' });
+    }
+  };
+
+  /**
+   * A delta rather than the whole set, so an admin saving a stale page only changes what
+   * they touched. Takes effect immediately — there is no approval step. An id in both
+   * arrays ends up attached, since the repository deletes before it creates.
+   */
+  setAttached = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const body = req.body as { added?: unknown; removed?: unknown };
+      const ids = (value: unknown): string[] | null => {
+        if (value === undefined) return [];
+        if (!Array.isArray(value)) return null;
+        if (value.some(id => typeof id !== 'string' || id.length === 0)) return null;
+        return [...new Set(value as string[])];
+      };
+
+      const added = ids(body?.added);
+      const removed = ids(body?.removed);
+      if (added === null || removed === null) {
+        res.status(400).json({ error: 'added and removed must be arrays of ids' });
+        return;
+      }
+      const resolved = await this.resolve(req, res);
+      if (!resolved) return;
+      const { install, resource } = resolved;
+      const workspaceId = req.user!.workspaceId;
+      const actorId = req.user!.id;
+
+      // Additions only: removing something already deleted is how an orphan gets pruned.
+      if (added.length) {
+        const found = await resource.describe(added, workspaceId);
+        const missing = added.filter(id => !found.some(row => row.id === id));
+        if (missing.length) {
+          res.status(400).json({ error: `Unknown ${resource.kind}`, entityIds: missing });
+          return;
+        }
+      }
+
+      await appResourceAccessService.applyAttachmentChanges({
+        workspaceId,
+        installedAppId: install.id,
+        entityType: resource.entityType,
+        added,
+        removed,
+      });
+
+      const items = await this.currentItems(install.id, workspaceId, resource);
+      logger.info(
+        `[APP-RESOURCES] install ${install.id} ${resource.kind}: +${added.length} -${removed.length} by ${actorId}`,
+      );
+      res.json({ resourceType: resource.kind, items });
+    } catch (error) {
+      logger.error('Error updating attached resources:', error);
+      res.status(500).json({ error: 'Failed to update attached resources' });
+    }
+  };
+}

--- a/apps/backend/src/apps/core/attachableResources.ts
+++ b/apps/backend/src/apps/core/attachableResources.ts
@@ -1,0 +1,41 @@
+import { ShareableEntityType } from '@xyne/shared';
+import { db } from '@/database/client';
+import { WORKFLOWS_SCOPE } from '@/workflowsV2/constants';
+
+/**
+ * The resource kinds an admin can attach to an installed app. Adding one is an entry here
+ * plus a `ShareableEntityType` value; storage, service, routes and UI are already generic.
+ *
+ * Enforcement is not, and cannot be: each feature decides where it calls `isAttached` and
+ * what an attachment means. A `PROJECT` kind would be checked by resolving a ticket's
+ * project and asking whether THAT is attached — same storage, different rule.
+ */
+export interface AttachableResource {
+  /** URL segment, and the key the dashboard uses. */
+  kind: string;
+  entityType: ShareableEntityType;
+  /**
+   * Those of `ids` that exist in this workspace, named. The only lookup a kind implements:
+   * it labels the UI, drops grants whose target was deleted, and by omission tells the
+   * write path which ids to reject.
+   */
+  describe(ids: string[], workspaceId: string): Promise<{ id: string; name: string }[]>;
+}
+
+const workflows: AttachableResource = {
+  kind: 'workflows',
+  entityType: ShareableEntityType.WORKFLOW,
+
+  async describe(ids, workspaceId) {
+    const rows = await db.workflow.findMany({
+      where: { id: { in: ids }, workspaceId, ...WORKFLOWS_SCOPE },
+      select: { id: true, workflowName: true },
+    });
+    return rows.map(row => ({ id: row.id, name: row.workflowName ?? row.id }));
+  },
+};
+
+const ATTACHABLE_RESOURCES: readonly AttachableResource[] = [workflows];
+
+export const attachableResourceFor = (kind: string): AttachableResource | undefined =>
+  ATTACHABLE_RESOURCES.find(resource => resource.kind === kind);

--- a/apps/backend/src/apps/routes/apps.ts
+++ b/apps/backend/src/apps/routes/apps.ts
@@ -19,6 +19,7 @@ import { uploadMultiple, uploadConfig } from '@/middleware/upload';
 import { authMiddleware } from '@/middleware/auth';
 import { FlowController } from '../controllers/flowController';
 import { PermissionController } from '../controllers/permissionController';
+import { AppResourceController } from '../controllers/appResourceController';
 import { webhookLimiter } from '@/middleware/rateLimiters';
 import { PlatformAdapterRegistry } from '../platform-adapters/types';
 import { SlackAdapter } from '../platform-adapters/slack';
@@ -28,6 +29,7 @@ const appController = new AppController();
 const chatController = new ChatController();
 const flowController = new FlowController();
 const permissionController = new PermissionController();
+const appResourceController = new AppResourceController();
 const platformRegistry = new PlatformAdapterRegistry();
 
 platformRegistry.register(new SlackAdapter());
@@ -61,6 +63,8 @@ router.get('/installed/:installedAppId/permissions', authMiddleware.authenticate
 router.post('/installed/:installedAppId/permissions', authMiddleware.authenticate, authorize('XYNE-APPS', AccessType.WRITE), permissionController.setInstalledPermissions);
 router.post('/installed/:installedAppId/permissions/activate', authMiddleware.authenticate, authorize('XYNE-APPS', AccessType.WRITE), permissionController.activateInstalledPermissions);
 router.get('/installed/:installedAppId/commands', authMiddleware.authenticate, authorize('XYNE-APPS', AccessType.READ), commandController.getInstalledCommands);
+router.get('/installed/:installedAppId/resources/:resourceType', authMiddleware.authenticate, authorize('XYNE-APPS', AccessType.READ), appResourceController.listAttached);
+router.patch('/installed/:installedAppId/resources/:resourceType', authMiddleware.authenticate, authorize('XYNE-APPS', AccessType.ADMIN), appResourceController.setAttached);
 
 router.post('/incoming-webhooks', authMiddleware.authenticate, authorize('XYNE-APPS', AccessType.WRITE), incomingWebhookController.createWebhook);
 router.get('/incoming-webhooks/:installedAppId', authMiddleware.authenticate, authorize('XYNE-APPS', AccessType.READ), incomingWebhookController.listWebhooks);

--- a/apps/backend/src/database/repositories/entityAccessRepository.ts
+++ b/apps/backend/src/database/repositories/entityAccessRepository.ts
@@ -119,4 +119,43 @@ export class EntityAccessRepository {
       where: { shareableEntityType, entityId },
     });
   }
+
+  /**
+   * Removals run first: if the process dies between the two statements the caller has lost
+   * access rather than kept access it was meant to lose. Deliberately not a transaction —
+   * the ACL extension passes straight through inside one (`tenant/acl-extension.ts:188`),
+   * so staying outside keeps its scoping.
+   */
+  async applyDeltaForUser(params: {
+    workspaceId: string;
+    shareableEntityType: string;
+    userId: string;
+    added: string[];
+    removed: string[];
+    entityUserAccess: string;
+    metadata?: Prisma.InputJsonValue;
+  }): Promise<void> {
+    const { workspaceId, shareableEntityType, userId, added, removed, entityUserAccess, metadata } =
+      params;
+    const scope = { workspaceId, shareableEntityType, userId };
+
+    if (removed.length) {
+      await this.db.entityAccess.deleteMany({
+        where: { ...scope, entityId: { in: removed } },
+      });
+    }
+
+    if (added.length) {
+      await this.db.entityAccess.createMany({
+        data: added.map(entityId => ({
+          ...scope,
+          entityId,
+          entityUserAccess,
+          updatedAt: new Date(),
+          ...(metadata !== undefined ? { metadata } : {}),
+        })),
+        skipDuplicates: true,
+      });
+    }
+  }
 }

--- a/apps/backend/src/services/appResourceAccessService.ts
+++ b/apps/backend/src/services/appResourceAccessService.ts
@@ -1,0 +1,67 @@
+import { EntityUserAccess, type ShareableEntityType } from '@xyne/shared';
+import { repositories } from '@/database/repositories';
+
+/**
+ * Which individual resources an installed app may act on. Deny by default — no rows means
+ * no access. Grants are `entity_access` rows keyed on the `installedApps` id in the
+ * polymorphic `userId` column — NOT on the app's Spaces user, which `installApp` derives
+ * from a slug of the app name and then reuses by email, so two apps whose names slugify
+ * alike ("Deploy Bot" and "deploy_bot") share one user and would share every grant.
+ *
+ * An uninstall flow, when one exists, MUST delete these: install ids are not reissued, but
+ * a stale row would keep a deleted install's grant alive if one ever were.
+ */
+class AppResourceAccessService {
+  /**
+   * `findByKey`, never `entityAccessService.hasActiveShare` — that also matches group and
+   * channel grants, and the app's bot user is a real `User` that sits in channels, so
+   * anything shared with such a channel would silently become reachable.
+   */
+  async isAttached(params: {
+    workspaceId: string;
+    installedAppId: string;
+    entityType: ShareableEntityType;
+    entityId: string;
+  }): Promise<boolean> {
+    const grant = await repositories.entityAccess.findByKey({
+      workspaceId: params.workspaceId,
+      shareableEntityType: params.entityType,
+      entityId: params.entityId,
+      userId: params.installedAppId,
+    });
+    return grant !== null && grant.entityUserAccess !== EntityUserAccess.REVOKED;
+  }
+
+  async listAttachedIds(params: {
+    workspaceId: string;
+    installedAppId: string;
+    entityType: ShareableEntityType;
+  }): Promise<string[]> {
+    const grants = await repositories.entityAccess.findActiveByUser({
+      workspaceId: params.workspaceId,
+      shareableEntityType: params.entityType,
+      userId: params.installedAppId,
+    });
+    return grants.map(grant => grant.entityId);
+  }
+
+  /** VIEW always — the level is never read; {@link isAttached} tests presence. */
+  async applyAttachmentChanges(params: {
+    workspaceId: string;
+    installedAppId: string;
+    entityType: ShareableEntityType;
+    added: string[];
+    removed: string[];
+  }): Promise<void> {
+    await repositories.entityAccess.applyDeltaForUser({
+      workspaceId: params.workspaceId,
+      shareableEntityType: params.entityType,
+      userId: params.installedAppId,
+      added: params.added,
+      removed: params.removed,
+      entityUserAccess: EntityUserAccess.VIEW,
+    });
+  }
+}
+
+export const appResourceAccessService = new AppResourceAccessService();

--- a/apps/backend/src/workflowsV2/router.ts
+++ b/apps/backend/src/workflowsV2/router.ts
@@ -6,27 +6,45 @@
  * `RouteResponse` → Express response, in both directions, including SSE, binary and
  * redirects.
  *
- * Two routers come out, and the split matters:
- *  - `workflowsPublicRouter` — routes the SDK marks `authenticated: false`. Their
- *    authorization is a secret in the path, so they mount BEFORE the auth middleware.
- *  - `workflowsRouter` — everything else, mounted behind it.
+ * Two routers come out, and which route lands on which is decided HERE rather than by
+ * the SDK's own `authenticated` flag:
+ *  - `workflowsTriggerRouter` — the app-token trigger route. Mounted BEFORE the session
+ *    middleware, because an app JWT is signed with the app's secret and `authenticate`
+ *    cannot verify one.
+ *  - `workflowsRouter` — everything else, mounted behind the session.
+ *
+ * Nothing is exposed anonymously. See {@link APP_AUTH_ROUTES}.
  */
 import express, { type Request, type Response, type Router } from 'express';
 import { createWorkflowRouter, type RouteRequest } from '@xyne/workflow-sdk';
 import { logger } from '@/utils/logger';
 import { uploadConfig } from '@/middleware/upload';
-import { workflowRuntime } from './runtime';
+import { authenticateApp } from '@/apps/middelware/authenticator';
+import { webhookLimiter } from '@/middleware/rateLimiters';
+import { requirePermission } from '@/middleware/requirePermission';
+import { ShareableEntityType } from '@xyne/shared';
+import { appResourceAccessService } from '@/services/appResourceAccessService';
+import { persistence, workflowRuntime } from './runtime';
+import { attrsOf } from './utils';
 import type { XyneCtx } from './types';
 
 /**
- * A workflow or folder name must be a well-formed string.
- *
- * Ported from xyne-search, where a JSON object arrived here as `{"$ne":"test"}` — a
- * NoSQL-injection probe — and crashed the analytics UI on `name.toLowerCase()`. The
- * character set is deliberately conservative: it covers every real name while refusing
- * the shapes that turn a name into a payload.
+ * Route key → the path param naming the workflow it acts on. The only routes not behind
+ * the session: anything the SDK marks `authenticated: false` and absent here is mounted
+ * behind it anyway, so a new SDK public route fails closed. Re-check on an SDK bump.
  */
-const NAME_PATTERN = /^[A-Za-z0-9 _()+-]+$/;
+const APP_AUTH_ROUTES = new Map<string, string>([
+  ['POST /v2/workflows/:workflowId/trigger/v2', 'workflowId'],
+]);
+
+const routeKey = (method: string, path: string): string => `${method} ${path}`;
+
+/**
+ * Both are `available_app_permissions` rows — `scripts/seed-app-permissions.ts` seeds them
+ * locally, the 20260903000000 migration everywhere else, since nothing runs that on deploy.
+ */
+const scopeForMethod = (method: string): string =>
+  method.toUpperCase() === 'GET' ? 'workflows:read' : 'workflows:write';
 
 /**
  * The SDK is generic over the caller's ctx and never inspects it. Ours comes from the
@@ -50,18 +68,63 @@ const ctxFromRequest = (req: Request): XyneCtx => {
  */
 const ATTRIBUTE_INJECTED_ROUTES = new Set(['POST /workflows', 'POST /folders', 'POST /credentials']);
 
+/**
+ * The authorization the SDK skips: the handler discards its `auth` and calls
+ * `triggerWebhookV2Public`, which by its own documentation "intentionally bypasses caller
+ * authorization". The workflow must be in the caller's workspace AND attached to this app.
+ *
+ * Both lookups always run, so "no such workflow", "not yours" and "not attached" give the
+ * same 404 at the same cost and cannot be told apart.
+ */
+const installedAppIdOf = (req: Request): string | null => {
+  const auth = (req as { auth?: { installedAppId?: unknown } }).auth;
+  return typeof auth?.installedAppId === 'string' ? auth.installedAppId : null;
+};
+
+const assertTriggerableWorkflow = async (
+  req: Request,
+  ctx: XyneCtx,
+  param: string,
+): Promise<void> => {
+  const workflowId = req.params[param];
+  const installedAppId = installedAppIdOf(req);
+  const [workflow, attached] = await Promise.all([
+    workflowId ? persistence.getWorkflow(workflowId) : Promise.resolve(null),
+    workflowId && installedAppId
+      ? appResourceAccessService.isAttached({
+          workspaceId: ctx.workspaceId,
+          installedAppId,
+          entityType: ShareableEntityType.WORKFLOW,
+          entityId: workflowId,
+        })
+      : Promise.resolve(false),
+  ]);
+
+  const ownedByCaller =
+    workflow !== null && attrsOf(workflow.attributes)?.workspaceId === ctx.workspaceId;
+
+  if (ownedByCaller && !attached) {
+    // A bare 404 and the wrapper only logs at 5xx, so this is the only trace an admin gets.
+    logger.warn(
+      `[workflows] install ${String(installedAppId)} is not attached to workflow ${String(workflowId)}`,
+    );
+  }
+
+  if (!ownedByCaller || !attached) {
+    throw Object.assign(new Error('Workflow not found'), { statusCode: 404 });
+  }
+};
+
 const buildRouteRequest = (req: Request): RouteRequest => {
   const body: unknown = req.body;
 
+  // Ported from xyne-search, where `{"$ne":"test"}` arrived as a name and crashed the UI on
+  // `name.toLowerCase()`. Only the type is wrong there — the value itself is inert, and is
+  // stored as JSON and rendered by React.
   if (body && typeof body === 'object' && !Array.isArray(body) && 'name' in body) {
     const rawName = (body as Record<string, unknown>)['name'];
-    if (rawName !== undefined && rawName !== null) {
-      if (typeof rawName !== 'string' || !NAME_PATTERN.test(rawName)) {
-        throw Object.assign(
-          new Error('`name` may contain only letters, digits, spaces, and _ ( ) + -'),
-          { statusCode: 400 },
-        );
-      }
+    if (rawName !== undefined && rawName !== null && typeof rawName !== 'string') {
+      throw Object.assign(new Error('`name` must be a string'), { statusCode: 400 });
     }
   }
 
@@ -127,33 +190,41 @@ const sendRouteResponse = async (
   res.status(response.status).json(response.body);
 };
 
-const mount = (router: Router, authenticated: boolean): void => {
-  const routes = createWorkflowRouter<XyneCtx>(workflowRuntime, {
-    // Only consulted for unauthenticated routes, whose authorization is a path secret —
-    // so reaching it at all means a route was misclassified.
+export const workflowRouteDefinitions = (): ReturnType<typeof createWorkflowRouter<XyneCtx>> =>
+  createWorkflowRouter<XyneCtx>(workflowRuntime, {
+    // Never reached: every route is mounted behind Express middleware that establishes the
+    // principal, so the SDK is never asked to authenticate one itself.
     authenticate: () => {
       throw Object.assign(new Error('Unauthorized'), { statusCode: 401 });
     },
   });
 
-  for (const route of routes) {
-    const isPublic = route.authenticated === false;
-    if (isPublic !== !authenticated) continue;
+const mount = (router: Router, appAuth: boolean): void => {
+  for (const route of workflowRouteDefinitions()) {
+    const key = routeKey(route.method, route.path);
+    const workflowIdParam = APP_AUTH_ROUTES.get(key);
+    if (Boolean(workflowIdParam) !== appAuth) continue;
 
     const method = route.method.toLowerCase() as 'get' | 'post' | 'put' | 'delete';
-    const key = `${route.method} ${route.path}`;
 
-    // The SDK tells us which routes need a multipart parser; run multer only there so
-    // ordinary JSON routes are untouched.
-    const middleware = route.multipart ? [uploadConfig.any()] : [];
+    // Order is load-bearing: the guard runs before multer, so an unauthenticated upload
+    // is refused without buffering a byte of it.
+    const middleware = [
+      ...(appAuth
+        ? [webhookLimiter, authenticateApp, requirePermission(scopeForMethod(route.method))]
+        : []),
+      ...(route.multipart ? [uploadConfig.any()] : []),
+    ];
 
     router[method](route.path, ...middleware, (req: Request, res: Response) => {
       void (async () => {
         try {
-          const ctx = authenticated ? ctxFromRequest(req) : null;
+          const ctx = ctxFromRequest(req);
+          if (workflowIdParam) await assertTriggerableWorkflow(req, ctx, workflowIdParam);
+
           const routeRequest = buildRouteRequest(req);
 
-          if (ctx && ATTRIBUTE_INJECTED_ROUTES.has(key)) {
+          if (ATTRIBUTE_INJECTED_ROUTES.has(key)) {
             const body = (routeRequest.body ?? {}) as Record<string, unknown>;
             body['attributes'] = { workspaceId: ctx.workspaceId, createdByUserId: ctx.userId };
             (routeRequest as { body: unknown }).body = body;
@@ -175,8 +246,10 @@ const mount = (router: Router, authenticated: boolean): void => {
   }
 };
 
-export const workflowsRouter: Router = express.Router();
-mount(workflowsRouter, true);
+/** Mounted before the session middleware — registers only {@link APP_AUTH_ROUTES}, so
+ *  every other request falls through to `workflowsRouter`. */
+export const workflowsTriggerRouter: Router = express.Router();
+mount(workflowsTriggerRouter, true);
 
-export const workflowsPublicRouter: Router = express.Router();
-mount(workflowsPublicRouter, false);
+export const workflowsRouter: Router = express.Router();
+mount(workflowsRouter, false);

--- a/apps/dashboard/src/components/Apps/EditAppForm/AppResourceSection.tsx
+++ b/apps/dashboard/src/components/Apps/EditAppForm/AppResourceSection.tsx
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useState, type ReactElement } from 'react';
+import { toast } from 'sonner';
+import { Button } from '../../ui/Button/Button';
+import { EntityMultiSelector } from '../../ui/EntitySelector/EntityMultiSelector';
+import type { SelectorOption } from '../../ui/EntitySelector/EntitySelector.types';
+import { appsService, type AttachedResource } from '../../../services/Apps/appsService';
+import { cn } from '../../../utils/classNames';
+
+interface AppResourceSectionProps {
+  installedAppId: string;
+  /** Backend `attachableResources` kind — the URL segment. */
+  resourceType: string;
+  /** Plural, lowercase, for the prose: "workflows", "projects". */
+  noun: string;
+  /** Omitted when read-only, so the full inventory is never fetched. */
+  loadOptions?: () => Promise<AttachedResource[]>;
+  requiredPermission: string;
+  readOnly?: boolean;
+}
+
+/**
+ * Generic over `resourceType`, like the storage and routes behind it — a second kind is a
+ * registry entry and another instance of this, not another screen.
+ *
+ * Read-only never fetches the inventory: someone with only XYNE-APPS READ should see what
+ * an app is attached to without being handed a list of everything that exists.
+ */
+export const AppResourceSection = ({
+  installedAppId,
+  resourceType,
+  noun,
+  loadOptions,
+  requiredPermission,
+  readOnly = false,
+}: AppResourceSectionProps): ReactElement => {
+  const [attached, setAttached] = useState<AttachedResource[]>([]);
+  /** What the server had at load — the delta is measured against this, not the options. */
+  const [baseline, setBaseline] = useState<string[]>([]);
+  const [options, setOptions] = useState<AttachedResource[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async (): Promise<void> => {
+      try {
+        const current = await appsService.getInstalledResources(installedAppId, resourceType);
+        const all = readOnly || !loadOptions ? [] : await loadOptions();
+        if (cancelled) return;
+        const currentIds = current.map(item => item.id);
+        setAttached(current);
+        setOptions(all);
+        setSelected(currentIds);
+        setBaseline(currentIds);
+      } catch {
+        if (!cancelled) toast.error(`Could not load attached ${noun}`);
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    };
+    void load();
+    return (): void => {
+      cancelled = true;
+    };
+  }, [installedAppId, resourceType, noun, readOnly, loadOptions]);
+
+  const added = selected.filter(id => !baseline.includes(id));
+  const removed = baseline.filter(id => !selected.includes(id));
+  const dirty = added.length > 0 || removed.length > 0;
+
+  const handleSave = useCallback(async (): Promise<void> => {
+    setSaving(true);
+    try {
+      const items = await appsService.updateInstalledResources(installedAppId, resourceType, {
+        added,
+        removed,
+      });
+      const ids = items.map(item => item.id);
+      setAttached(items);
+      setSelected(ids);
+      setBaseline(ids);
+      toast.success(`Updated the ${noun} this app can use`);
+    } catch {
+      toast.error(`Could not update ${noun}`);
+    } finally {
+      setSaving(false);
+    }
+  }, [installedAppId, resourceType, noun, added, removed]);
+
+  const selectorOptions: SelectorOption[] = options.map(item => ({
+    value: item.id,
+    label: item.name,
+    icon: null,
+  }));
+
+  // Attached items outside the fetched options still resolve, so a chip never falls back
+  // to a bare id just because the inventory was truncated.
+  const nameById = new Map([...options, ...attached].map(item => [item.id, item.name]));
+  const chips = (readOnly ? attached.map(item => item.id) : selected).map(id => ({
+    id,
+    name: nameById.get(id) ?? id,
+  }));
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <div className='flex items-center justify-between gap-2 flex-wrap'>
+        <h3 className='text-sm font-medium capitalize'>{noun}</h3>
+        <div className='flex items-center gap-2'>
+          <span className='text-xs text-muted-foreground'>
+            {selected.length} attached
+            {dirty ? ` · +${added.length} / −${removed.length}` : ''}
+          </span>
+          {!readOnly && (
+            <Button
+              type='button'
+              size='sm'
+              variant='outline'
+              className='h-7 text-xs'
+              onClick={() => void handleSave()}
+              disabled={saving || !loaded || !dirty}
+              data-track-category='Apps'
+              data-track-name='SaveAppResourceAccess'
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <p className='text-[11px] leading-snug text-muted-foreground bg-muted/40 border border-border rounded-md px-2.5 py-2'>
+        This app can only use the {noun} listed here, and changes take effect immediately — there is
+        nothing to activate. It also needs the{' '}
+        <code className='font-mono'>{requiredPermission}</code> permission, which an app update can
+        reset.
+      </p>
+
+      {!loaded ? (
+        <p className='text-xs text-muted-foreground'>Loading…</p>
+      ) : (
+        <div className={cn('grid gap-4 items-start', !readOnly && 'md:grid-cols-2')}>
+          {!readOnly && (
+            <EntityMultiSelector
+              options={selectorOptions}
+              selectedValues={selected}
+              onMultiSelect={setSelected}
+              placeholder={`Select ${noun}…`}
+              searchPlaceholder={`Search ${noun}`}
+              showSearch
+              collapseSelectedAfter={0}
+              collapsedLabel={noun}
+            />
+          )}
+
+          <div className='flex flex-col gap-2 min-w-0'>
+            <h4 className='text-xs font-medium text-muted-foreground'>
+              {dirty ? 'Selected' : 'Attached'} ({chips.length})
+            </h4>
+            {chips.length === 0 ? (
+              <p className='text-xs text-muted-foreground'>
+                No {noun} attached. This app cannot use any {noun}.
+              </p>
+            ) : (
+              <div className='flex flex-wrap gap-1.5'>
+                {chips.map(chip => (
+                  <span
+                    key={chip.id}
+                    className='text-xs bg-muted border border-border rounded px-2 py-0.5 max-w-full truncate'
+                    title={chip.name}
+                  >
+                    {chip.name}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/Apps/EditAppForm/EditAppForm.tsx
+++ b/apps/dashboard/src/components/Apps/EditAppForm/EditAppForm.tsx
@@ -1,6 +1,8 @@
 import { type ReactElement, useMemo, useEffect, useRef, useState, useCallback } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { Button } from '../../ui/Button/Button';
+import { AppResourceSection } from './AppResourceSection';
+import { ATTACHABLE_RESOURCES } from './attachableResources';
 import Input from '../../ui/Input/Input';
 import Textarea from '../../ui/Textarea/Textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../ui/Select';
@@ -22,6 +24,7 @@ import {
   Info,
   Command,
   Shield,
+  Boxes,
   Link2,
 } from 'lucide-react';
 import { cn } from '../../../utils/classNames';
@@ -858,7 +861,7 @@ function WebhookNameInput({
 
 // ─── Sectioned navigation ─────────────────────────────────────────────────────
 
-type EditAppSection = 'basic' | 'commands' | 'shortcuts' | 'permissions' | 'incoming';
+type EditAppSection = 'basic' | 'commands' | 'shortcuts' | 'permissions' | 'resources' | 'incoming';
 
 interface EditAppNavItem {
   id: EditAppSection;
@@ -1258,6 +1261,16 @@ export const EditAppForm = ({
     { id: 'commands', label: 'Commands', icon: <Command className='size-4' /> },
     { id: 'shortcuts', label: 'Shortcuts', icon: <Zap className='size-4' /> },
     { id: 'permissions', label: 'Permissions', icon: <Shield className='size-4' /> },
+    // Attachments are per-install, like incoming webhooks — meaningless on the template.
+    ...(isInstallMode
+      ? [
+          {
+            id: 'resources' as const,
+            label: 'Resource access',
+            icon: <Boxes className='size-4' />,
+          },
+        ]
+      : []),
     ...(showIncomingSection
       ? [
           {
@@ -1956,6 +1969,22 @@ export const EditAppForm = ({
                   ))}
                 </div>
               )}
+            </div>
+          )}
+
+          {activeSection === 'resources' && installedAppId && (
+            <div className='flex flex-col gap-6'>
+              {ATTACHABLE_RESOURCES.map(resource => (
+                <AppResourceSection
+                  key={resource.resourceType}
+                  installedAppId={installedAppId}
+                  resourceType={resource.resourceType}
+                  noun={resource.noun}
+                  requiredPermission={resource.requiredPermission}
+                  loadOptions={resource.loadOptions}
+                  readOnly={!canEditInstallSettings}
+                />
+              ))}
             </div>
           )}
 

--- a/apps/dashboard/src/components/Apps/EditAppForm/attachableResources.ts
+++ b/apps/dashboard/src/components/Apps/EditAppForm/attachableResources.ts
@@ -1,0 +1,49 @@
+import { apiInstance } from '../../../services/clients/apiClient';
+import type { AttachedResource } from '../../../services/Apps/appsService';
+
+/**
+ * Client half of the backend's `attachableResources` registry. `resourceType` must match
+ * the backend entry — it is the URL segment. `EditAppForm` renders whatever this holds.
+ */
+export interface AttachableResourceConfig {
+  resourceType: string;
+  /** Plural, lowercase, used in the section's prose. */
+  noun: string;
+  /** The scope the app additionally needs to use the resource at all. */
+  requiredPermission: string;
+  loadOptions: () => Promise<AttachedResource[]>;
+}
+
+/** Workflow names live in the SDK's `metadata` JSON, mirroring the backend's reader. */
+const readWorkflowName = (metadata: string | null, fallback: string): string => {
+  if (!metadata) return fallback;
+  try {
+    const parsed = JSON.parse(metadata) as { name?: unknown };
+    return typeof parsed.name === 'string' && parsed.name ? parsed.name : fallback;
+  } catch {
+    return fallback;
+  }
+};
+
+interface SdkWorkflow {
+  id: string;
+  metadata: string | null;
+}
+
+export const ATTACHABLE_RESOURCES: AttachableResourceConfig[] = [
+  {
+    resourceType: 'workflows',
+    noun: 'workflows',
+    requiredPermission: 'workflows:write',
+    async loadOptions(): Promise<AttachedResource[]> {
+      const response = await apiInstance.get<{ workflows: SdkWorkflow[] }>(
+        '/workflows-v2/workflows',
+        { params: { limit: 500 } },
+      );
+      return response.data.workflows.map(workflow => ({
+        id: workflow.id,
+        name: readWorkflowName(workflow.metadata, workflow.id),
+      }));
+    },
+  },
+];

--- a/apps/dashboard/src/services/Apps/appsService.ts
+++ b/apps/dashboard/src/services/Apps/appsService.ts
@@ -26,6 +26,11 @@ export interface UpdateAppRequest {
   webhookUrl?: string;
 }
 
+export interface AttachedResource {
+  id: string;
+  name: string;
+}
+
 export interface BotChannel {
   id: string;
   name: string;
@@ -470,6 +475,38 @@ export class AppsService {
    */
   async activateInstalledPermissions(installedAppId: string): Promise<void> {
     await apiInstance.post(`/apps/installed/${installedAppId}/permissions/activate`);
+  }
+
+  /**
+   * Individual resources this install may act on — see the backend's
+   * `attachableResources` registry for the kinds. Absent from the list means the app
+   * cannot act on it; there is no approval step, changes take effect immediately.
+   */
+  async getInstalledResources(
+    installedAppId: string,
+    resourceType: string,
+  ): Promise<AttachedResource[]> {
+    const response = await apiInstance.get<{ items: AttachedResource[] }>(
+      `/apps/installed/${installedAppId}/resources/${resourceType}`,
+    );
+    return response.data.items;
+  }
+
+  /**
+   * Apply just what the admin changed. A delta rather than the whole set, so a resource
+   * attached by someone else while this page was open is not silently dropped. Returns
+   * the attached set as the server now sees it.
+   */
+  async updateInstalledResources(
+    installedAppId: string,
+    resourceType: string,
+    changes: { added: string[]; removed: string[] },
+  ): Promise<AttachedResource[]> {
+    const response = await apiInstance.patch<{ items: AttachedResource[] }>(
+      `/apps/installed/${installedAppId}/resources/${resourceType}`,
+      changes,
+    );
+    return response.data.items;
   }
 
   /** Read-only snapshot of the install's commands/shortcuts. */

--- a/apps/dashboard/src/styles/workflow-ui-theme.css
+++ b/apps/dashboard/src/styles/workflow-ui-theme.css
@@ -1,3 +1,12 @@
+/*
+ * Layered, not plainly imported. The package ships its own unscoped Tailwind build, so its
+ * `.flex-col` and `.border-b` used to land after ours and beat the variants that override
+ * them — `md:flex-row`, `md:border-b-0` — collapsing every two-column layout in the app.
+ * Unlayered CSS always beats layered, so this holds regardless of import order.
+ */
+@layer workflow-ui;
+@import '@xyne/workflow-ui/styles.css' layer(workflow-ui);
+
 /**
  * Theme bridge for @xyne/workflow-ui.
  *

--- a/packages/shared/src/zero/types.ts
+++ b/packages/shared/src/zero/types.ts
@@ -1197,6 +1197,7 @@ export enum WorkflowMappingEntityType {
 export const ShareableEntityType = {
   NOTE_TAKER: 'NOTE_TAKER',
   SUMMARY_TEMPLATE: 'SUMMARY_TEMPLATE',
+  WORKFLOW: 'WORKFLOW',
   CALL: 'CALL',
 } as const;
 


### PR DESCRIPTION
Migration-Changes:
  - added scopes

Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
