### PR TITLE
fix: XYNE-sandbox stream sandbox-copy-in to avoid 413 on large tool-results

### DIFF
--- a/packages/xyne-claw-shared/src/tools/sandbox/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/sandbox/tools.ts
@@ -7,7 +7,7 @@ import { redactSecrets, redactAndStringify } from "./redact.js";
 import { rotateTemplate, isSameTemplateFamily } from "./template-rotation.js";
 import { formatSandboxUnavailable, isSandboxUnavailableDeferEnabled } from "./unavailable-signal.js";
 import { createLogger } from "../../logger.js";
-import { readFile } from "node:fs/promises";
+import { createReadStream } from "node:fs";
 import { resolve, join, sep } from "node:path";
 import {
   cleanupSdlcGitCredentialMaterial,
@@ -1235,9 +1235,20 @@ export const sandboxCopyIn: ToolDefinition = {
     if (roWrite) return roWrite;
 
     try {
-      const buf = await readFile(sourceAbs);
-      await session.files.write(destPath, buf);
-      return JSON.stringify({ sourcePath: relPath, destPath, bytes: buf.length, copied: true });
+      // Stream the file in bounded chunks instead of one base64 JSON POST.
+      // A whole-file write() base64-inflates the payload ~1.33x into a single
+      // /write body, which the sandbox workspace server rejects with
+      // "request entity too large" for large spilled MCP results (observed at
+      // ~486 KB raw -> ~650 KB body). writeStream reuses the same /write
+      // endpoint per chunk and appends server-side, so no single request is
+      // large and no workspace-image change is needed. 256 KiB keeps a clear
+      // margin under the observed cap.
+      const { bytesWritten } = await session.files.writeStream(
+        destPath,
+        createReadStream(sourceAbs),
+        { chunkBytes: 256 * 1024 },
+      );
+      return JSON.stringify({ sourcePath: relPath, destPath, bytes: bytesWritten, copied: true });
     } catch (err) {
       if (isStaleSessionError(err)) {
         evictSession(session);


### PR DESCRIPTION
## Problem
`sandbox-copy-in` (contextPath) read the whole source file and sent it as a single base64 JSON POST to the sandbox `/write` endpoint. For a large spilled MCP result (~486 KB raw → ~650 KB base64 body) the sandbox workspace server rejects it with `Error: request entity too large`, so forwarding a big tool-result into the sandbox for processing fails — exactly the PI Alerts exhaustive-table case.

## Fix
Switch the copy path from the one-shot `FilesystemModule.write()` to the existing `FilesystemModule.writeStream()`, which splits the source into bounded **256 KiB** chunks over the same `/write` endpoint and appends them server-side (`cat >> dest && rm part`). No single request is large, so the 413 goes away — and it needs no workspace-image change and no sandbox egress. This is the same pattern already used by the video-explainer composer and record-skill to fix the identical 413.

## Scope
- `packages/xyne-claw-shared/src/tools/sandbox/tools.ts`: `sandboxCopyIn.execute` now streams via `writeStream(createReadStream(sourceAbs), { chunkBytes: 256 * 1024 })`; removed the now-unused `readFile` import; added `createReadStream`.

## Validation
- `tsc --noEmit` passes for `xyne-claw-shared`.
- `vitest run` green for `copy-in.test.ts` (17) and `record-skill/streaming-write.test.ts` (2). The chunking mechanism itself is covered by `streaming-write.test`.

## Notes / follow-ups
- 256 KiB gives a clear margin under the observed ~650 KB failing body.
- Independent of this, server-side filtering on the Alerts MCP (filter by `metadata.classification` + column projection/pagination) would keep the payload small enough to never spill — the durable fix for that specific request.
