### PR TITLE
fix: XYNE-63232 emit MESSAGE_RECEIVED on message update

### DIFF
--- a/apps/backend/src/automations/engine/event-router.ts
+++ b/apps/backend/src/automations/engine/event-router.ts
@@ -6,9 +6,12 @@ import { currentUpstreamChain } from './automation-context-storage';
 import {
   AUTOMATION_WORKFLOW_TYPE,
   DESK_AUTOMATION_WORKFLOW_TYPE,
+  parseAutomationConfig,
   parseAutomationMetadata,
   triggerTypeToEventType,
 } from '../types/workflow-adapter';
+import { triggerRegistry } from '../triggers/trigger-registry';
+import type { TriggerType } from '../types/trigger-types';
 import { AutomationStatus, AutomationRunStatus } from '../types/status';
 import { automationQueue } from '../queue/automation.queue';
 import type { AutomationEvent } from '../types/automation-events';
@@ -33,13 +36,24 @@ class EventRouter {
     for (const workflow of candidates) {
       try {
         const metadata = parseAutomationMetadata(workflow.metadata);
+
+        const triggerImpl = triggerRegistry.has(event.type as TriggerType)
+          ? triggerRegistry.get(event.type as TriggerType)
+          : null;
+        const triggerConfig = (parseAutomationConfig(workflow.context).trigger.config ?? {}) as Record<
+          string,
+          unknown
+        >;
+        const data =
+          triggerImpl?.projectPayload?.(triggerConfig, payload as unknown as Record<string, unknown>) ??
+          payload;
         const initialContext = {
           automation: {
             id: workflow.id,
             workspaceId: workflow.workspaceId,
             createdById: metadata.createdById,
           },
-          trigger: { type: eventType, ...payload, data: payload },
+          trigger: { type: eventType, ...data, data },
           steps: {},
           __meta: { error: null, chain },
         };

--- a/apps/backend/src/automations/triggers/base-trigger.ts
+++ b/apps/backend/src/automations/triggers/base-trigger.ts
@@ -19,6 +19,11 @@ export abstract class BaseTrigger<TConfig extends z.ZodSchema> {
 
   hydratePayload?(payload: Record<string, unknown>): Promise<Record<string, unknown>>;
 
+  projectPayload?(
+    config: Record<string, unknown>,
+    payload: Record<string, unknown>,
+  ): Record<string, unknown>;
+
   matchFilters(filter: Record<string, unknown>, payload: Record<string, unknown>): boolean {
     void filter;
     void payload;

--- a/apps/backend/src/automations/triggers/message-received.trigger.ts
+++ b/apps/backend/src/automations/triggers/message-received.trigger.ts
@@ -39,6 +39,12 @@ const MessageReceivedConfigSchema = z.object({
     .array(z.string())
     .optional()
     .describe('Only fire when at least one of these user groups is mentioned. Empty matches any group mention; omit entirely to not filter on group mentions.'),
+  fireOnEdit: z
+    .boolean()
+    .default(false)
+    .describe(
+      'Also fire when an existing message is edited into a match — e.g. an alert card whose status field is rewritten in place. Only the transition fires: an edit that leaves an already-matching message still matching is ignored. Needs a Content Contains value to be meaningful.',
+    ),
 });
 
 export const MessageReceivedOutputSchema = z.object({
@@ -62,6 +68,8 @@ export const MessageReceivedOutputSchema = z.object({
   conversationId: z.string(),
   msgType: z.nativeEnum(MessageType),
   deleted: z.boolean(),
+  isEdit: z.boolean().optional(),
+  previousContentMatched: z.boolean().optional(),
   mentionedUsers: z
     .array(
       z.object({
@@ -106,6 +114,23 @@ export class MessageReceivedTrigger extends BaseTrigger<typeof MessageReceivedCo
     return hydrateMessageReceivedPayload(payload as unknown as MessageReceivedEventPayload);
   }
 
+  /**
+   * Drop the pre-edit body and keep only whether it already satisfied this
+   * automation's content filter. The body itself is never persisted or logged.
+   */
+  override projectPayload(
+    config: Record<string, unknown>,
+    payload: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const { previousContent, ...rest } = payload as { previousContent?: string };
+    if (previousContent === undefined) return rest;
+    const needle = (config as MessageReceivedConfig).contentContains;
+    return {
+      ...rest,
+      previousContentMatched: !!needle && previousContent.toLowerCase().includes(needle.toLowerCase()),
+    };
+  }
+
   override matchFilters(
     filter: Record<string, unknown>,
     payload: Record<string, unknown>,
@@ -115,6 +140,8 @@ export class MessageReceivedTrigger extends BaseTrigger<typeof MessageReceivedCo
 
     // The message was deleted before we got to run — nothing to act on.
     if (p.deleted) return false;
+    // Edits reach every candidate; only automations that opted in act on them.
+    if (p.isEdit && !cfg.fireOnEdit) return false;
     if (cfg.messageTypes && cfg.messageTypes.length > 0) {
       if (!cfg.messageTypes.includes(p.msgType)) return false;
     }
@@ -146,8 +173,11 @@ export class MessageReceivedTrigger extends BaseTrigger<typeof MessageReceivedCo
         // Decoded text and the stored blob: a filter written against a FlowJSON
         // card title or button label must keep firing after the decode.
         const needle = cfg.contentContains!.toLowerCase();
-        const contentPasses = [p.message.content, p.message.rawContent]
+        const nowMatches = [p.message.content, p.message.rawContent]
           .some(text => !!text && text.toLowerCase().includes(needle));
+        // On an edit only the transition counts — an edit that leaves an
+        // already-matching message still matching must not re-run the automation.
+        const contentPasses = p.isEdit ? nowMatches && !p.previousContentMatched : nowMatches;
         matchResults.push(contentPasses);
       }
 
@@ -199,6 +229,8 @@ interface ReceivedMessage {
   channelId: string;
   msgType?: MessageType | undefined;
   userId: string;
+  isEdit?: boolean;
+  previousContent?: string;
 }
 
 /**
@@ -224,6 +256,10 @@ export async function emitMessageReceived(message: ReceivedMessage): Promise<voi
           channelId: message.channelId,
           authorId: message.userId,
           msgType: message.msgType ?? MessageType.USER,
+          ...(message.isEdit ? { isEdit: true } : {}),
+          ...(message.previousContent !== undefined
+            ? { previousContent: message.previousContent }
+            : {}),
         },
       },
       channel.workspaceId,

--- a/apps/backend/src/automations/types/automation-events.ts
+++ b/apps/backend/src/automations/types/automation-events.ts
@@ -44,6 +44,8 @@ export interface MessageReceivedEventPayload {
   channelId: string;
   authorId: string;
   msgType: MessageType;
+  isEdit?: boolean;
+  previousContent?: string;
 }
 
 export interface CallEventPayload {

--- a/apps/backend/src/zero/side-effects/tables/messages-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/messages-handler.ts
@@ -2173,7 +2173,27 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
         previousValue.conversationId,
         previousValue.isThreadReply,
       );
-    } else if (currentMessage.edited && currentMessage.content !== previousValue.content && !currentMessage.isDeleted) {
+    }
+
+    if (
+      !currentMessage.isDeleted &&
+      previousValue.content !== undefined &&
+      currentMessage.content !== previousValue.content &&
+      !previousValue.isThreadReply &&
+      previousValue.channelId
+    ) {
+      void emitMessageReceived({
+        messageId: previousValue.messageId,
+        conversationId: previousValue.conversationId,
+        channelId: previousValue.channelId,
+        msgType: previousValue.msgType as MessageType,
+        userId: previousValue.senderId,
+        isEdit: true,
+        previousContent: previousValue.content,
+      });
+    }
+
+    if (currentMessage.edited && currentMessage.content !== previousValue.content && !currentMessage.isDeleted) {
       if (touchesArtifact) await syncMessageArtifact(db, previousValue.messageId);
       await this.sendMessageChangeNotifications(
         NotificationType.MESSAGE_EDITED,


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
