### PR TITLE
fix: XYNE-61830 stop keying a stored preference on the ?track= param

### DIFF
--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -473,8 +473,11 @@ export default function SdlcScreen(): ReactElement {
     ? (finderPathByTrack[selectedTrackId] ?? [])
     : [];
   const setFinderPath = (next: SdlcFinderStep[]): void => {
-    if (!selectedTrackId) return;
-    setUserPreference('sdlcFinderPathByTrack', { ...finderPathByTrack, [selectedTrackId]: next });
+    // Keyed by a track we know, never by the ?track= value directly: the param is
+    // reader-supplied, and it would otherwise name any property it liked.
+    const track = tracks.find(item => item.id === selectedTrackId);
+    if (!track) return;
+    setUserPreference('sdlcFinderPathByTrack', { ...finderPathByTrack, [track.id]: next });
   };
   useEffect(() => {
     setPreviewCanvasId(null);


### PR DESCRIPTION
Follow-up to #1754, which is merged. CodeQL raised `js/remote-property-injection` (alert 2379) against the folder work.

## The finding

`setFinderPath` wrote the `sdlcFinderPathByTrack` preference under the track id taken straight from the query string:

```ts
const selectedTrackId = routeSearchParams.get('track');
...
setUserPreference('sdlcFinderPathByTrack', { ...finderPathByTrack, [selectedTrackId]: next });
```

So a reader-supplied value named the property being written. CodeQL's data flow is accurate.

## How bad it actually was

Not prototype pollution. A computed key in an object literal defines an *own* property — `{ ['__proto__']: x }` does not assign the prototype, only the non-computed literal form does. And the destination is the reader's own IndexedDB preference store, not shared or server-side state.

So the reachable impact was a stray key in the reader's own preferences, plus unbounded growth of that object from any URL carrying a `?track=`.

Low, but it is still the wrong source for a key.

## The change

The path is keyed off a track we actually loaded rather than off the param:

```ts
const track = tracks.find(item => item.id === selectedTrackId);
if (!track) return;
setUserPreference('sdlcFinderPathByTrack', { ...finderPathByTrack, [track.id]: next });
```

That is also what it meant all along — a stored finder path for a track that does not exist is not worth keeping, and this stops the object growing from stray URLs.

## Verification

Stepping into a folder still persists the path across a page reload, which is the only behaviour this function has: two finder columns before, after stepping in, and after reloading.

Green: dashboard typecheck, `prettier --check "src/**/*"`, `eslint . --quiet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPBJtAza2gBg54qfRDv3t7