### PR TITLE
feat: XYNE-59714 ask ai

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -47,7 +47,7 @@ import userAssignmentStateRoutes from '@/routes/userAssignmentState';
 import { UserManagementController } from '@/controllers/userManagementController';
 import { registerAllWorkflows } from '@/workflows';
 import workflowRoutes from '@/routes/workflows';
-import { workflowsRouter } from '@/workflowsV2/router';
+import { workflowsClawRouter, workflowsRouter } from '@/workflowsV2/router';
 import { configSyncService } from '@/services/configSyncService';
 import { websocketService } from '@/services/websocketService';
 import { redisService } from '@/services/redisService';
@@ -489,6 +489,7 @@ export class App {
       aclMiddleware.checkAccess,
       workflowRoutes
     );
+    this.app.use('/api/workflows-v2/claw', authenticateUserOrApp, workflowsClawRouter);
     this.app.use('/api/workflows-v2', authMiddleware.authenticate, workflowsRouter);
     this.app.use('/api/tools', authMiddleware.authenticate, aclMiddleware.checkAccess, toolRoutes);
     this.app.use(

--- a/apps/backend/src/controllers/xyneAIControllerV2.ts
+++ b/apps/backend/src/controllers/xyneAIControllerV2.ts
@@ -94,6 +94,13 @@ const XyneAIRequestSchemaV2 = z.object({
   conversation_id: z.preprocess(emptyToUndefined, z.string().optional()),
   canvasId: z.string().optional(),
   canvas_id: z.string().optional(),
+  workflowContext: z
+    .object({
+      workflowId: z.string().min(1).nullish(),
+      executionId: z.string().min(1).nullish(),
+      stepId: z.string().min(1).nullish(),
+    })
+    .optional(),
   // Legacy aliases for canvasId (pre-XYNE-17290). Merged into canvasId below.
   canvasViewAccessId: z.string().optional(),
   canvas_view_access_id: z.string().optional(),
@@ -254,6 +261,7 @@ export class XyneAIControllerV2 {
       canvas_id,
       canvasViewAccessId,
       canvas_view_access_id,
+      workflowContext,
       createCanvasEnabled: createCanvasEnabledCC,
       create_canvas_enabled: createCanvasEnabledSC,
       webSearchEnabled: webSearchEnabledCC,
@@ -610,6 +618,7 @@ export class XyneAIControllerV2 {
           ticketIds: effectiveTicketIds,
           callIds: effectiveCallIds,
           ...(effectiveCanvasId && { canvasId: effectiveCanvasId }),
+          ...(workflowContext && { workflowContext }),
           attachedContext: mergedAttachedContext,
           attachments,
           messageAttachmentIds,

--- a/apps/backend/src/services/clawAgentService.ts
+++ b/apps/backend/src/services/clawAgentService.ts
@@ -96,6 +96,11 @@ export interface ClawRunRequest {
   dataSourceId?: string;
   draftId?: string;
   focusedComponentId?: string;
+  workflowContext?: {
+    workflowId?: string | null;
+    executionId?: string | null;
+    stepId?: string | null;
+  };
   /** Generate contextual next-question chips for this response. Ask AI v2
    *  enables this explicitly for every agent slug. */
   generateFollowUpSuggestions?: boolean;
@@ -632,6 +637,15 @@ export async function runClawAgentStream(
       ...(request.draftId && { SPACES_DASHBOARD_DRAFT_ID: request.draftId }),
       ...(request.focusedComponentId && {
         SPACES_FOCUSED_COMPONENT_ID: request.focusedComponentId,
+      }),
+      ...(request.workflowContext?.workflowId && {
+        SPACES_WORKFLOW_ID: request.workflowContext.workflowId,
+      }),
+      ...(request.workflowContext?.executionId && {
+        SPACES_WORKFLOW_EXECUTION_ID: request.workflowContext.executionId,
+      }),
+      ...(request.workflowContext?.stepId && {
+        SPACES_WORKFLOW_STEP_ID: request.workflowContext.stepId,
       }),
     },
     ...(additionalInstructions && { additionalInstructions }),

--- a/apps/backend/src/workflowsV2/router.ts
+++ b/apps/backend/src/workflowsV2/router.ts
@@ -127,7 +127,37 @@ const sendRouteResponse = async (
   res.status(response.status).json(response.body);
 };
 
-const mount = (router: Router, authenticated: boolean): void => {
+const CLAW_ALLOWED_ROUTES = new Set([
+  'GET /schema/steps',
+  'GET /schema/steps/:type',
+  'GET /schema/triggers',
+  'GET /schema/triggers/:type',
+  'GET /schema/operators',
+  'POST /schema/available-context',
+  'GET /capabilities',
+  // Authoring.
+  'GET /workflows',
+  'GET /workflows/counts',
+  'GET /workflows/:id',
+  'POST /workflows',
+  'PUT /workflows/:id',
+  'POST /workflows/validate',
+  'POST /workflows/:id/deactivate',
+  'GET /folders',
+  'GET /folders/:id',
+  'POST /folders',
+  'POST /workflows/:id/trigger',
+  'GET /executions',
+  'GET /executions/pending-approvals',
+  'GET /executions/:execId',
+  'GET /executions/:execId/steps/:stepName/events',
+  'POST /executions/:execId/rerun',
+  'POST /executions/:execId/cancel',
+  'GET /analytics/summary',
+  'GET /analytics/top-errors',
+]);
+
+const mount = (router: Router, authenticated: boolean, allow?: ReadonlySet<string>): void => {
   const routes = createWorkflowRouter<XyneCtx>(workflowRuntime, {
     // Only consulted for unauthenticated routes, whose authorization is a path secret —
     // so reaching it at all means a route was misclassified.
@@ -142,6 +172,8 @@ const mount = (router: Router, authenticated: boolean): void => {
 
     const method = route.method.toLowerCase() as 'get' | 'post' | 'put' | 'delete';
     const key = `${route.method} ${route.path}`;
+
+    if (allow && !allow.has(key)) continue;
 
     // The SDK tells us which routes need a multipart parser; run multer only there so
     // ordinary JSON routes are untouched.
@@ -180,3 +212,5 @@ mount(workflowsRouter, true);
 
 export const workflowsPublicRouter: Router = express.Router();
 mount(workflowsPublicRouter, false);
+export const workflowsClawRouter: Router = express.Router();
+mount(workflowsClawRouter, true, CLAW_ALLOWED_ROUTES);

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -140,7 +140,7 @@
     "@xyne/icons": "workspace:*",
     "@xyne/shared": "workspace:*",
     "@xyne/workflow-sdk": "3.2.36",
-    "@xyne/workflow-ui": "1.3.34",
+    "@xyne/workflow-ui": "1.3.35",
     "@y-sweet/client": "^0.9.1",
     "ag-grid-community": "^35.0.0",
     "ag-grid-react": "^35.0.0",

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/XyneAISidebar.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/XyneAISidebar.tsx
@@ -86,6 +86,8 @@ import {
   xyneAIActor,
   type ThreadInfo,
   type CanvasInfo,
+  type WorkflowInfo,
+  toWorkflowContext,
   type XyneAIContext,
   type AskAIInitialContextSelections,
   type SelectionInfo,
@@ -134,6 +136,8 @@ interface XyneAISidebarProps {
   kbCollectionId?: string;
   kbChannelId?: string;
   kbDocId?: string;
+  workflowInfo?: WorkflowInfo | null;
+  workflowDismissed?: boolean;
   kbDocName?: string;
   kbFolderId?: string;
   kbFolderName?: string;
@@ -171,6 +175,8 @@ const XyneAISidebar = ({
   onConversationChange,
   kbCollectionId: kbCollectionIdProp,
   kbDocId: kbDocIdProp,
+  workflowInfo,
+  workflowDismissed,
   kbDocName: kbDocNameProp,
   kbFolderId: kbFolderIdProp,
   kbFolderName: kbFolderNameProp,
@@ -302,6 +308,11 @@ const XyneAISidebar = ({
   const [selectedActivities, setSelectedActivities] = useState<UserActivity[]>([]);
   const [selectedTickets, setSelectedTickets] = useState<SelectedTicket[]>([]);
   const [selectedCanvases, setSelectedCanvases] = useState<SelectedCanvas[]>([]);
+  const activeWorkflowInfo = workflowDismissed ? null : (workflowInfo ?? null);
+  const handleRemoveWorkflowInfo = useCallback((e: React.MouseEvent): void => {
+    e.stopPropagation();
+    xyneAIActor.send({ type: 'DISMISS_WORKFLOW_CONTEXT' });
+  }, []);
   const [selectedTranscripts, setSelectedTranscripts] = useState<SelectedTranscript[]>([]);
   const [selectedRecordings, setSelectedRecordings] = useState<SelectedRecording[]>([]);
   const [browserContext, setBrowserContext] = useState<{
@@ -772,6 +783,7 @@ const XyneAISidebar = ({
     threadConversationId: activeThreadInfo?.conversationId,
     attachmentIds: activeThreadInfo?.attachmentIds,
     canvasId: canvasInfo?.canvasId ?? null,
+    workflowContext: toWorkflowContext(activeWorkflowInfo),
     setMessages,
     setConversationId,
     setCurrentTraceId,
@@ -1943,6 +1955,8 @@ const XyneAISidebar = ({
     scopeType,
     threadInfo: activeThreadInfo,
     canvasInfo,
+    workflowInfo: activeWorkflowInfo,
+    onRemoveWorkflowInfo: handleRemoveWorkflowInfo,
     selectionInfos: activeSelectionInfos,
     inputValue,
     onInputChange: setInputValue,

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPillRow.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPillRow.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from 'react';
 import {
+  Automation,
   ChevronBigDown,
   ChevronBigUp,
   FileText,
@@ -27,7 +28,12 @@ import { motion } from 'framer-motion';
 import Avatar from '../../../ui/Avatar/Avatar';
 import useMeasure from '../../../../hooks/useMeasure';
 import { ContextPicker } from './ContextPicker';
-import type { ThreadInfo, CanvasInfo, SelectionInfo } from '../../../../machines/xyneAIMachine';
+import type {
+  ThreadInfo,
+  CanvasInfo,
+  SelectionInfo,
+  WorkflowInfo,
+} from '../../../../machines/xyneAIMachine';
 import type { UserActivity } from '../../../../hooks/useUserActivity';
 import type { Attachment, BrowserContext } from './XyneAIInputBox';
 import type {
@@ -159,6 +165,9 @@ export interface ContextPillRowProps {
   onCanvasInfoClick: () => void;
   onRemoveCanvasInfo: (e: React.MouseEvent) => void;
 
+  workflowInfo: WorkflowInfo | null;
+  onRemoveWorkflowInfo: (e: React.MouseEvent) => void;
+
   selectionInfos: SelectionInfo[];
   onSelectionClick: (selection: SelectionInfo) => void;
   onRemoveSelection: (index: number) => void;
@@ -238,6 +247,8 @@ export const ContextPillRow = ({
   canvasInfo,
   onCanvasInfoClick,
   onRemoveCanvasInfo,
+  workflowInfo,
+  onRemoveWorkflowInfo,
   selectionInfos,
   onSelectionClick,
   onRemoveSelection,
@@ -377,6 +388,36 @@ export const ContextPillRow = ({
             data-track-category='XyneAI'
             data-track-name='RemoveCanvasContext'
             data-track-metadata={JSON.stringify({ canvasId: canvasInfo.canvasId })}
+          >
+            <MultipleCrossCancelDefault className='w-3 h-3' />
+          </button>
+        </div>
+      ),
+    });
+  }
+
+  if (workflowInfo) {
+    pills.push({
+      key: 'workflow-info',
+      node: (
+        <div className={CONTEXT_PILL_CLASS}>
+          {/* Static, not a trigger: the workflow is already the screen behind the panel,
+              so there is nowhere to navigate to. */}
+          <div className={CONTEXT_PILL_TRIGGER_CLASS}>
+            <Automation className={CONTEXT_PILL_ICON_CLASS} />
+            <span className={`${CONTEXT_PILL_LABEL_CLASS} max-w-[200px] truncate`}>
+              {workflowInfo.title || 'This workflow'}
+              {workflowInfo.executionId ? ' · run' : ''}
+            </span>
+          </div>
+          <button
+            type='button'
+            onClick={onRemoveWorkflowInfo}
+            className={CONTEXT_PILL_REMOVE_CLASS}
+            aria-label='Remove workflow context'
+            data-track-category='XyneAI'
+            data-track-name='RemoveWorkflowContext'
+            data-track-metadata={JSON.stringify({ workflowId: workflowInfo.workflowId })}
           >
             <MultipleCrossCancelDefault className='w-3 h-3' />
           </button>

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIInputBox.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIInputBox.tsx
@@ -59,7 +59,12 @@ import { posthogService } from '../../../../services/Analytics/posthogService';
 import type { CollectionSummary } from '../../../../services/Knowledge/collectionService';
 import { useCachedQuery } from '../../../../hooks/useCachedQuery';
 import { queries } from '../../../../zero/queries';
-import type { ThreadInfo, CanvasInfo, SelectionInfo } from '../../../../machines/xyneAIMachine';
+import type {
+  ThreadInfo,
+  CanvasInfo,
+  SelectionInfo,
+  WorkflowInfo,
+} from '../../../../machines/xyneAIMachine';
 import type { VisibleChannel } from '../../../../machines/stateMachine';
 import { useNavigate } from 'react-router-dom';
 import { xyneAIActor } from '../../../../machines/xyneAIMachine';
@@ -114,6 +119,8 @@ export interface XyneAIInputBoxProps {
   showChannelTag?: boolean;
   threadInfo?: ThreadInfo | null | undefined;
   canvasInfo?: CanvasInfo | null | undefined;
+  workflowInfo?: WorkflowInfo | null | undefined;
+  onRemoveWorkflowInfo?: ((e: React.MouseEvent) => void) | undefined;
   selectionInfos?: SelectionInfo[];
   inputValue: string;
   onInputChange: (value: string) => void;
@@ -231,6 +238,8 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
       scopeType: _scopeType,
       threadInfo,
       canvasInfo,
+      workflowInfo,
+      onRemoveWorkflowInfo,
       selectionInfos = EMPTY_SELECTION_INFOS,
       inputValue,
       onInputChange,
@@ -1741,6 +1750,8 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
           onThreadClick={handleThreadPillClick}
           onRemoveThread={handleRemoveThreadInfo}
           canvasInfo={activeCanvasInfo}
+          workflowInfo={workflowInfo ?? null}
+          onRemoveWorkflowInfo={onRemoveWorkflowInfo ?? ((): void => {})}
           onCanvasInfoClick={handleCanvasPillClick}
           onRemoveCanvasInfo={handleRemoveCanvasInfo}
           selectionInfos={activeSelectionInfos}

--- a/apps/dashboard/src/hooks/useXyneAIStream.ts
+++ b/apps/dashboard/src/hooks/useXyneAIStream.ts
@@ -9,6 +9,7 @@ import type {
 import type { ResearchContext } from '@xyne/shared';
 import type { AttachedContextItem } from '../components/Chat/XyneAISidebar/components/ContextPickerPanel';
 import type { UserActivity } from '../hooks/useUserActivity';
+import type { WorkflowContext } from '../machines/xyneAIMachine';
 import { xyneAIStreamManager, type StreamState } from '../services/XyneAI';
 import { buildXyneAIStreamThreadId } from '../utils/xyneAIStreamThreadId';
 
@@ -62,6 +63,7 @@ interface UseXyneAIStreamParams {
   threadConversationId?: string | undefined;
   attachmentIds?: string[] | undefined; // Attachment IDs to fetch from GCS on backend
   canvasId?: string | null;
+  workflowContext?: WorkflowContext | null;
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
   setConversationId: React.Dispatch<React.SetStateAction<string>>;
   setCurrentTraceId?: React.Dispatch<React.SetStateAction<string | undefined>>;
@@ -140,6 +142,7 @@ export const useXyneAIStream = ({
   threadConversationId,
   attachmentIds,
   canvasId,
+  workflowContext,
   setMessages,
   setConversationId,
   setCurrentTraceId,
@@ -463,6 +466,7 @@ export const useXyneAIStream = ({
           threadConversationId,
           attachmentIds,
           canvasId,
+          ...(workflowContext ? { workflowContext } : {}),
           webSearchEnabled: eWebSearchEnabled,
           deepResearchEnabled: eDeepResearchEnabled,
           createCanvasEnabled: eCreateCanvasEnabled,
@@ -501,6 +505,7 @@ export const useXyneAIStream = ({
       threadConversationId,
       attachmentIds,
       canvasId,
+      workflowContext,
       fileIds,
       folderIds,
       researchContext,

--- a/apps/dashboard/src/machines/xyneAIMachine.ts
+++ b/apps/dashboard/src/machines/xyneAIMachine.ts
@@ -85,6 +85,25 @@ export interface AskAIInitialContextSelections {
   }>;
 }
 
+export interface WorkflowContext {
+  workflowId?: string | null;
+  executionId?: string | null;
+  stepId?: string | null;
+}
+
+export interface WorkflowInfo extends WorkflowContext {
+  title?: string | null;
+}
+
+export const toWorkflowContext = (info: WorkflowInfo | null): WorkflowContext | null =>
+  info
+    ? {
+        ...(info.workflowId ? { workflowId: info.workflowId } : {}),
+        ...(info.executionId ? { executionId: info.executionId } : {}),
+        ...(info.stepId ? { stepId: info.stepId } : {}),
+      }
+    : null;
+
 export interface XyneAIResearchContext {
   type: 'product' | 'repository';
   id: string;
@@ -128,6 +147,8 @@ export interface XyneAIContext {
   // mutually exclusive with it (see the OPEN handler below).
   kbFolderId: string | null;
   kbFolderName: string | null;
+  workflowInfo: WorkflowInfo | null;
+  workflowDismissed: boolean;
   // Bumped on every OPEN dispatched with a kbCollectionId. Lets the input box
   // re-attach the KB collection chip when the user clicks the Ask AI button
   // again from /knowledge-base after manually removing the chip.
@@ -160,6 +181,7 @@ export type XyneAIEvent =
       kbDocName?: string | null;
       kbFolderId?: string | null;
       kbFolderName?: string | null;
+      workflowInfo?: WorkflowInfo | null;
       initialContextSelections?: AskAIInitialContextSelections | null;
       researchContext?: XyneAIResearchContext | null;
       initialQuery?: string | null;
@@ -168,6 +190,9 @@ export type XyneAIEvent =
   | { type: 'SET_FOCUS_SESSION'; sessionId: string | null }
   | { type: 'CLEAR_KB_CONTEXT' }
   | { type: 'SET_KB_CONTEXT'; kbCollectionId: string | null; kbChannelId?: string | null }
+  | { type: 'SET_WORKFLOW_CONTEXT'; workflowInfo: WorkflowInfo | null }
+  /** The user closed the workflow pill. Sticks until the subject changes. */
+  | { type: 'DISMISS_WORKFLOW_CONTEXT' }
   | { type: 'SET_CONTEXT'; contextType: XyneAIContextType; contextId: string }
   | { type: 'SET_CHANNEL'; channelId: string }
   | { type: 'SET_TICKET_CONTEXT'; channelId: string; threadInfo: ThreadInfo }
@@ -528,6 +553,8 @@ export const xyneAIMachine = setup({
           kbDocName: event.kbDocName ?? null,
           kbFolderId: event.kbFolderId ?? null,
           kbFolderName: event.kbFolderName ?? null,
+          workflowInfo: event.workflowInfo ?? null,
+          workflowDismissed: event.workflowInfo ? false : context.workflowDismissed,
           researchContext: event.researchContext ?? null,
           initialQuery: event.initialQuery?.trim() || null,
           autoSendNonce: event.initialQuery?.trim()
@@ -610,6 +637,8 @@ export const xyneAIMachine = setup({
           kbFolderId: event.kbFolderId !== undefined ? event.kbFolderId : context.kbFolderId,
           kbFolderName:
             event.kbFolderName !== undefined ? event.kbFolderName : context.kbFolderName,
+          workflowInfo: event.workflowInfo ?? null,
+          workflowDismissed: event.workflowInfo ? false : context.workflowDismissed,
           researchContext: event.researchContext ?? null,
           initialQuery: event.initialQuery?.trim() || null,
           autoSendNonce: event.initialQuery?.trim()
@@ -640,6 +669,19 @@ export const xyneAIMachine = setup({
       };
       void saveContextToIndexedDB(newContext);
       return newContext;
+    }),
+    dismissWorkflowContext: assign(() => ({ workflowDismissed: true })),
+    setWorkflowContext: assign(({ context, event }) => {
+      if (event.type !== 'SET_WORKFLOW_CONTEXT') return {};
+      const next = event.workflowInfo;
+      const prev = context.workflowInfo;
+      const subjectChanged =
+        (next?.workflowId ?? null) !== (prev?.workflowId ?? null) ||
+        (next?.executionId ?? null) !== (prev?.executionId ?? null);
+      return {
+        workflowInfo: next,
+        workflowDismissed: subjectChanged ? false : context.workflowDismissed,
+      };
     }),
     setKbContext: assign(({ event }) => {
       if (event.type === 'SET_KB_CONTEXT') {
@@ -822,6 +864,8 @@ export const xyneAIMachine = setup({
     kbDocName: null,
     kbFolderId: null,
     kbFolderName: null,
+    workflowInfo: null,
+    workflowDismissed: false,
     kbOpenNonce: 0,
     researchContext: null,
     initialQuery: null,
@@ -848,6 +892,12 @@ export const xyneAIMachine = setup({
         SET_KB_CONTEXT: {
           actions: 'setKbContext',
         },
+        SET_WORKFLOW_CONTEXT: {
+          actions: 'setWorkflowContext',
+        },
+        DISMISS_WORKFLOW_CONTEXT: {
+          actions: 'dismissWorkflowContext',
+        },
       },
     },
     open: {
@@ -864,6 +914,12 @@ export const xyneAIMachine = setup({
         },
         SET_KB_CONTEXT: {
           actions: 'setKbContext',
+        },
+        SET_WORKFLOW_CONTEXT: {
+          actions: 'setWorkflowContext',
+        },
+        DISMISS_WORKFLOW_CONTEXT: {
+          actions: 'dismissWorkflowContext',
         },
         SET_CONTEXT: {
           actions: 'setContext',

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -496,6 +496,11 @@ const AppRoot = (): ReactElement => {
   const xyneAIKbDocName = useSelector(xyneAIActor, state => state.context.kbDocName);
   const xyneAIKbFolderId = useSelector(xyneAIActor, state => state.context.kbFolderId);
   const xyneAIKbFolderName = useSelector(xyneAIActor, state => state.context.kbFolderName);
+  const xyneAIWorkflowInfo = useSelector(xyneAIActor, state => state.context.workflowInfo);
+  const xyneAIWorkflowDismissed = useSelector(
+    xyneAIActor,
+    state => state.context.workflowDismissed,
+  );
   const xyneAIKbOpenNonce = useSelector(xyneAIActor, state => state.context.kbOpenNonce);
   const xyneAIResearchContext = useSelector(xyneAIActor, state => state.context.researchContext);
   const xyneAIInitialQuery = useSelector(xyneAIActor, state => state.context.initialQuery);
@@ -775,6 +780,8 @@ const AppRoot = (): ReactElement => {
                                       kbCollectionId={xyneAIKbCollectionId ?? ''}
                                       kbChannelId={xyneAIKbChannelId ?? ''}
                                       kbDocId={xyneAIKbDocId ?? ''}
+                                      workflowInfo={xyneAIWorkflowInfo}
+                                      workflowDismissed={xyneAIWorkflowDismissed}
                                       kbDocName={xyneAIKbDocName ?? ''}
                                       kbFolderId={xyneAIKbFolderId ?? ''}
                                       kbFolderName={xyneAIKbFolderName ?? ''}
@@ -884,6 +891,8 @@ const AppRoot = (): ReactElement => {
                                       kbCollectionId={xyneAIKbCollectionId ?? ''}
                                       kbChannelId={xyneAIKbChannelId ?? ''}
                                       kbDocId={xyneAIKbDocId ?? ''}
+                                      workflowInfo={xyneAIWorkflowInfo}
+                                      workflowDismissed={xyneAIWorkflowDismissed}
                                       kbDocName={xyneAIKbDocName ?? ''}
                                       kbFolderId={xyneAIKbFolderId ?? ''}
                                       kbFolderName={xyneAIKbFolderName ?? ''}
@@ -1012,6 +1021,8 @@ const AppRoot = (): ReactElement => {
                             kbCollectionId={xyneAIKbCollectionId ?? ''}
                             kbChannelId={xyneAIKbChannelId ?? ''}
                             kbDocId={xyneAIKbDocId ?? ''}
+                            workflowInfo={xyneAIWorkflowInfo}
+                            workflowDismissed={xyneAIWorkflowDismissed}
                             kbDocName={xyneAIKbDocName ?? ''}
                             kbFolderId={xyneAIKbFolderId ?? ''}
                             kbFolderName={xyneAIKbFolderName ?? ''}
@@ -1046,6 +1057,8 @@ const AppRoot = (): ReactElement => {
                             kbCollectionId={xyneAIKbCollectionId ?? ''}
                             kbChannelId={xyneAIKbChannelId ?? ''}
                             kbDocId={xyneAIKbDocId ?? ''}
+                            workflowInfo={xyneAIWorkflowInfo}
+                            workflowDismissed={xyneAIWorkflowDismissed}
                             kbDocName={xyneAIKbDocName ?? ''}
                             kbFolderId={xyneAIKbFolderId ?? ''}
                             kbFolderName={xyneAIKbFolderName ?? ''}

--- a/apps/dashboard/src/routes/WorkflowScreen/WorkflowScreen.tsx
+++ b/apps/dashboard/src/routes/WorkflowScreen/WorkflowScreen.tsx
@@ -1,8 +1,13 @@
-import { type ReactElement } from 'react';
+import { type ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { WorkflowApp, WorkflowUIProvider } from '@xyne/workflow-ui';
 import { toast } from 'sonner';
 import { workflowClient } from '../../lib/workflowClient';
 import { queryClient } from '../../services/clients/queryClient';
+import { xyneAIActor, type WorkflowInfo } from '../../machines/xyneAIMachine';
+import { Button } from '../../components/ui/Button';
+import Tooltip from '../../components/ui/Tooltip';
+import { XyneAIStar } from '../../components/icons/xyne-ai';
 import { useWorkflowRouting } from './useWorkflowRouting';
 
 const notify = (kind: 'success' | 'error', message: string): void => {
@@ -10,19 +15,115 @@ const notify = (kind: 'success' | 'error', message: string): void => {
   else toast.error(message);
 };
 
+const scopeFromPath = (path: string): { workflowId?: string; executionId?: string } => {
+  const [segment, id] = path.split('/');
+  if (!id) return {};
+  if (segment === 'w') return { workflowId: id };
+  if (segment === 'runs') return { executionId: id };
+  return {};
+};
+
+const nameFromMetadata = (metadata: string | null): string | null => {
+  if (!metadata) return null;
+  try {
+    const parsed: unknown = JSON.parse(metadata);
+    const name = (parsed as { name?: unknown })?.name;
+    return typeof name === 'string' && name ? name : null;
+  } catch {
+    return null;
+  }
+};
+
 const WorkflowScreen = (): ReactElement => {
   const { path, search, navigate } = useWorkflowRouting();
+  const scope = useMemo(() => scopeFromPath(path), [path]);
+  const askAiTooltip = scope.executionId
+    ? 'Ask AI about this run'
+    : scope.workflowId
+      ? 'Ask AI about this workflow'
+      : 'Ask AI';
+
+  const { data: workflowInfo = null } = useQuery<WorkflowInfo | null>({
+    queryKey: ['askai-workflow-scope', scope.workflowId ?? null, scope.executionId ?? null],
+    enabled: Boolean(scope.workflowId || scope.executionId),
+    staleTime: 60_000,
+    queryFn: async (): Promise<WorkflowInfo | null> => {
+      if (scope.executionId) {
+        const detail = await workflowClient.executions.get(scope.executionId);
+        return {
+          workflowId: detail.workflowId,
+          title: detail.name ?? null,
+          executionId: scope.executionId,
+        };
+      }
+      if (!scope.workflowId) return null;
+      const record = await workflowClient.workflows.get(scope.workflowId);
+      return { workflowId: scope.workflowId, title: nameFromMetadata(record.metadata) };
+    },
+  });
+
+  const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
+  useEffect(() => {
+    setSelectedStepId(null);
+  }, [scope.workflowId, scope.executionId]);
+
+  const currentScope = useMemo((): WorkflowInfo | null => {
+    const base =
+      workflowInfo ??
+      (scope.workflowId
+        ? { workflowId: scope.workflowId }
+        : scope.executionId
+          ? { executionId: scope.executionId }
+          : null);
+    if (!base) return null;
+    return { ...base, ...(selectedStepId ? { stepId: selectedStepId } : {}) };
+  }, [workflowInfo, scope.workflowId, scope.executionId, selectedStepId]);
+
+  useEffect(() => {
+    xyneAIActor.send({ type: 'SET_WORKFLOW_CONTEXT', workflowInfo: currentScope });
+  }, [currentScope]);
+
+  useEffect(() => {
+    return () => {
+      xyneAIActor.send({ type: 'SET_WORKFLOW_CONTEXT', workflowInfo: null });
+    };
+  }, []);
+
+  const openAskAi = useCallback((): void => {
+    xyneAIActor.send({ type: 'OPEN', workflowInfo: currentScope });
+  }, [currentScope]);
+
+  const askAiButton = (
+    <Tooltip content={askAiTooltip} side='bottom'>
+      <Button
+        variant='ghost'
+        size='sm'
+        aria-label={askAiTooltip}
+        onClick={openAskAi}
+        className='h-8 w-8 rounded-lg p-0'
+        data-track-category='WORKFLOWS'
+        data-track-name='OPEN_XYNE_AI'
+        data-track-metadata={JSON.stringify(scope)}
+      >
+        <XyneAIStar />
+      </Button>
+    </Tooltip>
+  );
 
   return (
-    <WorkflowUIProvider client={workflowClient} queryClient={queryClient}>
-      <WorkflowApp
-        className='xyne-workflow-ui h-full'
-        path={path}
-        search={search}
-        onNavigate={navigate}
-        onToast={notify}
-      />
-    </WorkflowUIProvider>
+    <div className='h-full overflow-hidden rounded-2xl border border-border bg-background'>
+      <WorkflowUIProvider client={workflowClient} queryClient={queryClient} className='h-full'>
+        <WorkflowApp
+          className='xyne-workflow-ui h-full'
+          path={path}
+          search={search}
+          onNavigate={navigate}
+          onToast={notify}
+          headerActions={askAiButton}
+          onSelectStep={setSelectedStepId}
+        />
+      </WorkflowUIProvider>
+    </div>
   );
 };
 

--- a/apps/dashboard/src/services/XyneAI/XyneAIStreamManager.ts
+++ b/apps/dashboard/src/services/XyneAI/XyneAIStreamManager.ts
@@ -30,6 +30,7 @@ import type { ToolOutput as GeniusToolOutput } from '../../types/toolOutput';
 import type { ResearchContext } from '@xyne/shared';
 import type { AttachedContextItem } from '../../components/Chat/XyneAISidebar/components/ContextPickerPanel';
 import type { UserActivity } from '../../hooks/useUserActivity';
+import type { WorkflowContext } from '../../machines/xyneAIMachine';
 import {
   xyneAIStreamStorage,
   type StreamRecord,
@@ -105,6 +106,7 @@ export interface StreamRequest {
   threadConversationId?: string | undefined;
   attachmentIds?: string[] | undefined;
   canvasId?: string | null | undefined;
+  workflowContext?: WorkflowContext | null | undefined;
   webSearchEnabled: boolean;
   deepResearchEnabled?: boolean;
   createCanvasEnabled?: boolean;
@@ -1107,6 +1109,7 @@ class XyneAIStreamManager {
               : { type: request.researchContext.type, name: request.researchContext.name }
             : null,
           ...(request.canvasId && { canvasId: request.canvasId }),
+          ...(request.workflowContext && { workflowContext: request.workflowContext }),
           ...(request.attachmentIds &&
             request.attachmentIds.length > 0 && { messageAttachmentIds: request.attachmentIds }),
           ...(request.attachments.length > 0 && {

--- a/apps/dashboard/src/services/XyneAI/xyneAIStream.worker.ts
+++ b/apps/dashboard/src/services/XyneAI/xyneAIStream.worker.ts
@@ -50,6 +50,11 @@ export interface WorkerStartStreamMessage {
       thinkingLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high';
       researchContext?: { type: string; id?: string; name: string } | null;
       canvasId?: string;
+      workflowContext?: {
+        workflowId?: string | null;
+        executionId?: string | null;
+        stepId?: string | null;
+      };
       messageAttachmentIds?: string[];
       attachments?: Array<{
         data: string;
@@ -204,6 +209,7 @@ async function executeStream(
         ...(requestBody.canvasId && {
           canvas_id: requestBody.canvasId,
         }),
+        ...(requestBody.workflowContext && { workflowContext: requestBody.workflowContext }),
         ...(requestBody.messageAttachmentIds &&
           requestBody.messageAttachmentIds.length > 0 && {
             message_attachment_ids: requestBody.messageAttachmentIds,

--- a/apps/dashboard/src/styles/workflow-ui-theme.css
+++ b/apps/dashboard/src/styles/workflow-ui-theme.css
@@ -78,14 +78,6 @@
   --wui-status-skipped: hsl(var(--border));
 }
 
-/* WorkflowUIProvider renders an unstyled wrapper between the app shell's <main> and
-   WorkflowApp, so the app's own `h-full` resolves against a parent that has collapsed to
-   content height — leaving the pane floating above the wallpaper. Give that wrapper the
-   height instead of fighting it from inside. */
-:where(div):has(> .xyne-workflow-ui) {
-  height: 100%;
-}
-
 /* The package's Tailwind preflight pins `font-family: ui-sans-serif, system-ui`, so
    Inter has to be reasserted — including on form controls, which never inherit it. */
 .xyne-workflow-ui,

--- a/apps/xyne-claw-auth/backend/prisma/seed.ts
+++ b/apps/xyne-claw-auth/backend/prisma/seed.ts
@@ -5,6 +5,10 @@ import { createCipheriv, randomBytes } from "node:crypto";
 import { PrismaClient, type Prisma } from "@prisma/client";
 import { buildSdlcAgentToolProfile, getAllCustomTools } from "xyne-claw-shared";
 import { tools as xyneSpacesTools } from "../src/mcp/servers/xyne-spaces-tools.js";
+import {
+  WORKFLOW_TOOL_NAMES,
+  WORKFLOW_WRITE_TOOL_NAMES,
+} from "../src/mcp/servers/xyne-workflows-tools.js";
 
 const prisma = new PrismaClient();
 
@@ -140,6 +144,14 @@ const SERVERS = [
     description: "Dedicated dynamic-dashboard tools for the dashboard-ai agent (pinned; not user-connectable).",
     credentialForm: { fields: [] },
     writeToolPolicy: { mode: "allowlist", tools: [] },
+  },
+  {
+    type: "xyne-workflows",
+    name: "Xyne Workflows",
+    url: "",
+    description: "Workflow authoring and run tools for Ask AI (pinned; not user-connectable).",
+    credentialForm: { fields: [] },
+    writeToolPolicy: { mode: "allowlist", tools: [...WORKFLOW_WRITE_TOOL_NAMES] },
   },
   {
     type: "xyne-spaces-app-tools",
@@ -973,6 +985,7 @@ You:
             "spaces-create-canvas",
             "spaces-edit-canvas",
             "spaces-sdlc-mutate-artifact",
+            ...WORKFLOW_TOOL_NAMES,
           ],
           custom: ["genius-analytics", "genius-investigation", "query-codebase", "review-pull-request", "web-search", "deep-research", "generate-image", "add-citations", "visualize"]
         },
@@ -982,7 +995,10 @@ You:
           "xyne-spaces__spaces-schedule-call": "ask",
           "xyne-spaces__user-send-message": "ask",
           "xyne-spaces__spaces-create-canvas": "ask",
-          "xyne-spaces__spaces-edit-canvas": "ask"
+          "xyne-spaces__spaces-edit-canvas": "ask",
+          "xyne-workflows__workflow_create": "ask",
+          "xyne-workflows__workflow_update": "ask",
+          "xyne-workflows__workflow_run": "ask"
         },
         // Deterministic skill injection. Skills otherwise load via pi's
         // progressive disclosure (only the 1-line <available_skills> description
@@ -1055,6 +1071,7 @@ You:
             "spaces-create-canvas",
             "spaces-edit-canvas",
             "spaces-sdlc-mutate-artifact",
+            ...WORKFLOW_TOOL_NAMES,
           ],
           custom: ["genius-analytics", "genius-investigation", "query-codebase", "review-pull-request", "web-search", "deep-research", "generate-image", "add-citations", "visualize"]
         },
@@ -1064,7 +1081,10 @@ You:
           "xyne-spaces__spaces-schedule-call": "ask",
           "xyne-spaces__user-send-message": "ask",
           "xyne-spaces__spaces-create-canvas": "ask",
-          "xyne-spaces__spaces-edit-canvas": "ask"
+          "xyne-spaces__spaces-edit-canvas": "ask",
+          "xyne-workflows__workflow_create": "ask",
+          "xyne-workflows__workflow_update": "ask",
+          "xyne-workflows__workflow_run": "ask"
         },
         // Deterministic skill injection — see the matching block in `create`
         // for the full rationale and the toolName/skillSlug/when conventions.
@@ -2224,6 +2244,36 @@ DRILL-DOWN: Use this path ONLY when the user wants to EXPLORE a focused tile's d
     }
   } else {
     console.warn("[seed] Skipped dashboard-ai pin: ENCRYPTION_KEY not set");
+  }
+
+  const workflowsCredsPayload = encryptCreds({});
+  if (workflowsCredsPayload) {
+    const workflowsServerRow = await prisma.mcpServer.findUnique({ where: { type: "xyne-workflows" } });
+    if (workflowsServerRow) {
+      await prisma.agentMcpConnection.upsert({
+        where: {
+          agentId_mcpServerId_slug: {
+            agentId: askAIAgent.id,
+            mcpServerId: workflowsServerRow.id,
+            slug: "default",
+          },
+        },
+        create: {
+          agentId: askAIAgent.id,
+          mcpServerId: workflowsServerRow.id,
+          slug: "default",
+          encryptedCreds: workflowsCredsPayload.encryptedCreds,
+          iv: workflowsCredsPayload.iv,
+          authTag: workflowsCredsPayload.authTag,
+        },
+        update: {},
+      });
+      console.log("[seed] Pinned xyne-workflows MCP server to ask-ai");
+    } else {
+      console.warn("[seed] Skipped ask-ai workflows pin: xyne-workflows server row not found");
+    }
+  } else {
+    console.warn("[seed] Skipped ask-ai workflows pin: ENCRYPTION_KEY not set");
   }
 
   // ── Claw concierge agent ─────────────────────────────────────────────────

--- a/apps/xyne-claw-auth/backend/src/lib/credentials-loader.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/credentials-loader.ts
@@ -61,7 +61,11 @@ export interface EffectiveCredentials {
  * hide a run merely for using these — virtually every spaces-agent run reads
  * Spaces, so counting it would hide almost everything and defeat the feature.
  */
-const AMBIENT_USER_CREDENTIAL_SERVER_TYPES = new Set(["xyne-spaces", "xyne-dashboard"]);
+export const AMBIENT_USER_CREDENTIAL_SERVER_TYPES = new Set([
+  "xyne-spaces",
+  "xyne-dashboard",
+  "xyne-workflows",
+]);
 
 /**
  * True when an effective credential is a PRIVATE per-user credential whose use
@@ -179,6 +183,13 @@ export async function loadEffectiveCredentials(
     const live = await liveSpacesCredentials(userId);
     if (live) return live;
     log.info(`[creds-loader] xyne-dashboard userId=${userId} → no live Spaces session`);
+    return null;
+  }
+
+  if (serverType === "xyne-workflows") {
+    const live = await liveSpacesCredentials(userId);
+    if (live) return live;
+    log.info(`[creds-loader] xyne-workflows userId=${userId} → no live Spaces session`);
     return null;
   }
 

--- a/apps/xyne-claw-auth/backend/src/lib/write-actions.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/write-actions.ts
@@ -21,6 +21,7 @@ import { errMsg } from "./errors.js";
 import { decrypt, encrypt } from "../crypto.js";
 import { CONFIG } from "../config.js";
 import { GATEWAY_KEY_PREFIX, parseGatewayCatalogSource } from "../mcpgateway/key-format.js";
+import { AMBIENT_USER_CREDENTIAL_SERVER_TYPES } from "./credentials-loader.js";
 
 const DEFAULT_GATEWAY_TENANT = process.env.ALLOWED_TENANTS
   ?.split(",")
@@ -142,13 +143,8 @@ export async function executeWriteAction(action: SignedWriteAction): Promise<Wri
       return { ok: false, content: "", error: `No adapter for server type: ${serverType}` };
     }
 
-    // For xyne-spaces: resolve credentials from the Spaces DB directly, same as
-    // the MCP runner does in getOrCreateSession(). The userMcpConnection table
-    // may not have a row (user hasn't gone through dashboard connection flow),
-    // but their Spaces session still exists in workflow.user_sessions. Without
-    // this, all write-action approvals fail with "No xyne-spaces connection".
     let credentials: Record<string, unknown>;
-    if (serverType === "xyne-spaces") {
+    if (AMBIENT_USER_CREDENTIAL_SERVER_TYPES.has(serverType)) {
       const { getSpacesAuthForUser } = await import("../lib/spaces-db.js");
       const live = await getSpacesAuthForUser(userId, "write-action");
       if (live) {
@@ -160,7 +156,7 @@ export async function executeWriteAction(action: SignedWriteAction): Promise<Wri
           userId,
         };
       } else {
-        return { ok: false, content: "", error: `No xyne-spaces connection for this user.` };
+        return { ok: false, content: "", error: `No ${serverType} connection for this user.` };
       }
     } else {
       const connection = await prisma.userMcpConnection.findFirst({

--- a/apps/xyne-claw-auth/backend/src/mcp/adapters/xyne-workflows.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/adapters/xyne-workflows.ts
@@ -1,0 +1,34 @@
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+import type { StdioMcpAdapter } from "../types.js";
+import { WORKFLOW_WRITE_TOOL_NAMES } from "../servers/xyne-workflows-tools.js";
+
+const SERVER_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../servers/xyne-workflows-server.ts",
+);
+
+export const xyneWorkflowsAdapter: StdioMcpAdapter = {
+  transport: "stdio",
+  type: "xyne-workflows",
+  healthCheck: { name: "workflow_catalog", params: {} },
+  writeTools: [...WORKFLOW_WRITE_TOOL_NAMES],
+  credentialFields: [],
+  buildCommand(credentials) {
+    const url = String(
+      process.env["WORKFLOWS_SPACES_URL"] || credentials["url"] || "",
+    ).replace(/\/+$/, "");
+    return {
+      cmd: "node",
+      args: ["--import", "tsx/esm", SERVER_PATH],
+      env: {
+        XYNE_SPACES_URL: url,
+        XYNE_SPACES_TOKEN: String(credentials["token"] ?? ""),
+        XYNE_SPACES_SESSION_ID: String(credentials["sessionId"] ?? ""),
+        XYNE_SPACES_WORKSPACE_ID: String(credentials["workspaceId"] ?? ""),
+        INTERNAL_S2S_KEY: process.env["INTERNAL_S2S_KEY"] ?? "",
+        XYNE_USER_ID: String(credentials["userId"] ?? ""),
+      },
+    };
+  },
+};

--- a/apps/xyne-claw-auth/backend/src/mcp/run-scalars.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/run-scalars.ts
@@ -22,6 +22,9 @@ export interface RunScalars {
   dataSourceId?: string;
   draftId?: string;
   focusedComponentId?: string;
+  workflowId?: string;
+  executionId?: string;
+  focusedStepId?: string;
 }
 
 function key(sessionId: string): string {
@@ -30,7 +33,7 @@ function key(sessionId: string): string {
 
 export async function storeRunScalars(sessionId: string, scalars: RunScalars): Promise<void> {
   if (!sessionId) return;
-  if (!scalars.dataSourceId && !scalars.draftId && !scalars.focusedComponentId) return;
+  if (!Object.values(scalars).some((v) => typeof v === "string" && v)) return;
   try {
     await redisService.getConnection().set(key(sessionId), JSON.stringify(scalars), "EX", TTL_SECONDS);
   } catch (err) {

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-workflows-server.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-workflows-server.ts
@@ -1,0 +1,48 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { ListToolsRequestSchema, CallToolRequestSchema, type CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { tools } from "./xyne-workflows-tools.js";
+
+const url = process.env["XYNE_SPACES_URL"];
+const token = process.env["XYNE_SPACES_TOKEN"];
+const userId = process.env["XYNE_USER_ID"] ?? "";
+
+if (!url || !token) {
+  process.stderr.write("xyne-workflows-server: XYNE_SPACES_URL and XYNE_SPACES_TOKEN must be set\n");
+  process.exit(1);
+}
+
+const server = new Server(
+  { name: "xyne-workflows", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: tools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: t.inputSchema,
+  })),
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToolResult> => {
+  const { name, arguments: args } = request.params;
+  const tool = tools.find((t) => t.name === name);
+  if (!tool) {
+    return { content: [{ type: "text", text: `Unknown tool: ${name}` }], isError: true };
+  }
+  return tool.handler(args ?? {}, { userId });
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+
+process.on("SIGINT", async () => {
+  await server.close();
+  process.exit(0);
+});
+
+process.on("SIGTERM", async () => {
+  await server.close();
+  process.exit(0);
+});

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-workflows-tools.test.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-workflows-tools.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  spacesFetch: vi.fn(),
+  spacesFetchBuffer: vi.fn(),
+  spacesFetchText: vi.fn(),
+}));
+
+vi.mock("./xyne-spaces-client.js", () => mocks);
+
+async function loadTool(name: string) {
+  const mod = await import("./xyne-workflows-tools.js");
+  const tool = mod.tools.find((t) => t.name === name);
+  if (!tool) throw new Error(`${name} tool not found`);
+  return tool;
+}
+
+const ctx = { userId: "u1" };
+
+/** Every path spacesFetch was called with, in order. */
+function calledPaths(): string[] {
+  return mocks.spacesFetch.mock.calls.map((c) => String(c[0]));
+}
+
+/** The tool's model-facing text. Tools always emit exactly one text block. */
+function textOf(res: { content: Array<{ text: string }> }): string {
+  return res.content[0]?.text ?? "";
+}
+
+function bodyOf(callIndex: number): unknown {
+  const init = mocks.spacesFetch.mock.calls[callIndex]?.[1] as { body?: string } | undefined;
+  return init?.body ? JSON.parse(init.body) : undefined;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("tool surface", () => {
+  it("declares the injected run scalars on every tool, so /call can force-inject them", async () => {
+    const mod = await import("./xyne-workflows-tools.js");
+    expect(mod.tools.length).toBeGreaterThan(0);
+    for (const tool of mod.tools) {
+      const props = (tool.inputSchema as { properties?: Record<string, unknown> }).properties ?? {};
+      expect(Object.keys(props)).toEqual(
+        expect.arrayContaining(["workflowId", "executionId", "focusedStepId"]),
+      );
+    }
+  });
+
+  it("exports every tool name, so the adapter and seed cannot list a stale set", async () => {
+    const mod = await import("./xyne-workflows-tools.js");
+    // The seed spreads WORKFLOW_TOOL_NAMES into ask-ai's `direct` allowlist, which is
+    // strict: a name missing there is dropped with no error and the tool simply never
+    // reaches the agent. Deriving it is what makes that impossible.
+    expect(mod.WORKFLOW_TOOL_NAMES).toEqual(mod.tools.map((t) => t.name));
+    expect(mod.WORKFLOW_TOOL_NAMES).toHaveLength(mod.tools.length);
+  });
+
+  it("gates exactly the tools that mutate or execute", async () => {
+    const mod = await import("./xyne-workflows-tools.js");
+    // Reads must NOT be gated — an approval card on every lookup would train users to
+    // click through them, which is how a real write slips past.
+    expect([...mod.WORKFLOW_WRITE_TOOL_NAMES].sort()).toEqual(
+      ["workflow_create", "workflow_run", "workflow_update"],
+    );
+    for (const name of mod.WORKFLOW_WRITE_TOOL_NAMES) {
+      expect(mod.WORKFLOW_TOOL_NAMES).toContain(name);
+    }
+  });
+
+  it("uses names that cannot be confused with the legacy spaces-workflow-* tools", async () => {
+    const mod = await import("./xyne-workflows-tools.js");
+    for (const tool of mod.tools) {
+      expect(tool.name).toMatch(/^workflow_/);
+    }
+  });
+});
+
+describe("workflow_catalog", () => {
+  it("returns the cheap index when called with no arguments", async () => {
+    mocks.spacesFetch.mockResolvedValueOnce({ steps: [{ type: "CODE" }] });
+    mocks.spacesFetch.mockResolvedValueOnce({ triggers: [{ type: "CRON" }] });
+    mocks.spacesFetch.mockResolvedValueOnce({ operators: [] });
+
+    const tool = await loadTool("workflow_catalog");
+    const res = await tool.handler({}, ctx);
+
+    expect(calledPaths()).toEqual([
+      "/api/workflows-v2/claw/schema/steps",
+      "/api/workflows-v2/claw/schema/triggers",
+      "/api/workflows-v2/claw/schema/operators",
+    ]);
+    expect(res.isError).toBeUndefined();
+    expect(textOf(res)).toContain("CODE");
+  });
+
+  it("expands only the requested types, batching them into one call", async () => {
+    mocks.spacesFetch.mockResolvedValue({ type: "X", configSchema: {} });
+
+    const tool = await loadTool("workflow_catalog");
+    await tool.handler({ stepTypes: ["HTTP_REQUEST", "CODE"], triggerTypes: ["CRON"] }, ctx);
+
+    expect(calledPaths()).toEqual([
+      "/api/workflows-v2/claw/schema/steps/HTTP_REQUEST",
+      "/api/workflows-v2/claw/schema/steps/CODE",
+      "/api/workflows-v2/claw/schema/triggers/CRON",
+    ]);
+  });
+});
+
+describe("workflow_create", () => {
+  const config = { trigger: { type: "CRON" }, steps: [] };
+
+  it("refuses to save an invalid config and hands the issues back for repair", async () => {
+    mocks.spacesFetch.mockResolvedValueOnce({ valid: false, issues: [{ message: "no trigger" }] });
+
+    const tool = await loadTool("workflow_create");
+    const res = await tool.handler({ name: "W", config, folderId: "f1" }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain("no trigger");
+    // Validate only — nothing was created.
+    expect(calledPaths()).toEqual(["/api/workflows-v2/claw/workflows/validate"]);
+  });
+
+  it("switches the new workflow off, so an agent-authored CRON cannot fire unreviewed", async () => {
+    mocks.spacesFetch.mockResolvedValueOnce({ valid: true, issues: [] });
+    mocks.spacesFetch.mockResolvedValueOnce({ id: "wf-1" });
+    mocks.spacesFetch.mockResolvedValueOnce({ deactivated: true });
+
+    const tool = await loadTool("workflow_create");
+    const res = await tool.handler({ name: "W", config, folderId: "f1" }, ctx);
+
+    expect(calledPaths()).toEqual([
+      "/api/workflows-v2/claw/workflows/validate",
+      "/api/workflows-v2/claw/workflows",
+      "/api/workflows-v2/claw/workflows/wf-1/deactivate",
+    ]);
+    expect(bodyOf(1)).toMatchObject({ name: "W", folderId: "f1" });
+    expect(res.isError).toBeUndefined();
+    expect(textOf(res)).toContain('"live": false');
+  });
+
+  it("reports a failed deactivate as live rather than as a failed create", async () => {
+    mocks.spacesFetch.mockResolvedValueOnce({ valid: true, issues: [] });
+    mocks.spacesFetch.mockResolvedValueOnce({ id: "wf-2" });
+    mocks.spacesFetch.mockRejectedValueOnce(new Error("boom"));
+
+    const tool = await loadTool("workflow_create");
+    const res = await tool.handler({ name: "W", config, folderId: "f1" }, ctx);
+
+    expect(res.isError).toBe(true);
+    // The model must not retry — a second create would leave two live workflows.
+    expect(textOf(res)).toContain("wf-2");
+    expect(textOf(res)).toContain("LIVE");
+    expect(textOf(res)).toContain("Do not create it again");
+  });
+});
+
+describe("run scalars", () => {
+  it("scopes workflow_get to the injected workflowId", async () => {
+    mocks.spacesFetch.mockResolvedValueOnce({ id: "wf-9", config: '{"steps":[]}' });
+
+    const tool = await loadTool("workflow_get");
+    await tool.handler({ workflowId: "wf-9" }, ctx);
+
+    expect(calledPaths()).toEqual(["/api/workflows-v2/claw/workflows/wf-9"]);
+  });
+
+  it("tells the agent what to do instead of guessing when nothing is in scope", async () => {
+    const tool = await loadTool("workflow_get");
+    const res = await tool.handler({}, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain("workflow_list");
+    expect(mocks.spacesFetch).not.toHaveBeenCalled();
+  });
+
+  it("reads the run in scope for workflow_run_get", async () => {
+    mocks.spacesFetch.mockResolvedValueOnce({ status: "EXTERNAL_WAIT" });
+
+    const tool = await loadTool("workflow_run_get");
+    await tool.handler({ executionId: "ex-1" }, ctx);
+
+    expect(calledPaths()).toEqual(["/api/workflows-v2/claw/executions/ex-1"]);
+  });
+
+  it("falls back to the focused step for workflow_step_events", async () => {
+    mocks.spacesFetch.mockResolvedValueOnce({ events: [] });
+
+    const tool = await loadTool("workflow_step_events");
+    await tool.handler({ executionId: "ex-1", focusedStepId: "fetch_data" }, ctx);
+
+    expect(calledPaths()).toEqual([
+      "/api/workflows-v2/claw/executions/ex-1/steps/fetch_data/events",
+    ]);
+  });
+});
+
+describe("workflow_node_context", () => {
+  it("evaluates an unsaved draft config without touching the saved workflow", async () => {
+    mocks.spacesFetch.mockResolvedValueOnce({ context: {} });
+
+    const tool = await loadTool("workflow_node_context");
+    const draft = { trigger: { type: "MANUAL" }, steps: [{ id: "a" }] };
+    await tool.handler({ config: draft, atStepId: "a", workflowId: "wf-1" }, ctx);
+
+    expect(calledPaths()).toEqual(["/api/workflows-v2/claw/schema/available-context"]);
+    expect(bodyOf(0)).toEqual({ config: draft, atStepId: "a" });
+  });
+
+  it("falls back to the saved config of the workflow in scope", async () => {
+    mocks.spacesFetch.mockResolvedValueOnce({ config: '{"trigger":{"type":"MANUAL"},"steps":[]}' });
+    mocks.spacesFetch.mockResolvedValueOnce({ context: {} });
+
+    const tool = await loadTool("workflow_node_context");
+    await tool.handler({ atStepId: "a", workflowId: "wf-1" }, ctx);
+
+    expect(calledPaths()).toEqual([
+      "/api/workflows-v2/claw/workflows/wf-1",
+      "/api/workflows-v2/claw/schema/available-context",
+    ]);
+    expect(bodyOf(1)).toMatchObject({ atStepId: "a" });
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-workflows-tools.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-workflows-tools.ts
@@ -1,0 +1,595 @@
+/**
+ * Xyne Workflows MCP tool definitions — Ask AI's workflow authoring + run toolset.
+ *
+ * A DEDICATED server, like xyne-dashboard and for the same reason: these tools are pinned
+ * to the agents that should author workflows, so no other agent's palette sees them. They
+ * call the Spaces backend's /api/workflows-v2/claw/* mount, which is the `@xyne/workflow-sdk`
+ * HTTP surface narrowed to an agent-safe allowlist and running as the signed-in user.
+ *
+ * Not merged into xyne-spaces-tools.ts on purpose. That file already carries
+ * `spaces-workflow-stats`, which reads the LEGACY workflow engine — a different set of
+ * tables with a contradicting status vocabulary (SUCCESS/FAILURE there, COMPLETED/FAILED
+ * here). Keeping the two in separate servers with separate naming (`workflow_*` vs
+ * `spaces-workflow-*`) is what stops the model blending them.
+ *
+ * `workflowId` and `executionId` are injected per-session by claw-auth's MCP /call
+ * boundary from where the user opened Ask AI (see mcp/run-scalars.ts) — the model never
+ * supplies them, and cannot override them.
+ */
+
+import { spacesFetch } from "./xyne-spaces-client.js";
+import { errMsg } from "../../lib/errors.js";
+
+const BASE = "/api/workflows-v2/claw";
+
+interface ToolResult {
+  [key: string]: unknown;
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}
+
+export interface HandlerContext {
+  userId: string;
+}
+
+export interface ToolDef {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  handler: (params: Record<string, unknown>, ctx: HandlerContext) => Promise<ToolResult>;
+}
+
+function ok(text: string): ToolResult {
+  return { content: [{ type: "text", text }] };
+}
+
+function err(text: string): ToolResult {
+  return { content: [{ type: "text", text }], isError: true };
+}
+
+/** JSON back to the model. Pretty-printed: these are configs a model has to edit, and
+ *  two spaces of indentation costs far less than a mis-parsed one-liner costs in retries. */
+function okJson(value: unknown): ToolResult {
+  return ok(JSON.stringify(value, null, 2));
+}
+
+/** spacesFetch folds a non-2xx body into its Error message. Dig the SDK's `{ error }` out
+ *  so the agent reads "Body must contain a folderId" rather than a JSON-escaped blob. */
+function modelText(e: unknown, tool: string): string {
+  const raw = errMsg(e);
+  const jsonStart = raw.indexOf("{");
+  if (jsonStart >= 0) {
+    try {
+      const parsed = JSON.parse(raw.slice(jsonStart)) as { error?: string; message?: string };
+      const text = parsed?.error ?? parsed?.message;
+      if (typeof text === "string" && text) return `${tool}: ${text}`;
+    } catch {
+      // fall through to the raw message
+    }
+  }
+  return `${tool} failed: ${raw}`;
+}
+
+async function get(path: string): Promise<unknown> {
+  return spacesFetch(`${BASE}${path}`);
+}
+
+async function send(method: "POST" | "PUT", path: string, body: unknown): Promise<unknown> {
+  return spacesFetch(`${BASE}${path}`, { method, body: JSON.stringify(body ?? {}) });
+}
+
+// Injected per-run by claw-auth. Declared so schema validation tolerates the injected
+// keys, described so the model does not try to fill them itself.
+const RUN_CTX_PROPS = {
+  workflowId: { type: "string", description: "Set automatically for this session — never provide." },
+  executionId: { type: "string", description: "Set automatically for this session — never provide." },
+  focusedStepId: { type: "string", description: "Set automatically for this session — never provide." },
+} as const;
+
+function requireWorkflowId(params: Record<string, unknown>, tool: string): string | ToolResult {
+  const id = typeof params["workflowId"] === "string" ? params["workflowId"].trim() : "";
+  if (id) return id;
+  return err(
+    `${tool}: no workflow in scope. This session was not opened on a workflow — ` +
+      "use workflow_list to find one and tell the user which you mean, or ask them to " +
+      "open the workflow first.",
+  );
+}
+
+function isToolResult(v: string | ToolResult): v is ToolResult {
+  return typeof v !== "string";
+}
+
+// ─── Discovery ───
+
+const workflowCatalog: ToolDef = {
+  name: "workflow_catalog",
+  description:
+    "The building blocks available for authoring. Call with NO arguments first: returns a " +
+    "compact index of every step type and trigger type (name, description, category) plus " +
+    "the condition operators — enough to choose. Then call again with `stepTypes` and/or " +
+    "`triggerTypes` to get the FULL config + output JSON Schemas for just the ones you " +
+    "picked. Batch them in one call. Never author a config from the index alone: the " +
+    "schemas carry required fields, enums and formats you cannot guess, and a config that " +
+    "misses them fails validation.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      ...RUN_CTX_PROPS,
+      stepTypes: {
+        type: "array",
+        items: { type: "string", minLength: 1 },
+        maxItems: 12,
+        description: 'Step types to expand, e.g. ["HTTP_REQUEST", "CODE"].',
+      },
+      triggerTypes: {
+        type: "array",
+        items: { type: "string", minLength: 1 },
+        maxItems: 8,
+        description: 'Trigger types to expand, e.g. ["CRON"].',
+      },
+    },
+  },
+  async handler(params) {
+    const stepTypes = Array.isArray(params["stepTypes"]) ? (params["stepTypes"] as string[]) : [];
+    const triggerTypes = Array.isArray(params["triggerTypes"])
+      ? (params["triggerTypes"] as string[])
+      : [];
+
+    try {
+      if (stepTypes.length === 0 && triggerTypes.length === 0) {
+        const [steps, triggers, operators] = await Promise.all([
+          get("/schema/steps"),
+          get("/schema/triggers"),
+          get("/schema/operators"),
+        ]);
+        return okJson({
+          ...(steps as object),
+          ...(triggers as object),
+          ...(operators as object),
+          hint: "Call workflow_catalog again with stepTypes/triggerTypes for full schemas.",
+        });
+      }
+
+      const [steps, triggers] = await Promise.all([
+        Promise.all(stepTypes.map((t) => get(`/schema/steps/${encodeURIComponent(t)}`))),
+        Promise.all(triggerTypes.map((t) => get(`/schema/triggers/${encodeURIComponent(t)}`))),
+      ]);
+      return okJson({
+        ...(steps.length > 0 ? { steps } : {}),
+        ...(triggers.length > 0 ? { triggers } : {}),
+      });
+    } catch (e) {
+      return err(modelText(e, "workflow_catalog"));
+    }
+  },
+};
+
+const workflowNodeContext: ToolDef = {
+  name: "workflow_node_context",
+  description:
+    "What a given step can REFERENCE. Returns the variable paths addressable at that point " +
+    "in the workflow — `trigger.*` and each earlier step's `output.*` — as JSON Schemas, " +
+    "scope-aware (a step inside a LOOP/MAP/PARALLEL branch sees a different set than one " +
+    "outside it). Call this before writing any {{...}} reference. Inventing a reference " +
+    "that is not in this list is the single most common way an authored workflow breaks: " +
+    "it passes validation shape-wise and then resolves to nothing at run time.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      ...RUN_CTX_PROPS,
+      config: {
+        type: "object",
+        description:
+          "The workflow config to evaluate against. Pass the draft you are building — it " +
+          "does not have to be saved. Omit to use the saved config of the workflow in scope.",
+      },
+      atStepId: {
+        type: "string",
+        minLength: 1,
+        description: "The step id to compute available references for.",
+      },
+    },
+    required: ["atStepId"],
+  },
+  async handler(params) {
+    const atStepId = String(params["atStepId"] ?? "").trim();
+    if (!atStepId) return err("workflow_node_context: atStepId is required");
+
+    try {
+      let config = params["config"];
+      if (!config) {
+        const id = requireWorkflowId(params, "workflow_node_context");
+        if (isToolResult(id)) return id;
+        const wf = (await get(`/workflows/${encodeURIComponent(id)}`)) as { config?: string };
+        config = typeof wf.config === "string" ? JSON.parse(wf.config) : wf.config;
+      }
+      const res = await send("POST", "/schema/available-context", { config, atStepId });
+      return okJson(res);
+    } catch (e) {
+      return err(modelText(e, "workflow_node_context"));
+    }
+  },
+};
+
+// ─── Authoring ───
+
+const workflowList: ToolDef = {
+  name: "workflow_list",
+  description:
+    "List the workflows this user can see, with their folders. Use to find a workflow by " +
+    "name when the session was not opened on one, or to pick a folder id for workflow_create.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      ...RUN_CTX_PROPS,
+      folderId: { type: "string", description: "Restrict to one folder." },
+    },
+  },
+  async handler(params) {
+    try {
+      const folderId = typeof params["folderId"] === "string" ? params["folderId"] : "";
+      const [workflows, folders] = await Promise.all([
+        get(`/workflows${folderId ? `?folderId=${encodeURIComponent(folderId)}` : ""}`),
+        get("/folders"),
+      ]);
+      return okJson({ ...(workflows as object), ...(folders as object) });
+    } catch (e) {
+      return err(modelText(e, "workflow_list"));
+    }
+  },
+};
+
+const workflowGet: ToolDef = {
+  name: "workflow_get",
+  description:
+    "Read one workflow: its name, summary, status and full config (trigger + steps). Use " +
+    "this before editing so you patch the real current config rather than reconstructing " +
+    "it from the conversation. Defaults to the workflow the user has open.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      ...RUN_CTX_PROPS,
+      id: { type: "string", description: "Workflow id. Omit to use the one in scope." },
+    },
+  },
+  async handler(params) {
+    const explicit = typeof params["id"] === "string" ? params["id"].trim() : "";
+    const id = explicit || requireWorkflowId(params, "workflow_get");
+    if (isToolResult(id)) return id;
+    try {
+      const wf = (await get(`/workflows/${encodeURIComponent(id)}`)) as Record<string, unknown>;
+      const config = typeof wf["config"] === "string" ? JSON.parse(wf["config"] as string) : wf["config"];
+      return okJson({ ...wf, config });
+    } catch (e) {
+      return err(modelText(e, "workflow_get"));
+    }
+  },
+};
+
+const workflowValidate: ToolDef = {
+  name: "workflow_validate",
+  description:
+    "Check a workflow config without saving it. Returns { valid, issues[] } where each " +
+    "issue names the step and field at fault. Cheap — run it whenever you are unsure, " +
+    "rather than saving and reading the failure back.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      ...RUN_CTX_PROPS,
+      config: { type: "object", description: "A full WorkflowConfig: { trigger, steps }." },
+    },
+    required: ["config"],
+  },
+  async handler(params) {
+    try {
+      return okJson(await send("POST", "/workflows/validate", params["config"]));
+    } catch (e) {
+      return err(modelText(e, "workflow_validate"));
+    }
+  },
+};
+
+const workflowCreate: ToolDef = {
+  name: "workflow_create",
+  description:
+    "Create a new workflow. Validates the config first and refuses to save an invalid one, " +
+    "returning the issues so you can fix them and retry. " +
+    "The workflow is created but LEFT SWITCHED OFF — its trigger is not registered, so a " +
+    "CRON will not fire and a WEBHOOK URL is not live until a person turns it on in the " +
+    "builder. Say so when you report back. You can still run it yourself with workflow_run " +
+    "to show the user it works.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      ...RUN_CTX_PROPS,
+      name: {
+        type: "string",
+        minLength: 1,
+        description:
+          "Letters, digits, spaces and _ ( ) + - only — the backend rejects anything else.",
+      },
+      config: { type: "object", description: "A full WorkflowConfig: { trigger, steps }." },
+      folderId: {
+        type: "string",
+        description: "Folder to create it in. Required — use workflow_list to find one.",
+      },
+      summary: {
+        type: "string",
+        description: "One or two sentences on what it does, shown in the workflow list.",
+      },
+    },
+    required: ["name", "config", "folderId"],
+  },
+  async handler(params) {
+    const config = params["config"];
+    try {
+      const validation = (await send("POST", "/workflows/validate", config)) as {
+        valid?: boolean;
+        issues?: unknown[];
+      };
+      if (!validation.valid) {
+        return err(
+          "workflow_create: config is not valid, nothing was saved. Fix these and call " +
+            `again:\n${JSON.stringify(validation.issues ?? [], null, 2)}`,
+        );
+      }
+
+      const created = (await send("POST", "/workflows", {
+        name: params["name"],
+        config,
+        folderId: params["folderId"],
+        ...(typeof params["summary"] === "string" ? { summary: params["summary"] } : {}),
+      })) as { id?: string };
+
+      if (!created.id) return err("workflow_create: backend returned no workflow id");
+
+      // createWorkflow hardcodes status ACTIVE and self-activates, which for a CRON or
+      // WEBHOOK trigger means it is live the moment it exists. Nothing an agent authored
+      // should start firing before a person has read it, so take the trigger back out of
+      // service straight away. Manual runs still work.
+      //
+      // Handled apart from the create because the two failures need opposite reactions:
+      // a failed create means nothing exists and retrying is right; a failed deactivate
+      // means the workflow DOES exist and IS live, and retrying would build a second one.
+      try {
+        await send("POST", `/workflows/${encodeURIComponent(created.id)}/deactivate`, {});
+      } catch (e) {
+        return err(
+          `Workflow ${created.id} was created but could NOT be switched off ` +
+            `(${errMsg(e)}). It is LIVE: a CRON trigger will fire and a WEBHOOK URL is ` +
+            "reachable. Do not create it again — tell the user to open it and turn it off " +
+            "if that is not what they wanted.",
+        );
+      }
+
+      return okJson({
+        id: created.id,
+        live: false,
+        note: "Created and switched off. A person must turn it on in the builder before its trigger fires.",
+      });
+    } catch (e) {
+      return err(modelText(e, "workflow_create"));
+    }
+  },
+};
+
+const workflowUpdate: ToolDef = {
+  name: "workflow_update",
+  description:
+    "Update an existing workflow. Validates before saving and refuses an invalid config. " +
+    "Pass the WHOLE config, not a fragment — read it with workflow_get, change what you " +
+    "need, send it back. Editing does not switch a workflow on or off.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      ...RUN_CTX_PROPS,
+      id: { type: "string", description: "Workflow id. Omit to use the one in scope." },
+      name: { type: "string", minLength: 1 },
+      config: { type: "object", description: "A full WorkflowConfig: { trigger, steps }." },
+      summary: { type: "string" },
+    },
+  },
+  async handler(params) {
+    const explicit = typeof params["id"] === "string" ? params["id"].trim() : "";
+    const id = explicit || requireWorkflowId(params, "workflow_update");
+    if (isToolResult(id)) return id;
+
+    const config = params["config"];
+    try {
+      if (config) {
+        const validation = (await send("POST", "/workflows/validate", config)) as {
+          valid?: boolean;
+          issues?: unknown[];
+        };
+        if (!validation.valid) {
+          return err(
+            "workflow_update: config is not valid, nothing was saved. Fix these and call " +
+              `again:\n${JSON.stringify(validation.issues ?? [], null, 2)}`,
+          );
+        }
+      }
+      const body: Record<string, unknown> = {};
+      if (typeof params["name"] === "string") body["name"] = params["name"];
+      if (config) body["config"] = config;
+      if (typeof params["summary"] === "string") body["summary"] = params["summary"];
+      if (Object.keys(body).length === 0) {
+        return err("workflow_update: pass at least one of name, config or summary");
+      }
+      return okJson(await send("PUT", `/workflows/${encodeURIComponent(id)}`, body));
+    } catch (e) {
+      return err(modelText(e, "workflow_update"));
+    }
+  },
+};
+
+// ─── Running and inspecting ───
+
+const workflowRun: ToolDef = {
+  name: "workflow_run",
+  description:
+    "Run a workflow now and return its executionId. Works even on a workflow that is " +
+    "switched off, so this is how you demonstrate one you just built. The run is " +
+    "asynchronous — poll workflow_run_get for the outcome rather than assuming success.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      ...RUN_CTX_PROPS,
+      id: { type: "string", description: "Workflow id. Omit to use the one in scope." },
+      payload: {
+        type: "object",
+        description:
+          "Trigger input. Must match the trigger's inputSchema — check it with " +
+          "workflow_catalog if the trigger declares one.",
+      },
+    },
+  },
+  async handler(params) {
+    const explicit = typeof params["id"] === "string" ? params["id"].trim() : "";
+    const id = explicit || requireWorkflowId(params, "workflow_run");
+    if (isToolResult(id)) return id;
+    try {
+      const res = await send(
+        "POST",
+        `/workflows/${encodeURIComponent(id)}/trigger`,
+        params["payload"] ?? {},
+      );
+      return okJson(res);
+    } catch (e) {
+      return err(modelText(e, "workflow_run"));
+    }
+  },
+};
+
+const workflowRunGet: ToolDef = {
+  name: "workflow_run_get",
+  description:
+    "Read one execution: overall status, and every step with its status, output and error. " +
+    "Defaults to the run the user has open. Status is COMPLETED | FAILED | RUNNING | " +
+    "PENDING | SCHEDULED | CANCELLED | SKIPPED | EXTERNAL_WAIT. EXTERNAL_WAIT is not a " +
+    "failure and not a hang — the run is parked at a gate waiting for a person or an " +
+    "external callback; say which step, and what it is waiting for.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      ...RUN_CTX_PROPS,
+      id: { type: "string", description: "Execution id. Omit to use the one in scope." },
+    },
+  },
+  async handler(params) {
+    const explicit = typeof params["id"] === "string" ? params["id"].trim() : "";
+    const id = explicit || (typeof params["executionId"] === "string" ? params["executionId"] : "");
+    if (!id) {
+      return err(
+        "workflow_run_get: no execution in scope. This session was not opened on a run — " +
+          "use workflow_run_list to find one.",
+      );
+    }
+    try {
+      return okJson(await get(`/executions/${encodeURIComponent(id)}`));
+    } catch (e) {
+      return err(modelText(e, "workflow_run_get"));
+    }
+  },
+};
+
+const workflowRunList: ToolDef = {
+  name: "workflow_run_list",
+  description:
+    "Recent executions, newest first. Filter by workflow and/or status to answer 'did it " +
+    "run last night', 'how often does this fail', 'what is stuck right now'.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      ...RUN_CTX_PROPS,
+      id: { type: "string", description: "Workflow id to filter by. Omit to use the one in scope, if any." },
+      status: {
+        type: "string",
+        enum: [
+          "PENDING",
+          "SCHEDULED",
+          "RUNNING",
+          "COMPLETED",
+          "FAILED",
+          "CANCELLED",
+          "SKIPPED",
+          "EXTERNAL_WAIT",
+        ],
+      },
+      limit: { type: "integer", minimum: 1, maximum: 100, description: "Default 20." },
+    },
+  },
+  async handler(params) {
+    const explicit = typeof params["id"] === "string" ? params["id"].trim() : "";
+    const scoped = typeof params["workflowId"] === "string" ? params["workflowId"] : "";
+    const workflowId = explicit || scoped;
+    const query = new URLSearchParams();
+    if (workflowId) query.set("workflowId", workflowId);
+    if (typeof params["status"] === "string") query.set("status", params["status"]);
+    query.set("limit", String(params["limit"] ?? 20));
+    try {
+      return okJson(await get(`/executions?${query.toString()}`));
+    } catch (e) {
+      return err(modelText(e, "workflow_run_list"));
+    }
+  },
+};
+
+const workflowStepEvents: ToolDef = {
+  name: "workflow_step_events",
+  description:
+    "The event trail a single step emitted during a run — logs, sub-steps, tool calls, " +
+    "progress. Use this when a step failed and workflow_run_get's error line is not enough " +
+    "to explain why.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      ...RUN_CTX_PROPS,
+      stepName: {
+        type: "string",
+        minLength: 1,
+        description: "The step's id as it appears in the run. Omit to use the focused step.",
+      },
+      id: { type: "string", description: "Execution id. Omit to use the one in scope." },
+    },
+  },
+  async handler(params) {
+    const explicit = typeof params["id"] === "string" ? params["id"].trim() : "";
+    const execId = explicit || (typeof params["executionId"] === "string" ? params["executionId"] : "");
+    const named = typeof params["stepName"] === "string" ? params["stepName"].trim() : "";
+    const stepName = named || (typeof params["focusedStepId"] === "string" ? params["focusedStepId"] : "");
+    if (!execId) return err("workflow_step_events: no execution in scope, and no id given");
+    if (!stepName) return err("workflow_step_events: stepName is required");
+    try {
+      return okJson(
+        await get(
+          `/executions/${encodeURIComponent(execId)}/steps/${encodeURIComponent(stepName)}/events`,
+        ),
+      );
+    } catch (e) {
+      return err(modelText(e, "workflow_step_events"));
+    }
+  },
+};
+
+export const WORKFLOW_WRITE_TOOL_NAMES = [
+  "workflow_create",
+  "workflow_update",
+  "workflow_run",
+] as const;
+
+export const tools: ToolDef[] = [
+  workflowCatalog,
+  workflowNodeContext,
+  workflowList,
+  workflowGet,
+  workflowValidate,
+  workflowCreate,
+  workflowUpdate,
+  workflowRun,
+  workflowRunGet,
+  workflowRunList,
+  workflowStepEvents,
+];
+
+export const WORKFLOW_TOOL_NAMES: string[] = tools.map((tool) => tool.name);

--- a/apps/xyne-claw-auth/backend/src/mcp/static-adapters.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/static-adapters.ts
@@ -4,6 +4,7 @@ import { bitbucketAdapter } from "./adapters/bitbucket.js";
 import { kibanaAdapter } from "./adapters/kibana.js";
 import { xyneSpacesAdapter } from "./adapters/xyne-spaces.js";
 import { xyneDashboardAdapter } from "./adapters/xyne-dashboard.js";
+import { xyneWorkflowsAdapter } from "./adapters/xyne-workflows.js";
 import { figmaAdapter } from "./adapters/figma.js";
 import { ardraFinopsAdapter } from "./adapters/ardra-finops.js";
 import { sequencethinkingAdapter } from "./adapters/sequentialthinking.js";
@@ -57,6 +58,7 @@ export const STATIC_ADAPTERS: Record<string, McpAdapter> = {
   kibana: kibanaAdapter,
   "xyne-spaces": xyneSpacesAdapter,
   "xyne-dashboard": xyneDashboardAdapter,
+  "xyne-workflows": xyneWorkflowsAdapter,
   google: googleAdapter,
   microsoft: microsoftAdapter,
   figma: figmaAdapter,

--- a/apps/xyne-claw-auth/backend/src/routes/mcp.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/mcp.ts
@@ -1731,6 +1731,16 @@ router.post("/:sessionId/mcp/call", async (req: Request<{ sessionId: string }>, 
       };
     }
 
+    if (serverType === "xyne-workflows") {
+      const scalars = await loadRunScalars(req.params.sessionId);
+      effectiveParams = {
+        ...effectiveParams,
+        ...(scalars.workflowId ? { workflowId: scalars.workflowId } : {}),
+        ...(scalars.executionId ? { executionId: scalars.executionId } : {}),
+        ...(scalars.focusedStepId ? { focusedStepId: scalars.focusedStepId } : {}),
+      };
+    }
+
     // Write tools always require approval — cannot be overridden by agent config
     const definition = await resolveConnectorDefinition(serverType);
     const isWriteTool = definition?.writeTools?.includes(tool) ?? false;

--- a/apps/xyne-claw-auth/backend/src/routes/run.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/run.ts
@@ -1048,6 +1048,8 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
     };
     const attachedThreadConversationId = readAgentConfigString("SPACES_CONVERSATION_ID");
     const attachedCanvasViewAccessId = readAgentConfigString("SPACES_CANVAS_VIEW_ACCESS_ID");
+    const attachedWorkflowId = readAgentConfigString("SPACES_WORKFLOW_ID");
+    const attachedWorkflowExecutionId = readAgentConfigString("SPACES_WORKFLOW_EXECUTION_ID");
     let resolvedAttachedContext:
       | { contextFiles: Array<{ path: string; content: string }>; promptPrefix?: string }
       | undefined;
@@ -1057,7 +1059,13 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
       if (normalized.error) log.warn(`[run] attachedContext ignored: ${normalized.error}`);
       normalizedAttached = normalized.items;
     }
-    if (normalizedAttached.length > 0 || attachedThreadConversationId || attachedCanvasViewAccessId) {
+    if (
+      normalizedAttached.length > 0 ||
+      attachedThreadConversationId ||
+      attachedCanvasViewAccessId ||
+      attachedWorkflowId ||
+      attachedWorkflowExecutionId
+    ) {
       // Try to get Spaces auth from request cookies
       const spacesAuth = await resolveSpacesAuthFromRequest(req, resolved.userId);
       if (spacesAuth) {
@@ -1065,9 +1073,13 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
           resolvedAttachedContext = await buildAttachedContextPayload(normalizedAttached, spacesAuth, {
             ...(attachedThreadConversationId ? { threadConversationId: attachedThreadConversationId } : {}),
             ...(attachedCanvasViewAccessId ? { canvasViewAccessId: attachedCanvasViewAccessId } : {}),
+            ...(attachedWorkflowId ? { workflowId: attachedWorkflowId } : {}),
+            ...(attachedWorkflowExecutionId
+              ? { workflowExecutionId: attachedWorkflowExecutionId }
+              : {}),
           });
           log.info(
-            `[run] Resolved ${normalizedAttached.length} attached item(s)${attachedThreadConversationId ? " + thread" : ""}${attachedCanvasViewAccessId ? " + canvas" : ""} to ${resolvedAttachedContext.contextFiles.length} context files`,
+            `[run] Resolved ${normalizedAttached.length} attached item(s)${attachedThreadConversationId ? " + thread" : ""}${attachedCanvasViewAccessId ? " + canvas" : ""}${attachedWorkflowExecutionId ? " + workflow-run" : attachedWorkflowId ? " + workflow" : ""} to ${resolvedAttachedContext.contextFiles.length} context files`,
           );
         } catch (err) {
           log.warn(
@@ -1493,22 +1505,22 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
       storeAttachedContextForSession(sessionId, normalizedAttached).catch(() => {});
     }
 
-    // Dashboard-ai run scalars: the Spaces proxy passes the dashboard being
-    // edited via agentConfig. Stored per-session so the MCP /call boundary can
-    // force-inject them into xyne-dashboard tool calls. Fire-and-forget.
     {
       const ac = mergedAgentConfig as Record<string, unknown>;
       const scalar = (k: string): string | undefined =>
         typeof ac[k] === "string" && ac[k] ? (ac[k] as string) : undefined;
-      const dashboardDataSourceId = scalar("SPACES_DATA_SOURCE_ID");
-      const dashboardDraftId = scalar("SPACES_DASHBOARD_DRAFT_ID");
-      const dashboardFocusedComponentId = scalar("SPACES_FOCUSED_COMPONENT_ID");
-      if (dashboardDataSourceId || dashboardDraftId || dashboardFocusedComponentId) {
-        storeRunScalars(sessionId, {
-          ...(dashboardDataSourceId ? { dataSourceId: dashboardDataSourceId } : {}),
-          ...(dashboardDraftId ? { draftId: dashboardDraftId } : {}),
-          ...(dashboardFocusedComponentId ? { focusedComponentId: dashboardFocusedComponentId } : {}),
-        }).catch(() => {});
+      const pick = (k: string, v: string | undefined): Record<string, string> =>
+        v ? { [k]: v } : {};
+      const scalars = {
+        ...pick("dataSourceId", scalar("SPACES_DATA_SOURCE_ID")),
+        ...pick("draftId", scalar("SPACES_DASHBOARD_DRAFT_ID")),
+        ...pick("focusedComponentId", scalar("SPACES_FOCUSED_COMPONENT_ID")),
+        ...pick("workflowId", scalar("SPACES_WORKFLOW_ID")),
+        ...pick("executionId", scalar("SPACES_WORKFLOW_EXECUTION_ID")),
+        ...pick("focusedStepId", scalar("SPACES_WORKFLOW_STEP_ID")),
+      };
+      if (Object.keys(scalars).length > 0) {
+        storeRunScalars(sessionId, scalars).catch(() => {});
       }
     }
 

--- a/apps/xyne-claw-auth/backend/src/services/agentChatContextService.ts
+++ b/apps/xyne-claw-auth/backend/src/services/agentChatContextService.ts
@@ -223,11 +223,26 @@ export async function searchContextItems(type: ContextSearchType, q: string, lim
 export async function buildAttachedContextPayload(
   items: AttachedContextRef[],
   auth?: SpacesAuthContext,
-  opts?: { threadConversationId?: string; canvasViewAccessId?: string },
+  opts?: {
+    threadConversationId?: string;
+    canvasViewAccessId?: string;
+    workflowId?: string;
+    workflowExecutionId?: string;
+  },
 ): Promise<{ promptPrefix?: string; contextFiles: ContextFile[] }> {
   const threadConversationId = opts?.threadConversationId;
   const canvasViewAccessId = opts?.canvasViewAccessId;
-  if (items.length === 0 && !threadConversationId && !canvasViewAccessId) return { contextFiles: [] };
+  const workflowId = opts?.workflowId;
+  const workflowExecutionId = opts?.workflowExecutionId;
+  if (
+    items.length === 0 &&
+    !threadConversationId &&
+    !canvasViewAccessId &&
+    !workflowId &&
+    !workflowExecutionId
+  ) {
+    return { contextFiles: [] };
+  }
 
   const sections = await Promise.all(items.map(async (item) => {
     try {
@@ -277,6 +292,10 @@ export async function buildAttachedContextPayload(
         inlineText: `Unable to resolve canvas: ${message}. Read it with \`spaces-read-canvas\` (viewAccessId=${canvasViewAccessId}).`,
       });
     }
+  }
+
+  if (workflowId || workflowExecutionId) {
+    sections.unshift(buildWorkflowScopeSection(workflowId, workflowExecutionId));
   }
 
   const lines: string[] = [
@@ -599,6 +618,33 @@ async function resolveActivitySection(item: AttachedContextRef): Promise<Resolve
 /** A Spaces thread/conversation the user opened the assistant from. It arrives
  *  as agentConfig.SPACES_CONVERSATION_ID (NOT via the attachedContext array),
  *  so it's resolved here and folded into the same "# Attached context" block. */
+function buildWorkflowScopeSection(
+  workflowId?: string,
+  workflowExecutionId?: string,
+): ResolvedContextSection {
+  if (workflowExecutionId) {
+    return {
+      header: `Workflow run (executionId=${workflowExecutionId})`,
+      inlineText: [
+        "The user is looking at this run in the workflow viewer, and is almost certainly",
+        "asking about it. Your `workflow_*` tools are already scoped to it — call",
+        "`workflow_run_get` with no id to read its status, steps and errors, and",
+        "`workflow_step_events` for a step that failed. Do not call `workflow_run_list` to",
+        "find it; it is already in scope.",
+      ].join(" "),
+    };
+  }
+  return {
+    header: `Workflow (id=${workflowId})`,
+    inlineText: [
+      "The user is looking at this workflow in the builder, and is almost certainly asking",
+      "about it — read \"this workflow\" as this one. Your `workflow_*` tools are already",
+      "scoped to it: call `workflow_get` with no id to read its current definition. Do not",
+      "call `workflow_list` to work out which workflow is meant.",
+    ].join(" "),
+  };
+}
+
 async function resolveThreadSection(conversationId: string, auth?: SpacesAuthContext): Promise<ResolvedContextSection> {
   const header = `Spaces thread (conversationId=${conversationId})`;
   const rows = (await interact({

--- a/apps/xyne-claw-auth/backend/src/services/agentChatContextService.workflow.test.ts
+++ b/apps/xyne-claw-auth/backend/src/services/agentChatContextService.workflow.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The workflow scope section is pure — no Spaces call — so the client is stubbed only to
+// keep the module import side-effect free.
+vi.mock("../mcp/servers/xyne-spaces-client.js", () => ({
+  interact: vi.fn(),
+  spacesFetch: vi.fn(),
+  spacesFetchText: vi.fn(),
+  spacesFetchBuffer: vi.fn(),
+}));
+
+const { buildAttachedContextPayload } = await import("./agentChatContextService.js");
+
+/** The prompt block the agent actually reads. */
+async function promptFor(opts: Parameters<typeof buildAttachedContextPayload>[2]): Promise<string> {
+  const res = await buildAttachedContextPayload([], undefined, opts);
+  return res.promptPrefix ?? "";
+}
+
+describe("workflow scope in the attached-context block", () => {
+  it("says nothing when no workflow is in scope", async () => {
+    const res = await buildAttachedContextPayload([], undefined, {});
+    expect(res.promptPrefix ?? "").toBe("");
+    expect(res.contextFiles).toEqual([]);
+  });
+
+  it("names the workflow the builder has open", async () => {
+    const prompt = await promptFor({ workflowId: "wf-1" });
+    expect(prompt).toContain("# Attached context");
+    expect(prompt).toContain("Workflow (id=wf-1)");
+  });
+
+  it("tells the agent the tools are already scoped, so it stops listing to find it", async () => {
+    // The defect this fixes: with only a run scalar and no prose, the agent opened by
+    // calling workflow_list and describing "one workflow — Test" instead of answering
+    // about the one on screen.
+    const prompt = await promptFor({ workflowId: "wf-1" });
+    expect(prompt).toContain("workflow_get");
+    expect(prompt).toContain("Do not call `workflow_list`");
+  });
+
+  it("describes a run rather than a definition when an execution is in scope", async () => {
+    const prompt = await promptFor({ workflowExecutionId: "ex-9" });
+    expect(prompt).toContain("Workflow run (executionId=ex-9)");
+    expect(prompt).toContain("workflow_run_get");
+    expect(prompt).toContain("workflow_step_events");
+    expect(prompt).not.toContain("workflow_get with no id to read its current definition");
+  });
+
+  it("prefers the run when both ids ride along, since that is the narrower subject", async () => {
+    const prompt = await promptFor({ workflowId: "wf-1", workflowExecutionId: "ex-9" });
+    expect(prompt).toContain("Workflow run (executionId=ex-9)");
+    expect(prompt).not.toContain("Workflow (id=wf-1)");
+  });
+
+  it("puts the workflow first — it is the subject, not a footnote", async () => {
+    const prompt = await promptFor({ workflowId: "wf-1" });
+    const headingIndex = prompt.indexOf("## Workflow (id=wf-1)");
+    expect(headingIndex).toBeGreaterThan(-1);
+    // Nothing but the block preamble precedes it.
+    expect(prompt.slice(0, headingIndex)).not.toContain("##");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,7 +299,7 @@ importers:
         version: 1.18.1(debug@4.4.3)
       blocknote-layout-server-utils:
         specifier: 4.2.0
-        version: 4.2.0(@blocknote/core@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(highlight.js@11.11.1)(lowlight@3.3.0)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(@blocknote/react@0.54.0(@floating-ui/dom@1.8.0)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(highlight.js@11.11.1)(lowlight@3.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(react-icons@5.7.0(react@19.2.3))(react@19.2.3)
+        version: 4.2.0(@blocknote/core@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(highlight.js@11.11.1)(lowlight@3.3.0)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(@blocknote/react@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(highlight.js@11.11.1)(lowlight@3.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(react-icons@5.7.0(react@19.2.3))(react@19.2.3)
       bull:
         specifier: ^4.16.5
         version: 4.16.5
@@ -952,8 +952,8 @@ importers:
         specifier: 3.2.36
         version: 3.2.36(@earendil-works/pi-agent-core@0.80.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.1)(zod@4.3.6))(@earendil-works/pi-ai@0.80.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.1)(zod@4.3.6))(@earendil-works/pi-coding-agent@0.80.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.1)(zod@4.3.6))(typebox@1.3.8)
       '@xyne/workflow-ui':
-        specifier: 1.3.34
-        version: 1.3.34(@babel/runtime@7.29.7)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@tanstack/react-query@5.90.19(react@19.2.3))(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@xyne/workflow-sdk@3.2.36(@earendil-works/pi-agent-core@0.80.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.1)(zod@4.3.6))(@earendil-works/pi-ai@0.80.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.1)(zod@4.3.6))(@earendil-works/pi-coding-agent@0.80.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.1)(zod@4.3.6))(typebox@1.3.8))(codemirror@6.0.2)(immer@11.1.15)(react-dom@19.2.3(react@19.2.3))(react-is@18.3.1)(react@19.2.3)
+        specifier: 1.3.35
+        version: 1.3.35(@babel/runtime@7.29.7)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@tanstack/react-query@5.90.19(react@19.2.3))(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@xyne/workflow-sdk@3.2.36(@earendil-works/pi-agent-core@0.80.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.1)(zod@4.3.6))(@earendil-works/pi-ai@0.80.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.1)(zod@4.3.6))(@earendil-works/pi-coding-agent@0.80.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.1)(zod@4.3.6))(typebox@1.3.8))(codemirror@6.0.2)(immer@11.1.15)(react-dom@19.2.3(react@19.2.3))(react-is@18.3.1)(react@19.2.3)
       '@y-sweet/client':
         specifier: ^0.9.1
         version: 0.9.1(yjs@13.6.31)
@@ -2099,13 +2099,13 @@ importers:
         version: 16.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.20.1)
+        version: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
       prettier:
         specifier: 3.5.3
         version: 3.5.3
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.12(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.20.1))(typescript@5.8.3)
+        version: 29.4.12(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3)))(typescript@5.8.3)
       tsx:
         specifier: ^4.20.4
         version: 4.23.1
@@ -10461,8 +10461,8 @@ packages:
       typebox:
         optional: true
 
-  '@xyne/workflow-ui@1.3.34':
-    resolution: {integrity: sha512-R94cGcl8rn38lBGeDJ1MlIOhcLIOzKefAeRYbqtVWn9IVGoBlgToI6UGEpCCVkie5YPEvi3Km7aMYUjulqjpgw==}
+  '@xyne/workflow-ui@1.3.35':
+    resolution: {integrity: sha512-7gGfbSm1ysHaD46flGPFN5392yizoHw3WgXFdQBnOzZyqiTve5g6AD3o6BgJfjXB7osBa3oh3zyZBL4oLx9QuQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
@@ -23728,6 +23728,41 @@ snapshots:
       - supports-color
       - ts-node
 
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.43
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   '@jest/environment@29.7.0':
     dependencies:
       '@jest/fake-timers': 29.7.0
@@ -30766,7 +30801,7 @@ snapshots:
       '@earendil-works/pi-coding-agent': 0.80.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.1)(zod@4.3.6)
       typebox: 1.3.8
 
-  '@xyne/workflow-ui@1.3.34(@babel/runtime@7.29.7)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@tanstack/react-query@5.90.19(react@19.2.3))(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@xyne/workflow-sdk@3.2.36(@earendil-works/pi-agent-core@0.80.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.1)(zod@4.3.6))(@earendil-works/pi-ai@0.80.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.1)(zod@4.3.6))(@earendil-works/pi-coding-agent@0.80.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.1)(zod@4.3.6))(typebox@1.3.8))(codemirror@6.0.2)(immer@11.1.15)(react-dom@19.2.3(react@19.2.3))(react-is@18.3.1)(react@19.2.3)':
+  '@xyne/workflow-ui@1.3.35(@babel/runtime@7.29.7)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@tanstack/react-query@5.90.19(react@19.2.3))(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@xyne/workflow-sdk@3.2.36(@earendil-works/pi-agent-core@0.80.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.1)(zod@4.3.6))(@earendil-works/pi-ai@0.80.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.1)(zod@4.3.6))(@earendil-works/pi-coding-agent@0.80.7(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.1)(zod@4.3.6))(typebox@1.3.8))(codemirror@6.0.2)(immer@11.1.15)(react-dom@19.2.3(react@19.2.3))(react-is@18.3.1)(react@19.2.3)':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/lang-javascript': 6.2.5
@@ -31435,7 +31470,7 @@ snapshots:
   blocknote-layout-extensions@4.2.0(8fa8305b3dd8345bc9c24c360a72c350):
     dependencies:
       blocknote-layout-core: 4.2.0(@blocknote/core@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(highlight.js@11.11.1)(lowlight@3.3.0)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))
-      blocknote-layout-mentions: 4.2.0(@blocknote/core@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(highlight.js@11.11.1)(lowlight@3.3.0)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(@blocknote/react@0.54.0(@floating-ui/dom@1.8.0)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(highlight.js@11.11.1)(lowlight@3.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(react-icons@5.7.0(react@19.2.3))(react@19.2.3)
+      blocknote-layout-mentions: 4.2.0(@blocknote/core@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(highlight.js@11.11.1)(lowlight@3.3.0)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(@blocknote/react@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(highlight.js@11.11.1)(lowlight@3.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(react-icons@5.7.0(react@19.2.3))(react@19.2.3)
       blocknote-layout-slideshow: 4.2.0(d43cf2b008f1e1ee63ed02488fb426b7)
       blocknote-layout-whiteboard: 4.2.0(2dfbe3058f1512013378b1a751b106b1)
     transitivePeerDependencies:
@@ -31452,17 +31487,17 @@ snapshots:
       - react-icons
       - supports-color
 
-  blocknote-layout-mentions@4.2.0(@blocknote/core@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(highlight.js@11.11.1)(lowlight@3.3.0)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(@blocknote/react@0.54.0(@floating-ui/dom@1.8.0)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(highlight.js@11.11.1)(lowlight@3.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(react-icons@5.7.0(react@19.2.3))(react@19.2.3):
+  blocknote-layout-mentions@4.2.0(@blocknote/core@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(highlight.js@11.11.1)(lowlight@3.3.0)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(@blocknote/react@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(highlight.js@11.11.1)(lowlight@3.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(react-icons@5.7.0(react@19.2.3))(react@19.2.3):
     dependencies:
       '@blocknote/core': 0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(highlight.js@11.11.1)(lowlight@3.3.0)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
       '@blocknote/react': 0.54.0(@floating-ui/dom@1.8.0)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(highlight.js@11.11.1)(lowlight@3.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
       react: 19.2.3
       react-icons: 5.7.0(react@19.2.3)
 
-  blocknote-layout-server-utils@4.2.0(@blocknote/core@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(highlight.js@11.11.1)(lowlight@3.3.0)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(@blocknote/react@0.54.0(@floating-ui/dom@1.8.0)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(highlight.js@11.11.1)(lowlight@3.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(react-icons@5.7.0(react@19.2.3))(react@19.2.3):
+  blocknote-layout-server-utils@4.2.0(@blocknote/core@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(highlight.js@11.11.1)(lowlight@3.3.0)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(@blocknote/react@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(highlight.js@11.11.1)(lowlight@3.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(react-icons@5.7.0(react@19.2.3))(react@19.2.3):
     dependencies:
       '@blocknote/core': 0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(highlight.js@11.11.1)(lowlight@3.3.0)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
-      blocknote-layout-mentions: 4.2.0(@blocknote/core@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(highlight.js@11.11.1)(lowlight@3.3.0)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(@blocknote/react@0.54.0(@floating-ui/dom@1.8.0)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(highlight.js@11.11.1)(lowlight@3.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(react-icons@5.7.0(react@19.2.3))(react@19.2.3)
+      blocknote-layout-mentions: 4.2.0(@blocknote/core@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(highlight.js@11.11.1)(lowlight@3.3.0)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(@blocknote/react@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(highlight.js@11.11.1)(lowlight@3.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(react-icons@5.7.0(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
       - '@blocknote/react'
       - react
@@ -31491,7 +31526,7 @@ snapshots:
       '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
       '@tiptap/react': 3.29.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       blocknote-layout-core: 4.2.0(@blocknote/core@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(highlight.js@11.11.1)(lowlight@3.3.0)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))
-      blocknote-layout-server-utils: 4.2.0(@blocknote/core@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(highlight.js@11.11.1)(lowlight@3.3.0)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(@blocknote/react@0.54.0(@floating-ui/dom@1.8.0)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(highlight.js@11.11.1)(lowlight@3.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(react-icons@5.7.0(react@19.2.3))(react@19.2.3)
+      blocknote-layout-server-utils: 4.2.0(@blocknote/core@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(highlight.js@11.11.1)(lowlight@3.3.0)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(@blocknote/react@0.54.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@types/hast@3.0.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(highlight.js@11.11.1)(lowlight@3.3.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(refractor@5.0.0)(y-prosemirror@1.3.7(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(react-icons@5.7.0(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       react-icons: 5.7.0(react@19.2.3)
@@ -32415,13 +32450,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.20.1):
+  create-jest@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.20.1)
+      jest-config: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -36379,16 +36414,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.20.1):
+  jest-cli@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.20.1)
+      create-jest: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.20.1)
+      jest-config: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.3
@@ -36429,7 +36464,38 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.20.1):
+  jest-config@29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.19.43
+      ts-node: 10.9.2(@types/node@22.20.1)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/test-sequencer': 29.7.0
@@ -36455,6 +36521,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.20.1
+      ts-node: 10.9.2(@types/node@22.20.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -36686,12 +36753,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.20.1):
+  jest@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.20.1)
+      jest-cli: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -42280,12 +42347,12 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.29.7)
       jest-util: 29.7.0
 
-  ts-jest@29.4.12(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.20.1))(typescript@5.8.3):
+  ts-jest@29.4.12(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3)))(typescript@5.8.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 29.7.0(@types/node@22.20.1)
+      jest: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -42340,6 +42407,25 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@22.20.1)(typescript@5.8.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.20.1
+      acorn: 8.18.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.8.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   ts-node@10.9.2(@types/node@24.13.3)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
