### PR TITLE
fix: XYNE-57690 stop Radar assigning items to cc'd users and mis-targ…

### DIFF
--- a/apps/backend/src/services/radar/radarExecutionService.ts
+++ b/apps/backend/src/services/radar/radarExecutionService.ts
@@ -9,7 +9,7 @@ import {
   type ParserOpenItem,
   type ParserWindowMessage,
 } from '@/services/radar/radarParser';
-import { validateTransitions } from '@/services/radar/radarValidator';
+import { noOpReassignFeedback, validateTransitions } from '@/services/radar/radarValidator';
 import { radarApplier } from '@/services/radar/radarApplier';
 import type { RadarScope } from '@/services/radar/radarScope';
 
@@ -263,18 +263,6 @@ class RadarExecutionService {
             new Set(openItems.map(i => i.conversationId)),
             scope.isDmChannel,
           );
-          const transitions = await radarParser.parseWindow(
-            openItems.map(({ conversationId, ...item }) =>
-              threadLabels.size > 0
-                ? { ...item, thread: threadLabels.get(conversationId) ?? null }
-                : item,
-            ),
-            this.toParserMessages(window, mentionsByMessage, nameById, attachmentsByMessage, threadLabels),
-            knownUsers,
-            this.toParserMessages(context, contextMentions, nameById, attachmentsByMessage, threadLabels),
-          );
-          run.proposedOps = transitions.operations;
-          run.assessment = transitions.assessment;
           const windowSenders = new Map(window.map(m => [m.messageId, m.senderId]));
           // Legal assignees: window mentions + senders, plus everyone already
           // involved in the thread's open items or the context tail — the
@@ -302,17 +290,44 @@ class RadarExecutionService {
             window[0].workspaceId,
             candidateUserIds,
           );
-          const { valid, dropped } = validateTransitions(transitions.operations, {
+          const validationCtx = {
             openItems,
             windowSenders,
             // Mention ids are regex-scraped out of message HTML, so they are
             // attacker-authored: narrow them to ids that are really users in
             // this workspace before they can land in the ledger.
             allowedUserIds,
-          });
+          };
+          const transitions = await radarParser.parseWindow(
+            openItems.map(({ conversationId, ...item }) =>
+              threadLabels.size > 0
+                ? { ...item, thread: threadLabels.get(conversationId) ?? null }
+                : item,
+            ),
+            this.toParserMessages(window, mentionsByMessage, nameById, attachmentsByMessage, threadLabels),
+            knownUsers,
+            this.toParserMessages(context, contextMentions, nameById, attachmentsByMessage, threadLabels),
+            undefined,
+            // The validator doubles as the parser's semantic check: a reassign
+            // it would drop as a no-op goes back to the model once, because
+            // that drop nearly always means the wrong open item was matched.
+            ops => noOpReassignFeedback(validateTransitions(ops, validationCtx).dropped, openItems),
+          );
+          run.proposedOps = transitions.operations;
+          run.assessment = transitions.assessment;
+          const { valid, dropped } = validateTransitions(transitions.operations, validationCtx);
           await this.directDmOwnerless(valid, scope, windowSenders, allowedUserIds);
           run.validOps = valid;
-          run.droppedOps = dropped;
+          // A repaired pass keeps its first attempt's rejects in the trail,
+          // flagged, so the debug panel shows what the model was corrected on.
+          run.droppedOps = transitions.repair
+            ? [
+                ...validateTransitions(transitions.repair.firstAttempt, validationCtx).dropped.map(
+                  d => ({ ...d, repaired: true }),
+                ),
+                ...dropped,
+              ]
+            : dropped;
           const last = window[window.length - 1];
           const applied = await radarApplier.apply({
             workspaceId: last.workspaceId,

--- a/apps/backend/src/services/radar/radarParser.ts
+++ b/apps/backend/src/services/radar/radarParser.ts
@@ -73,7 +73,17 @@ export interface ParsedTransitions {
   operations: ParserOperation[];
   /** The model's one-sentence read of the window — why these ops, or why none. */
   assessment?: string;
+  /** Set when the caller's semantic check sent the first answer back: what the
+   *  model was told, and what it had proposed before being corrected. */
+  repair?: { feedback: string; firstAttempt: ParserOperation[] };
 }
+
+/**
+ * A caller-side judgment on a schema-valid response — in practice the
+ * validator's rejects. A string is sent back to the model for ONE more
+ * attempt; null accepts the response as it stands.
+ */
+export type SemanticCheck = (operations: ParserOperation[]) => string | null;
 
 /**
  * Everything the model may return, structurally. Per-op required fields
@@ -139,6 +149,7 @@ Decide which state transitions the new messages imply. Operations:
 2. "resolve" — ${RESOLVE_MEANING}. itemId: the open item's id, OR a tempId declared by a create in this same response.
 2b. When this window carries BOTH a new ask and the message that settles it, do not choose between them: emit the "create" with a tempId ("t1", "t2", …) and a "resolve" citing that same tempId. That is the ONLY way to close something raised in this same window — real ids come from the database and do not exist yet. Never invent an itemId that is neither in open_items nor a tempId you declared here, and never redirect a resolve onto a different open item because it looks similar: if what is being settled was raised in this window, the tempId is the answer.
 3. "reassign" — the ball moved on an open item: it was explicitly handed to someone, someone claimed it, or the ball bounced back to the asker: a clarifying question, a dispute ("works for me", "cannot reproduce", "I don't think that's a bug"), or any reply the requester must now verify, confirm or answer before the item can close. itemId + new pendingOn (a bounce-back goes to requested_by).
+   Which item a reassign targets: when more than one item is open and the message does not name one, the AUTHOR is the strongest signal — someone handing off or claiming work is talking about an item they are party to. Prefer an item whose pending_on includes the author (they hold it and are passing it on), then one whose requested_by includes the author (they are waiting on it). A reassign whose new pendingOn equals the item's current pending_on is a contradiction — the ball is already there — and means you matched the wrong item: target the item where the ball actually changes hands, or emit nothing. Never pick an item because its wording echoes the message ("check" / "checking"); pick by who holds what.
 
 A reply is not fulfillment. When the assignee responds without delivering what was asked — they push back, can't reproduce, disagree, answer partially, or hand back a question — the item stays OPEN and the ball moves to whoever must act next (usually the requester, via reassign). Only the requester's confirmation, an objectively delivered result, or an explicit withdrawal closes an item.
 
@@ -156,7 +167,7 @@ The only legal operation on a reaction pass is "resolve", and an empty operation
   - the reacted message settles ONE specific open item, per the resolve rule above. An item whose source_message_id equals the reacted message's id was RAISED BY that message: a completion emoji there is not a comment on a delivery, it is the reactor asserting that item is now finished — resolve it.
 Topical overlap is not settlement: a tick on a lunch plan settles nothing, even when the reactor holds open work in the thread. If two items fit equally well, emit nothing — a wrong close costs more than a missed one.
 
-Be conservative about chatter: greetings, acknowledgements, thanks, FYIs and status updates someone volunteers produce NO operations — an empty operations array is the normal answer for such windows. A bare @mention with no request text is a HANDOFF, not noise: tagging someone under shared content (a report, a table, a log, an error) or into a thread puts that content in front of them — create an item pending on the mentioned user, titled from what the content or thread is about (e.g. "Review the tagging coverage report"). The ONLY exception is an explicit cc: when the message itself marks the mention as informational — "cc @x", "fyi @x", "looping in @x for visibility" — it is not an ask, create nothing. But do not confuse conservatism with dropping real asks: a request or question directed at a mentioned user is never chatter. Do not create an item for something an open item already covers — check open_items BEFORE every create, and treat a near-match as a match: the same work described in different words, a follow-up nudge on an ask already tracked ("any update on this?", "still waiting"), or a restatement with more detail is the SAME item, not a new one. Create a second item only when you are confident it is genuinely a different piece of work; when it could plausibly be either, say so in the assessment and create nothing; do not resolve on a vague "ok" unless it clearly confirms completion.
+Be conservative about chatter: greetings, acknowledgements, thanks, FYIs and status updates someone volunteers produce NO operations — an empty operations array is the normal answer for such windows. A bare @mention with no request text is a HANDOFF, not noise: tagging someone under shared content (a report, a table, a log, an error) or into a thread puts that content in front of them — create an item pending on the mentioned user, titled from what the content or thread is about (e.g. "Review the tagging coverage report"). The ONLY exception is an explicit cc: when the message itself marks the mention as informational — "cc @x", "fyi @x", "looping in @x for visibility" — it is not an ask, create nothing. This holds even when the rest of the message carries real content — a diagnosis, a plan, a "Fix:" line: a user the message cc's is never pendingOn for anything that message raises, and an author describing work they will do themselves is claiming the existing item (leave it on them), not opening a new one on the people cc'd. But do not confuse conservatism with dropping real asks: a request or question directed at a mentioned user is never chatter. Do not create an item for something an open item already covers — check open_items BEFORE every create, and treat a near-match as a match: the same work described in different words, a follow-up nudge on an ask already tracked ("any update on this?", "still waiting"), or a restatement with more detail is the SAME item, not a new one. Create a second item only when you are confident it is genuinely a different piece of work; when it could plausibly be either, say so in the assessment and create nothing; do not resolve on a vague "ok" unless it clearly confirms completion.
 
 Besides operations, ALWAYS return assessment: ONE short sentence giving your overall read of this window — what the messages were and why you produced these operations. When operations is empty this matters most: say exactly why nothing is trackable (e.g. "bare mention used as a cc on a shared report — no ask directed at anyone").
 
@@ -269,6 +280,7 @@ class RadarParser {
     knownUsers: Record<string, string> = {},
     contextMessages: ParserWindowMessage[] = [],
     reaction?: { by: string; emoji: string },
+    semanticCheck?: SemanticCheck,
   ): Promise<ParsedTransitions> {
     const { apiKey, baseUrl, keyName } = this.resolveAuth();
 
@@ -302,20 +314,43 @@ class RadarParser {
     ];
 
     let lastError = '';
-    for (let attempt = 0; attempt <= MAX_REPAIR_ATTEMPTS; attempt++) {
+    let schemaRepairs = 0;
+    let repair: ParsedTransitions['repair'];
+    // Two separate budgets: schema repairs keep their cap, and the single
+    // semantic round-trip never eats into it.
+    for (;;) {
       const raw = await callLiteLLM({ apiKey, baseUrl, keyName }, model, messages);
       const parsed = tryParseJson(raw);
 
-      if (!parsed.ok) {
-        lastError = `Response was not valid JSON: ${parsed.error}`;
-      } else {
+      if (parsed.ok) {
         const errors = validate(parsed.value, TRANSITIONS_SCHEMA);
-        if (errors.length === 0) return parsed.value as ParsedTransitions;
+        if (errors.length === 0) {
+          const value = parsed.value as ParsedTransitions;
+          const feedback = !repair && semanticCheck ? semanticCheck(value.operations) : null;
+          if (!feedback) return repair ? { ...value, repair } : value;
+          // Structurally fine, but the caller can show it is empty: hand the
+          // model its own answer and the reason, once. The second answer is
+          // final either way — the validator still stands behind it.
+          repair = { feedback, firstAttempt: value.operations };
+          logger.warn(`${TAG} response rejected by semantic check, retrying once`, {
+            feedback: feedback.slice(0, 300),
+          });
+          messages.push({ role: 'assistant', content: raw.slice(0, 4000) });
+          messages.push({
+            role: 'user',
+            content: `${feedback}\n\nReturn only valid JSON matching the schema. No prose, no code fences.`,
+          });
+          continue;
+        }
         lastError = formatErrors(errors);
+      } else {
+        lastError = `Response was not valid JSON: ${parsed.error}`;
       }
 
+      if (schemaRepairs >= MAX_REPAIR_ATTEMPTS) break;
+      schemaRepairs++;
       logger.warn(`${TAG} response rejected, retrying`, {
-        attempt: attempt + 1,
+        attempt: schemaRepairs,
         error: lastError.slice(0, 300),
       });
       messages.push({ role: 'assistant', content: raw.slice(0, 4000) });

--- a/apps/backend/src/services/radar/radarValidator.ts
+++ b/apps/backend/src/services/radar/radarValidator.ts
@@ -35,6 +35,41 @@ export interface ValidationResult {
   dropped: DroppedOperation[];
 }
 
+/** Matched by noOpReassignFeedback below; keep the two together. */
+const NO_OP_REASSIGN = 'no-op reassign (pendingOn unchanged)';
+
+/**
+ * Turns this pass's no-op reassigns into one message for the parser's
+ * semantic repair. A reassign that changes nothing almost always means the
+ * model matched the wrong open item — it can see every item's pending_on, so
+ * the fix is to make it look again, with "nothing moves" as a legal answer.
+ * Null when there is nothing to send back.
+ */
+export function noOpReassignFeedback(
+  dropped: DroppedOperation[],
+  openItems: ParserOpenItem[],
+): string | null {
+  const noOps = dropped.filter(d => d.reason === NO_OP_REASSIGN);
+  if (noOps.length === 0) return null;
+  const byId = new Map(openItems.map(i => [i.id, i]));
+  const lines = noOps.map(({ op }) => {
+    const title = byId.get(op.itemId as string)?.title ?? '?';
+    return (
+      `- reassign of item ${op.itemId} ("${title}") to [${(op.pendingOn ?? []).join(', ')}] ` +
+      'changed nothing: that item is already pending on exactly those users.'
+    );
+  });
+  return [
+    'Your response was structurally valid but these operations were rejected:',
+    ...lines,
+    'A reassign to whoever already holds the ball means you matched the wrong item. ' +
+      'Re-read open_items and their pending_on. If a DIFFERENT open item is what this ' +
+      'message actually moves — the one the author holds or is waiting on — target that ' +
+      'one. If nothing in the message truly changes who holds the ball, return an empty ' +
+      'operations array. Never reassign an item to its current pending_on.',
+  ].join('\n');
+}
+
 /** Hard caps on model output: transaction budget and feed layout both bound. */
 const MAX_OPERATIONS = 50;
 const MAX_TITLE_CHARS = 300;
@@ -146,7 +181,7 @@ export function validateTransitions(
         }
         const current = [...item.pending_on].sort().join(',');
         if (pendingOn.slice().sort().join(',') === current) {
-          dropped.push({ op, reason: 'no-op reassign (pendingOn unchanged)' });
+          dropped.push({ op, reason: NO_OP_REASSIGN });
           continue;
         }
         valid.push({ ...op, pendingOn });


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

Two Radar parser defects, both observed on one real thread (XYNE-57690).

**1. A `cc:` created work for the people cc'd.** Priyanshu posted a root-cause
diagnosis ending in `cc: @Sourish @Mamtha` and `Fix: move OCR result write to GCS`.
The parser created an item *pending on Sourish and Mamtha* — putting work on two
people that the author was doing himself. The prompt's cc exemption was phrased
around "a bare @mention with no request text", so the model applied it correctly
to a pure cc three messages earlier and abandoned it here, once the message
carried real content. The rule now holds regardless of what else the message
says: a cc'd user is never `pendingOn` for anything that message raises, and an
author describing work they will do themselves claims the existing item rather
than opening a new one on the people cc'd.

**2. A status message reassigned the wrong item.** Mamtha's "@Priyanshu is
checking" targeted the older KB item — already pending on Priyanshu — instead of
the GCS item she actually held. Rule 3 said *when* to reassign but never *which*
item when several are open, so nothing pointed at the author as the signal and a
lexical echo ("check" / "checking") decided it. Rule 3 now prefers an item whose
`pending_on` includes the author, then one whose `requested_by` does, and treats
a reassign whose `pendingOn` equals the item's current `pending_on` as evidence
of a wrong match rather than a harmless no-op.

**The validator was correct throughout and is unchanged.** Its no-op drop caught
the bad op exactly as designed. What changes is that the drop is no longer
silent: `validateTransitions` now doubles as the parser's semantic check via a
new `noOpReassignFeedback`, and a response it would reject as a no-op goes back
to the model once. The feedback states "return an empty operations array" as a
legal answer — without that, the retry gets pressured into inventing a move in
the case where emitting nothing was right.

Reviewer notes:
- The semantic retry has its **own budget**, separate from `MAX_REPAIR_ATTEMPTS`.
  A schema repair and a semantic repair can't starve each other, and the semantic
  one never repeats — a second rejected answer is returned as-is for the validator
  to drop, same as today.
- `parseWindow`'s new `semanticCheck` parameter is optional and last, so
  `radarReactionResolver`'s call site is unchanged and behaves exactly as before.
- `validateTransitions` is called up to three times per pass now (semantic check,
  final, and once more to re-derive a repaired pass's first-attempt rejects for the
  run log). It's a pure function over data already in memory — no extra queries.
- A repaired pass keeps its first attempt's rejects in `droppedOps` flagged
  `repaired: true`, so the debug panel shows what the model was corrected on
  rather than silently showing a different proposal.

## Areas Touched

- [x] `apps/backend` (API / worker)

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Replayed the real thread end to end against the local stack — real messages
inserted as real users, the real Bull job, the real worker, parser, validator
and applier, against the dev Postgres. Not mocks. Prompt changes can only be
verified against a live model, so this is the evidence that matters.

**Scenario A — the actual thread (rows 5–8), one message per window:**

| Message | Before | After |
|---|---|---|
| Kushagar asks two people for help | create → Nasim+Sourish | create → Nasim+Sourish (unchanged) |
| Sourish: "@Priyanshu can you check this?" | reassign → Priyanshu | reassign → Priyanshu (unchanged) |
| Priyanshu: diagnosis + `cc:` + `Fix:` | **create → Sourish+Mamtha** | **create → ∅ (nobody)** |
| Mamtha: "@Priyanshu is checking" | reassign → dropped as no-op | **no operations at all** |

The model's own assessment on the cc message is now *"the message is a cc to
Sourish and Rohan, not a direct ask, so no one is pending on the new item"*.

**Scenario B — two open items with different holders**, to exercise reassign
targeting directly: the status message produced no operations, correctly
declining rather than reassigning the item already on that person.

### Automated

- [ ] Backend unit tests — not added; there is no existing test coverage for
      `radarParser`/`validateTransitions`, and the defect is prompt behaviour,
      which a unit test cannot assert. Verified by live replay instead (above).
- [x] Not covered by tests <!-- prompt behaviour; see live replay -->

### Manual

**Run mode**
- [x] Local dev — backend worker + LiteLLM `open-fast`, real dev Postgres

**Surface & data**
- [x] Error paths — schema-repair budget verified to remain independent of the
      semantic repair by reading the loop; both paths typecheck and build

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Backend `typecheck` + `build` pass (0 errors)
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*`
- [x] No debug logging or commented-out code left behind
- [ ] `pnpm run build:shared` — not run as a check, but `@xyne/shared` had to be
      rebuilt and the Prisma client regenerated before the backend would boot;
      both were stale on `main` beforehand, unrelated to this change
- [ ] Dashboard checks — no dashboard files touched