### PR TITLE
fix: XYNE-63438 reduce channel/DM switch style-recalc cost

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
+++ b/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
@@ -1169,7 +1169,7 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
       data-hover-key={hoverToolbarKey}
       className={cn(
         isMobile && 'no-select-mobile',
-        'group/bubble relative transition-all duration-200 ease-in-out',
+        'group/bubble relative transition-colors duration-200 ease-in-out',
         // Row highlight driven by the shared MessageHoverToolbar, which stamps
         // `data-hovered` on the [data-message-id] root. Applied at the root so
         // every sub-layout (message, link/canvas previews, reply layout) is

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -748,6 +748,16 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
     [message.messageId, clawCitationCtx],
   );
 
+  // Memoize the emoji font-size decision for the main message body. It was
+  // called inline in JSX on every render and internally builds a DOMParser
+  // Document (via isEmojiOnly -> htmlToPlainText); keying it on message.content
+  // keeps it from re-running on unrelated re-renders. Declared before the early
+  // returns below so the hook runs unconditionally on every render.
+  const emojiFontSizeClass = useMemo(
+    () => getEmojiFontSizeClass(message.content),
+    [message.content],
+  );
+
   if (!message) {
     return null;
   }
@@ -785,15 +795,6 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
 
   const isXyneBot = message.msgType === MessageType.BOT;
   const isShowInChannelHighlight = context === 'thread' && message.showInChannel === true;
-
-  // Memoize the emoji font-size decision for the main message body. It was
-  // called inline in JSX on every render and internally builds a DOMParser
-  // Document (via isEmojiOnly -> htmlToPlainText); keying it on message.content
-  // keeps it from re-running on unrelated re-renders.
-  const emojiFontSizeClass = useMemo(
-    () => getEmojiFontSizeClass(message.content),
-    [message.content],
-  );
 
   const messageBubbleClassName = getMessageBubbleClassName(
     shouldShowPending,

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -758,10 +758,6 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
     [message.content],
   );
 
-  if (!message) {
-    return null;
-  }
-
   // For mobile "my" messages, use the specialized mobile component
   const isSlashCommandArtifact = isSlashCommandArtifactMessage(message.content);
 

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -786,6 +786,15 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
   const isXyneBot = message.msgType === MessageType.BOT;
   const isShowInChannelHighlight = context === 'thread' && message.showInChannel === true;
 
+  // Memoize the emoji font-size decision for the main message body. It was
+  // called inline in JSX on every render and internally builds a DOMParser
+  // Document (via isEmojiOnly -> htmlToPlainText); keying it on message.content
+  // keeps it from re-running on unrelated re-renders.
+  const emojiFontSizeClass = useMemo(
+    () => getEmojiFontSizeClass(message.content),
+    [message.content],
+  );
+
   const messageBubbleClassName = getMessageBubbleClassName(
     shouldShowPending,
     variant,
@@ -1547,7 +1556,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                 <>
                   {hasMessageContent(message.content) && (
                     <div
-                      className={`jp-message-html whitespace-pre-wrap break-all-words inline-block ${getEmojiFontSizeClass(message.content)}`}
+                      className={`jp-message-html whitespace-pre-wrap break-all-words inline-block ${emojiFontSizeClass}`}
                       style={isSystemMessage ? systemMessageStyles : undefined}
                     >
                       {isMobile ? (

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -483,14 +483,6 @@
     @apply border-border;
   }
 
-  .scrollbar-none {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-  }
-  .scrollbar-none::-webkit-scrollbar {
-    display: none;
-  }
-
   /* Custom scrollbars: transparent rails + subtle thumb, scoped to the actual
      scroll containers (document root + Tailwind overflow utilities) instead of a
      universal `*` rule. The old `* { scrollbar-color: hsl(var(--border)) ... }`
@@ -500,8 +492,9 @@
      Scoping to elements that can actually show a scrollbar removes that cost while
      keeping the same appearance. The ::-webkit-scrollbar* rules below stay global:
      they match scrollbar pseudo-elements (only rendered on scrollable elements),
-     not real elements, so they do not defeat style sharing. Opt-out utilities
-     (.no-scrollbar, .scrollbar-none) still win via higher class specificity. */
+     not real elements, so they do not defeat style sharing. The opt-out utilities
+     .no-scrollbar and .scrollbar-none live in @layer utilities, which overrides
+     @layer base regardless of source order, so they still win over this rule. */
   html,
   body,
   #root,
@@ -1320,6 +1313,17 @@ span.chat-input-special-mention[data-mention-type="here"]:hover {
     /* IE and Edge */
     scrollbar-width: none;
     /* Firefox */
+  }
+
+  /* Opt out of the app-wide thin scrollbar entirely (no visible scrollbar).
+     Lives in @layer utilities so it overrides the scoped scrollbar rule in
+     @layer base regardless of source order. */
+  .scrollbar-none {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-none::-webkit-scrollbar {
+    display: none;
   }
 
   .thin-scrollbar {

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -491,11 +491,26 @@
     display: none;
   }
 
-  /* Custom scrollbars app-wide, every theme: transparent rails + subtle thumb.
-     Forcing a width switches WebKit off native scrollbars so the transparent
-     track actually applies. Opt-out utilities (.no-scrollbar, .scrollbar-none)
-     win via higher class specificity. */
-  * {
+  /* Custom scrollbars: transparent rails + subtle thumb, scoped to the actual
+     scroll containers (document root + Tailwind overflow utilities) instead of a
+     universal `*` rule. The old `* { scrollbar-color: hsl(var(--border)) ... }`
+     matched every element with declarations, which defeated Blink's ComputedStyle
+     sharing cache and forced a per-element re-resolution of the `--border` CSS var
+     on every style recalc. That dominated style-recalc time on channel/DM switch.
+     Scoping to elements that can actually show a scrollbar removes that cost while
+     keeping the same appearance. The ::-webkit-scrollbar* rules below stay global:
+     they match scrollbar pseudo-elements (only rendered on scrollable elements),
+     not real elements, so they do not defeat style sharing. Opt-out utilities
+     (.no-scrollbar, .scrollbar-none) still win via higher class specificity. */
+  html,
+  body,
+  #root,
+  .overflow-auto,
+  .overflow-x-auto,
+  .overflow-y-auto,
+  .overflow-scroll,
+  .overflow-x-scroll,
+  .overflow-y-scroll {
     scrollbar-width: thin;
     scrollbar-color: hsl(var(--border)) transparent;
   }

--- a/apps/dashboard/src/utils/emojiUtils.ts
+++ b/apps/dashboard/src/utils/emojiUtils.ts
@@ -140,8 +140,15 @@ export function isEmojiOnly(text: string): boolean {
   // Remove custom emoji images from HTML
   const textWithoutCustomEmojis = text.replace(customEmojiPattern, '');
 
-  // Now process as before
-  const strippedText = htmlToPlainText(textWithoutCustomEmojis);
+  // Avoid a full DOMParser round-trip for plain-text messages (the common
+  // emoji-only case, e.g. "🎉🎉🎉"). With no tags and no HTML entities
+  // there is nothing for htmlToPlainText to strip or decode, so the trimmed
+  // string is already the plain text. This removes the throwaway detached
+  // Document that was profiled as heap churn during message rendering.
+  const strippedText =
+    textWithoutCustomEmojis.includes('<') || textWithoutCustomEmojis.includes('&')
+      ? htmlToPlainText(textWithoutCustomEmojis)
+      : textWithoutCustomEmojis.trim();
 
   if (!strippedText && customEmojiCount === 0) {
     return false;


### PR DESCRIPTION
## Summary
Three targeted fixes for the style-recalculation that dominates channel/DM switch time, based on a Chrome performance trace analysis (Style recalc was ~54% of a 13.3s / 3-switch trace; Layout was negligible at 83ms).

1. **Scope the scrollbar CSS** (`apps/dashboard/src/global.css`) — replaced the universal `* { scrollbar-width; scrollbar-color: hsl(var(--border)) transparent }` rule with a scoped selector list (`html, body, #root` + Tailwind overflow utilities). The `*`-with-declarations rule defeated Blink's ComputedStyle sharing cache and forced a per-element re-resolution of the `--border` CSS var on every style recalc — the single largest contributor. The `::-webkit-scrollbar*` pseudo rules are kept global (they match scrollbar pseudo-elements, not real elements, so they don't defeat style sharing) to preserve WebKit scrollbar appearance app-wide.
2. **`transition-all` → `transition-colors`** (`apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx:1172`) — only a background-color changes on hover (`data-[hovered]:bg-muted/50`), so `transition-all` was needlessly animating `scrollbar-color` on every mounting bubble, keeping style permanently dirty (~1,751 scrollbar-color transition events in the trace).
3. **Emoji font-size decision** — memoized `getEmojiFontSizeClass(message.content)` in `MessageBubble.tsx` (it was called inline in JSX on every render) and added a plain-text fast path in `isEmojiOnly` (`emojiUtils.ts`) that skips the `DOMParser` round-trip when the content has no tags/entities, removing throwaway detached Documents (heap grew 222→347MB over 3 switches in the trace).

## PR checklist
1. Problem Description: Switching DMs/channels is slow (~3.0–3.5s blocked per switch), driven almost entirely by CSS style recalculation, not layout/data/React.
2. How the issue was identified: Chrome DevTools performance trace analysis of 3 DM switches; validated against the code.
3. Solution: See the three fixes above.
4. Documentation: N/A
5. DB Alter Details: N/A
6. Data fix Details: N/A
7. Environment variable Changes: N/A
8. Testing: Manual — verify scrollbars still render correctly across scroll containers (chat list, sidebars, canvas, dialogs) on Chrome and Firefox; verify emoji-only messages still render large; verify hover row-highlight still animates. Re-run a performance trace on DM switching to confirm style-recalc time drops. CI runs typecheck/lint/build.
9. Services to deploy: dashboard (frontend).
10. Main PR link (if against release): N/A

## Risk notes
- Fix #1 changes scrollbar styling scope. Firefox scrollbar theming now applies to root + Tailwind overflow-utility elements rather than literally every element; scroll containers that set overflow without a Tailwind overflow class (e.g. some component/inline-styled or Radix viewports) may fall back to default Firefox scrollbars. WebKit/Chrome appearance is unchanged since the `::-webkit-scrollbar*` rules stay global. Worth a visual pass on less-common scroll surfaces.
- Fixes #2 and #3 are behavior-preserving.