### PR TITLE
feat: XYNE-63280 add seconds and business-hours support to schedule…

### DIFF
--- a/apps/backend/src/automations/types/automation-config.ts
+++ b/apps/backend/src/automations/types/automation-config.ts
@@ -4,6 +4,7 @@ import type { StepType } from './step-types';
 import { ControlFlowStepType } from './known-types';
 import { ConditionOperator, ConditionOperatorSchema } from './operators';
 import { TAG_FORMAT_REGEX } from '@xyne/shared';
+import { calculateETADeadline } from '@/utils/etaCalculation';
 
 function isValidHasTagValue(value: unknown): boolean {
   if (typeof value !== 'string') return false;
@@ -116,7 +117,7 @@ export interface SwitchStepConfig {
 
 export type AutomationStepConfig = ActionStepConfig | ConditionalStepConfig | SwitchStepConfig;
 
-export const ScheduleOffsetUnitSchema = z.enum(['minutes', 'hours', 'days']);
+export const ScheduleOffsetUnitSchema = z.enum(['seconds', 'minutes', 'hours', 'days']);
 export type ScheduleOffsetUnit = z.infer<typeof ScheduleOffsetUnitSchema>;
 
 export const ScheduleOffsetSchema = z.object({
@@ -129,10 +130,14 @@ export const ImmediateScheduleSchema = z.object({
   type: z.literal('IMMEDIATE'),
 });
 
+export const MAX_SCHEDULE_OFFSET_MINUTES = 30 * 24 * 60;
+export const MAX_SCHEDULE_OFFSET_MS = MAX_SCHEDULE_OFFSET_MINUTES * 60 * 1000;
+
 export const ScheduledScheduleSchema = z.object({
   type: z.literal('SCHEDULED'),
   field: z.string().min(1),
   offset: ScheduleOffsetSchema,
+  businessHoursOnly: z.boolean().default(false).describe('Business Hours Only'),
 });
 
 export const ScheduleConfigSchema = z.discriminatedUnion('type', [
@@ -141,16 +146,17 @@ export const ScheduleConfigSchema = z.discriminatedUnion('type', [
 ]);
 export type ScheduleConfig = z.infer<typeof ScheduleConfigSchema>;
 
-export const MAX_SCHEDULE_OFFSET_MINUTES = 30 * 24 * 60;
-
 export function scheduleOffsetMs(offset: ScheduleOffset): number {
-  const minutes =
-    offset.unit === 'minutes'
-      ? offset.amount
-      : offset.unit === 'hours'
-        ? offset.amount * 60
-        : offset.amount * 60 * 24;
-  return minutes * 60 * 1000;
+  switch (offset.unit) {
+    case 'seconds':
+      return offset.amount * 1000;
+    case 'minutes':
+      return offset.amount * 60 * 1000;
+    case 'hours':
+      return offset.amount * 60 * 60 * 1000;
+    case 'days':
+      return offset.amount * 24 * 60 * 60 * 1000;
+  }
 }
 
 export function readDottedPath(payload: Record<string, unknown>, path: string): unknown {
@@ -183,7 +189,17 @@ export function computeScheduleRunAt(
   const fieldValue = readDottedPath(payload, schedule.field);
   const fieldDate = coerceToDate(fieldValue);
   if (!fieldDate) return null;
-  return fieldDate.getTime() + scheduleOffsetMs(schedule.offset);
+
+  const offsetMs = scheduleOffsetMs(schedule.offset);
+  if (!schedule.businessHoursOnly) {
+    return fieldDate.getTime() + offsetMs;
+  }
+
+  const seconds = Math.floor(offsetMs / 1000);
+  const roundedMinutes = Math.ceil(seconds / 60);
+  const deadline = calculateETADeadline(fieldDate, roundedMinutes / 60);
+  const roundingRemainderMs = (roundedMinutes * 60 - seconds) * 1000;
+  return deadline.getTime() - roundingRemainderMs;
 }
 
 export interface AutomationConfig {

--- a/apps/dashboard/src/api/automationsApi.ts
+++ b/apps/dashboard/src/api/automationsApi.ts
@@ -174,6 +174,7 @@ export interface SwitchStepConfig {
 export type AutomationStepConfig = ActionStepConfig | ConditionalStepConfig | SwitchStepConfig;
 
 export const ScheduleOffsetUnitValues = {
+  seconds: 'seconds',
   minutes: 'minutes',
   hours: 'hours',
   days: 'days',
@@ -188,7 +189,7 @@ export interface ScheduleOffset {
 
 export type ScheduleConfig =
   | { type: 'IMMEDIATE' }
-  | { type: 'SCHEDULED'; field: string; offset: ScheduleOffset };
+  | { type: 'SCHEDULED'; field: string; offset: ScheduleOffset; businessHoursOnly?: boolean };
 
 export const MAX_SCHEDULE_OFFSET_MINUTES = 30 * 24 * 60;
 

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/ScheduleCard/ScheduleCard.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/ScheduleCard/ScheduleCard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { Clock, Zap } from 'lucide-react';
 import { cn } from '../../../../utils/classNames';
 import Input from '../../../ui/Input/Input';
+import { Checkbox } from '../../../ui/Checkbox/Checkbox';
 import {
   Select,
   SelectContent,
@@ -77,6 +78,7 @@ function findDateFields(
 }
 
 const MAX_BY_UNIT: Record<ScheduleOffsetUnit, number> = {
+  seconds: MAX_SCHEDULE_OFFSET_MINUTES * 60,
   minutes: MAX_SCHEDULE_OFFSET_MINUTES,
   hours: Math.floor(MAX_SCHEDULE_OFFSET_MINUTES / 60),
   days: Math.floor(MAX_SCHEDULE_OFFSET_MINUTES / 60 / 24),
@@ -105,6 +107,7 @@ export function ScheduleCard({
       type: 'SCHEDULED',
       field: defaultField,
       offset: { amount: 1, unit: 'hours' },
+      businessHoursOnly: false,
     });
   };
 
@@ -180,6 +183,7 @@ export function ScheduleCard({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
+                    <SelectItem value='seconds'>Seconds</SelectItem>
                     <SelectItem value='minutes'>Minutes</SelectItem>
                     <SelectItem value='hours'>Hours</SelectItem>
                     <SelectItem value='days'>Days</SelectItem>
@@ -207,6 +211,13 @@ export function ScheduleCard({
                 </Select>
               </FieldGroup>
             </div>
+
+            <Checkbox
+              label='Business hours only'
+              checked={sched.businessHoursOnly ?? false}
+              onChange={checked => onChange({ ...sched, businessHoursOnly: checked })}
+              size='sm'
+            />
 
             {overMax && (
               <p className='text-[11px] text-destructive'>


### PR DESCRIPTION
…d trigger wait

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
