### PR TITLE
fix: XYNE additional form fields missing on GET /api/apps/ticket/:xyneId

### DIFF
--- a/apps/backend/src/apps/controllers/ticketController.ts
+++ b/apps/backend/src/apps/controllers/ticketController.ts
@@ -1939,9 +1939,30 @@ export class TicketController {
       const timestamp = new Date();
       const stringValue = normalizedFieldValue.fieldValue;
 
-      // Upsert the form entity value
+      // Upsert the form entity value.
+      // Values MUST be stamped with contextId = boardId and the current visit
+      // version, matching the canonical write path (FormsRepository
+      // .upsertTicketFormFields) and the read path (getTicketCustomFormData),
+      // which both scope by (contextId = boardId, version). Writing rows with a
+      // NULL contextId/version made them invisible to GET /api/apps/ticket/:xyneId,
+      // so app-updated fields looked blank even though the value was stored.
+      // NULL version is treated as version 1; compute the max in code because the
+      // column is nullable with no DB default and ORDER BY version DESC sorts NULLs
+      // first in Postgres.
+      const existingVersions = await prismaClient.formEntityValues.findMany({
+        where: { entityId: ticketId, entityType: 'TICKET', contextId: ticket.boardId },
+        select: { version: true },
+      });
+      const currentVersion = existingVersions.reduce((max, v) => Math.max(max, v.version ?? 1), 1);
+
       const existing = await prismaClient.formEntityValues.findFirst({
-        where: { entityId: ticketId, entityType: 'TICKET', fieldId: field.id },
+        where: {
+          entityId: ticketId,
+          entityType: 'TICKET',
+          fieldId: field.id,
+          contextId: ticket.boardId,
+          version: currentVersion,
+        },
       });
 
       if (existing) {
@@ -1961,6 +1982,8 @@ export class TicketController {
             entityType: 'TICKET',
             formId: formMapping.formId,
             fieldId: field.id,
+            contextId: ticket.boardId,
+            version: currentVersion,
             fieldValue: stringValue,
             actualFieldValue: normalizedFieldValue.actualFieldValue,
             workspaceId: ticket.workspaceId,


### PR DESCRIPTION
## Problem
Additional (custom form) fields updated via the apps API were stored but not returned by `GET /api/apps/ticket/:ticket_id`. Reported on ticket EULER-80528 — custom fields looked blank on the GET response even though the value was persisted.

## Root cause
`form_entity_values` are scoped by `(contextId = boardId, version)`. The read path `FormsRepository.getTicketCustomFormData` (used by `GET /:xyneId`) only surfaces rows whose `contextId === boardId` and `version === currentVersion`, and skips everything else.

The apps endpoint `POST /api/apps/ticket/updateFormField` (`ticketController.updateFormField`) wrote rows with a **NULL `contextId` and NULL `version`**, and its existing-row lookup was keyed only on `(entityId, entityType, fieldId)`. Those rows never matched the read filter, so app-updated fields were invisible on GET.

## Fix
Stamp `updateFormField` writes with `contextId = ticket.boardId` and the current visit `version` (NULL treated as 1, max computed in code), matching the canonical write path `FormsRepository.upsertTicketFormFields` and the read path. The existing-row lookup is scoped the same way so updates target the current-version row instead of creating a duplicate.

## Files
- `apps/backend/src/apps/controllers/ticketController.ts`

## Validation
- Type-safe change (`contextId: String?`, `version: Int?`). tsc showed only pre-existing unrelated errors in `sdlc/*` and `zero/*`.
- Suggested manual check: call `updateFormField` for a board-mapped form field, then `GET /api/apps/ticket/:xyneId` and confirm the field appears in `customFormData.fields`.