### PR TITLE
fix: XYNE-63241 make supportTicketsPageV4 a faithful V3 copy with IN filters and repoint callers

### DIFF
--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -2025,29 +2025,133 @@ export const queries: AnyQueryRegistry = defineQueries({
       channelId: z.string(),
       isMember: z.boolean(),
       assignedTo: z.array(z.string()).optional(),
+      createdBy: z.array(z.string()).optional(),
       priority: z.array(z.nativeEnum(TicketPriority)).optional(),
       stageName: z.array(z.string()).optional(),
+      aiCategory: z.array(z.string()).optional(),
+      hasAiDraft: z.boolean().optional(),
+      hasSubTickets: z.boolean().optional(),
+      mailboxFolder: z.enum(['inbox', 'all', 'starred', 'spam', 'sent', 'drafts']).optional(),
+      userGroups: z.array(z.string()).optional(),
+      lastEmailAtStart: z.number().optional(),
+      lastEmailAtEnd: z.number().optional(),
+      createdAtStart: z.number().optional(),
+      createdAtEnd: z.number().optional(),
+      conversationLabelId: z.string().optional(),
+      dynamicFieldFilters: supportDynamicFieldFiltersSchema,
       limit: z.number(),
       start: z.object({ id: z.string(), lastEmailAt: z.number() }).nullable(),
       dir: z.literal('forward').or(z.literal('backward')),
-    }),
-    ({ ctx, args: { channelId, assignedTo, priority, stageName, limit, start, dir } }) => {
+    }).refine(
+      args => args.createdAtStart === undefined || args.createdAtEnd === undefined || args.createdAtStart <= args.createdAtEnd,
+      'createdAtStart must be less than or equal to createdAtEnd',
+    ),
+    ({ ctx, args: { channelId, assignedTo, createdBy, priority, stageName, aiCategory, hasAiDraft, hasSubTickets, mailboxFolder, userGroups, lastEmailAtStart, lastEmailAtEnd, createdAtStart, createdAtEnd, conversationLabelId, dynamicFieldFilters, limit, start, dir } }) => {
       let query = zql.tickets.where('channelId', channelId);
+      query = query.where('isArchived', false);
 
       if (assignedTo && assignedTo.length > 0) {
-        query = query.where(({ or, cmp }) => or(...assignedTo.map((id) => cmp('assignedTo', id))));
+        query = query.where('assignedTo', 'IN', assignedTo);
+      }
+
+      if (createdBy && createdBy.length > 0) {
+        query = query.where('createdBy', 'IN', createdBy);
       }
 
       if (priority && priority.length > 0) {
-        query = query.where(({ or, cmp }) => or(...priority.map((p) => cmp('priority', p))));
+        query = query.where('priority', 'IN', priority);
       }
 
       if (stageName && stageName.length > 0) {
-        query = query.where(({ or, cmp }) => or(...stageName.map((s) => cmp('stageName', s))));
+        query = query.where('stageName', 'IN', stageName);
       }
+
+      if (aiCategory && aiCategory.length > 0) {
+        query = query.where('aiCategory', 'IN', aiCategory);
+      }
+
+      if (hasAiDraft) {
+        query = query.where(({ exists }) =>
+          exists('emailDrafts', (draft) => draft.where('userId', 'IS', null)),
+        );
+      }
+
+      if (hasSubTickets) {
+        query = query.where(({ exists }) => exists('subTicketMappings'));
+      }
+
+      // Mailbox folder server-side filtering. Spam and Starred REQUIRE an overlay row, so they
+      // can be filtered with a positive exists() (works on the client too, unlike not(exists)),
+      // making pagination meaningful instead of scanning the whole channel client-side. Inbox /
+      // All Mail include no-overlay tickets (default = Inbox) and stay client-side.
+      if (mailboxFolder === 'spam') {
+        query = query.where(({ exists }) =>
+          exists('userMailbox', (m) => m.where('userId', ctx.userID).where('state', MailboxState.SPAM)),
+        );
+      } else if (mailboxFolder === 'starred') {
+        query = query.where(({ exists }) =>
+          exists('userMailbox', (m) =>
+            m
+              .where('userId', ctx.userID)
+              .where('starred', true)
+              .where(({ or, cmp }) =>
+                or(cmp('state', MailboxState.INBOX), cmp('state', MailboxState.ARCHIVED)),
+              ),
+          ),
+        );
+      } else if (mailboxFolder === 'sent') {
+        // "Sent" = tickets the current user has sent an outbound email on (REPLY /
+        // REPLY_ALL / COMPOSE). A positive exists() runs client-side too, so pagination
+        // stays meaningful and the list is one-row-per-ticket (no email-level collapse).
+        query = query.where(({ exists }) =>
+          exists('emails', (e) =>
+            e
+              .where('type', 'IN', [EmailType.REPLY, EmailType.REPLY_ALL, EmailType.COMPOSE])
+              .where('sentByUserId', ctx.userID),
+          ),
+        );
+      } else if (mailboxFolder === 'drafts') {
+        // "Drafts" = tickets the current user has a saved reply draft on (conversationId
+        // set → tied to a ticket). Compose drafts (no conversationId, no ticket yet) are
+        // surfaced separately via the Drafts chip banner, not in this list.
+        query = query.where(({ exists }) =>
+          exists('emailDrafts', (d) =>
+            d.where('userId', ctx.userID).where('conversationId', 'IS NOT', null),
+          ),
+        );
+      }
+
+      if (userGroups && userGroups.length > 0) {
+        query = query.where('userGroupId', 'IN', userGroups);
+      }
+      if (conversationLabelId) {
+        query = query.where(({ exists }) =>
+          exists('conversationLabelMappings', (m) => m.where('labelId', conversationLabelId)),
+        );
+      }
+
+      if (lastEmailAtStart !== undefined) {
+        query = query.where('lastEmailAt', '>=', lastEmailAtStart);
+      }
+
+      if (lastEmailAtEnd !== undefined) {
+        query = query.where('lastEmailAt', '<=', lastEmailAtEnd);
+      }
+
+      if (createdAtStart !== undefined) {
+        query = query.where('createdAt', '>=', createdAtStart);
+      }
+
+      if (createdAtEnd !== undefined) {
+        query = query.where('createdAt', '<=', createdAtEnd);
+      }
+
+      query = applySupportDynamicFieldFilters(query, dynamicFieldFilters);
 
       const orderDirection = dir === 'forward' ? 'desc' : 'asc';
       query = query.orderBy('lastEmailAt', orderDirection);
+      // id tiebreak keeps the (lastEmailAt, id) keyset cursor deterministic on ties.
+      query = query.orderBy('id', orderDirection);
 
       if (start) {
         query = query.start(
@@ -2058,17 +2162,19 @@ export const queries: AnyQueryRegistry = defineQueries({
 
       return query
         .limit(limit)
-        .related('project')
-        .related('tagMappings')
-        .related('entity')
-        .related('emails', q => q.related('attachments'))
         .related('emailDrafts', q =>
           q.where(({ or, cmp }) =>
             or(cmp('userId', '=', ctx.userID), cmp('userId', 'IS', null)),
           ),
         )
         .related('emailReads', q => q.where('userId', ctx.userID))
-        .related('conversation');
+        // Caller's per-user mailbox overlay so the list can be filtered into mailbox
+        // folders (Inbox / All Mail / Starred / Spam) client-side. A ticket with no
+        // overlay row defaults to Inbox.
+        .related('userMailbox', q => q.where('userId', ctx.userID))
+        .related('formEntityValues', (fev) =>
+          relateSupportDynamicFieldValues(fev, dynamicFieldFilters),
+        );
     }
   ),
 

--- a/apps/dashboard/src/components/Tickets/TicketListView/TicketListView.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketListView/TicketListView.tsx
@@ -88,7 +88,7 @@ const loadColumnWidths = (): TicketListColumnWidths => {
 };
 
 export type SupportTicketRow = NonNullable<
-  QueryResultType<typeof queries.supportTicketsPageV3>[number]
+  QueryResultType<typeof queries.supportTicketsPageV4>[number]
 >;
 
 type PageCursor = { id: string; lastEmailAt: number };
@@ -407,7 +407,7 @@ export const TicketListView = function TicketListView({
 
   const pageStart = pageCursors[pageIndex] ?? null;
   const [firstPage, firstPageDetails] = useCachedQuery(
-    queries.supportTicketsPageV3({
+    queries.supportTicketsPageV4({
       channelId,
       isMember,
       assignedTo,

--- a/apps/dashboard/src/components/xyne-desk/DeskCalendar/DeskCalendarView.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskCalendar/DeskCalendarView.tsx
@@ -22,9 +22,9 @@ import { queries } from '../../../zero/queries';
 import { useFallbackHydratedQuery } from '@xyne/shared/hooks';
 import type { DynamicFieldQueryFilter } from '../../../utils/board/dynamicFieldFilters';
 
-type SupportTicketsArgs = Parameters<typeof queries.supportTicketsPageV3>[0];
+type SupportTicketsArgs = Parameters<typeof queries.supportTicketsPageV4>[0];
 
-/** Row cap for one rendered span — supportTicketsPageV3's `limit` is required. */
+/** Row cap for one rendered span — supportTicketsPageV4's `limit` is required. */
 const RANGE_LIMIT = 50000;
 
 /** Mounted keyed by its query args so a span change never serves a stale span's cached rows. */
@@ -43,7 +43,7 @@ const RangeCalendar = ({
   onTicketClick: (ticket: Ticket) => void;
   onTicketsLoaded?: (tickets: Ticket[]) => void;
 }): ReactElement => {
-  const [rows, details] = useFallbackHydratedQuery(queries.supportTicketsPageV3(args), { enabled });
+  const [rows, details] = useFallbackHydratedQuery(queries.supportTicketsPageV4(args), { enabled });
   const tickets = useMemo(
     () => (details?.type === 'complete' ? ((rows ?? []) as unknown as Ticket[]) : []),
     [rows, details?.type],
@@ -89,7 +89,7 @@ export const DeskCalendarView = ({
   onTicketClick,
   onTicketsLoaded,
 }: DeskCalendarViewProps): ReactElement => {
-  // supportTicketsPageV3's schema has no `conversationIdWhitelist` field — it's
+  // supportTicketsPageV4's schema has no `conversationIdWhitelist` field — it's
   // `conversationIds`. Every other caller (TicketListView, SupportScreen's own nav
   // queries) renames it before spreading; skipping that here silently drops the
   // "AI Tags" filter for this view since the zod schema just strips the unknown key.

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/MetricsTab.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/MetricsTab.tsx
@@ -32,7 +32,7 @@ export const MetricsTab: React.FC<MetricsTabProps> = ({ form }) => {
     let cancelled = false;
     void zero
       .run(
-        queries.supportTicketsPageV3({
+        queries.supportTicketsPageV4({
           channelId,
           isMember: true,
           limit: 1,

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -4510,7 +4510,7 @@ export const SupportTicketDetail = ({
       if (!channelId) return [];
       const { conversationIdWhitelist: _ciw, ...restTicketFilter } = ticketFilter;
       return (await zero.run(
-        queries.supportTicketsPageV3({
+        queries.supportTicketsPageV4({
           channelId,
           isMember,
           ...restTicketFilter,
@@ -4561,7 +4561,7 @@ export const SupportTicketDetail = ({
     try {
       const { conversationIdWhitelist: _ciw, ...restTicketFilter } = ticketFilter;
       const result = (await zero.run(
-        queries.supportTicketsPageV3({
+        queries.supportTicketsPageV4({
           channelId,
           isMember,
           ...restTicketFilter,

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -1686,30 +1686,140 @@ export const queries = defineQueries({
       channelId: z.string(),
       isMember: z.boolean(),
       assignedTo: z.array(z.string()).optional(),
+      createdBy: z.array(z.string()).optional(),
       priority: z.array(z.nativeEnum(TicketPriority)).optional(),
       stageName: z.array(z.string()).optional(),
+      aiCategory: z.array(z.string()).optional(),
+      conversationIds: z.array(z.string()).optional(),
+      hasAiDraft: z.boolean().optional(),
+      hasSubTickets: z.boolean().optional(),
+      mailboxFolder: z.enum(['inbox', 'all', 'starred', 'spam', 'sent', 'drafts']).optional(),
+      userGroups: z.array(z.string()).optional(),
+      lastEmailAtStart: z.number().optional(),
+      lastEmailAtEnd: z.number().optional(),
+      createdAtStart: z.number().optional(),
+      createdAtEnd: z.number().optional(),
+      conversationLabelId: z.string().optional(),
+      dynamicFieldFilters: supportDynamicFieldFiltersSchema,
       limit: z.number(),
       start: z.object({ id: z.string(), lastEmailAt: z.number() }).nullable(),
       dir: z.literal('forward').or(z.literal('backward')),
-    }),
-    ({ ctx, args: { channelId, assignedTo, priority, stageName, limit, start, dir } }) => {
+    }).refine(
+      args => args.createdAtStart === undefined || args.createdAtEnd === undefined || args.createdAtStart <= args.createdAtEnd,
+      'createdAtStart must be less than or equal to createdAtEnd',
+    ),
+    ({ ctx, args: { channelId, assignedTo, createdBy, priority, stageName, aiCategory, conversationIds, hasAiDraft, hasSubTickets, mailboxFolder, userGroups, lastEmailAtStart, lastEmailAtEnd, createdAtStart, createdAtEnd, conversationLabelId, dynamicFieldFilters, limit, start, dir } }) => {
       let query = zql.tickets.where('channelId', channelId);
       query = query.where('isArchived', false);
 
       if (assignedTo && assignedTo.length > 0) {
-        query = query.where(({ or, cmp }) => or(...assignedTo.map((id) => cmp('assignedTo', id))));
+        query = query.where('assignedTo', 'IN', assignedTo);
+      }
+
+      if (createdBy && createdBy.length > 0) {
+        query = query.where('createdBy', 'IN', createdBy);
       }
 
       if (priority && priority.length > 0) {
-        query = query.where(({ or, cmp }) => or(...priority.map((p) => cmp('priority', p))));
+        query = query.where('priority', 'IN', priority);
       }
 
       if (stageName && stageName.length > 0) {
-        query = query.where(({ or, cmp }) => or(...stageName.map((s) => cmp('stageName', s))));
+        query = query.where('stageName', 'IN', stageName);
       }
+
+      if (aiCategory && aiCategory.length > 0) {
+        query = query.where('aiCategory', 'IN', aiCategory);
+      }
+
+      if (conversationIds !== undefined) {
+        query = query.where('conversationId', 'IN', conversationIds.length > 0 ? conversationIds : ['']);
+      }
+
+      if (hasAiDraft) {
+        query = query.where(({ exists }) =>
+          exists('emailDrafts', (draft) => draft.where('userId', 'IS', null)),
+        );
+      }
+
+      if (hasSubTickets) {
+        query = query.where(({ exists }) => exists('subTicketMappings'));
+      }
+
+      // Mailbox folder server-side filtering. Spam and Starred REQUIRE an overlay row, so they
+      // can be filtered with a positive exists() (works on the client too, unlike not(exists)),
+      // making pagination meaningful instead of scanning the whole channel client-side. Inbox /
+      // All Mail include no-overlay tickets (default = Inbox) and stay client-side.
+      if (mailboxFolder === 'spam') {
+        query = query.where(({ exists }) =>
+          exists('userMailbox', m =>
+            m.where('userId', ctx.userID).where('state', MailboxState.SPAM),
+          ),
+        );
+      } else if (mailboxFolder === 'starred') {
+        query = query.where(({ exists }) =>
+          exists('userMailbox', m =>
+            m
+              .where('userId', ctx.userID)
+              .where('starred', true)
+              .where(({ or, cmp }) =>
+                or(cmp('state', MailboxState.INBOX), cmp('state', MailboxState.ARCHIVED)),
+              ),
+          ),
+        );
+      } else if (mailboxFolder === 'sent') {
+        // "Sent" = tickets the current user has sent an outbound email on (REPLY /
+        // REPLY_ALL / COMPOSE). A positive exists() runs client-side too, so pagination
+        // stays meaningful and the list is one-row-per-ticket (no email-level collapse).
+        query = query.where(({ exists }) =>
+          exists('emails', e =>
+            e
+              .where('type', 'IN', [EmailType.REPLY, EmailType.REPLY_ALL, EmailType.COMPOSE])
+              .where('sentByUserId', ctx.userID),
+          ),
+        );
+      } else if (mailboxFolder === 'drafts') {
+        // "Drafts" = tickets the current user has a saved reply draft on (conversationId
+        // set → tied to a ticket). Compose drafts (no conversationId, no ticket yet) are
+        // surfaced separately via the Drafts chip banner, not in this list.
+        query = query.where(({ exists }) =>
+          exists('emailDrafts', d =>
+            d.where('userId', ctx.userID).where('conversationId', 'IS NOT', null),
+          ),
+        );
+      }
+
+      if (userGroups && userGroups.length > 0) {
+        query = query.where('userGroupId', 'IN', userGroups);
+      }
+      if (conversationLabelId) {
+        query = query.where(({ exists }) =>
+          exists('conversationLabelMappings', (m) => m.where('labelId', conversationLabelId)),
+        );
+      }
+
+      if (lastEmailAtStart !== undefined) {
+        query = query.where('lastEmailAt', '>=', lastEmailAtStart);
+      }
+
+      if (lastEmailAtEnd !== undefined) {
+        query = query.where('lastEmailAt', '<=', lastEmailAtEnd);
+      }
+
+      if (createdAtStart !== undefined) {
+        query = query.where('createdAt', '>=', createdAtStart);
+      }
+
+      if (createdAtEnd !== undefined) {
+        query = query.where('createdAt', '<=', createdAtEnd);
+      }
+
+      query = applySupportDynamicFieldFilters(query, dynamicFieldFilters);
 
       const orderDirection = dir === 'forward' ? 'desc' : 'asc';
       query = query.orderBy('lastEmailAt', orderDirection);
+      // id tiebreak keeps the (lastEmailAt, id) keyset cursor deterministic on ties.
+      query = query.orderBy('id', orderDirection);
 
       if (start) {
         query = query.start(
@@ -1718,19 +1828,23 @@ export const queries = defineQueries({
         );
       }
 
-      return query
-        .limit(limit)
-        .related('project')
-        .related('tagMappings')
-        .related('entity')
-        .related('emails', q => q.related('attachments'))
-        .related('emailDrafts', q =>
-          q.where(({ or, cmp }) =>
-            or(cmp('userId', '=', ctx.userID), cmp('userId', 'IS', null)),
-          ),
-        )
-        .related('emailReads', q => q.where('userId', ctx.userID))
-        .related('conversation');
+      return (
+        query
+          .limit(limit)
+          .related('emailDrafts', q =>
+            q.where(({ or, cmp }) =>
+              or(cmp('userId', '=', ctx.userID), cmp('userId', 'IS', null)),
+            ),
+          )
+          .related('emailReads', q => q.where('userId', ctx.userID))
+          // Caller's per-user mailbox overlay so the list can be filtered into mailbox
+          // folders (Inbox / All Mail / Starred / Spam) client-side. A ticket with no
+          // overlay row defaults to Inbox.
+          .related('userMailbox', q => q.where('userId', ctx.userID))
+          .related('formEntityValues', fev =>
+            relateSupportDynamicFieldValues(fev, dynamicFieldFilters),
+          )
+      );
     },
   ),
 


### PR DESCRIPTION
## What
Backport to `release-20260909`. `supportTicketsPageV3` hit the same SQLite `expression tree is too large` error as the filtered query — large multi-select selections expand `or(...arr.map(cmp))` equality chains into a deep boolean tree.

`supportTicketsPageV4` already existed but had drifted into a reduced query (missing `createdBy` / `aiCategory` / `conversationIds` / `mailboxFolder` / `userGroups` / date-range / `dynamicFieldFilters` / `conversationLabelId` args, missing the `userMailbox` and `formEntityValues` relations and the id-tiebreak ordering; the backend copy even lacked the `isArchived=false` guard). Repointing callers onto it as-is would have silently dropped those filters.

This rewrites `supportTicketsPageV4` (backend + shared) as a verbatim copy of `supportTicketsPageV3` with the four user-scalable multi-select filters (`assignedTo`, `priority`, `stageName`, `aiCategory`) built via `'IN'` instead of `or(...)`. `createdBy` / `userGroups` / `conversationIds` were already `IN`. All other logic, ordering and relations are identical to V3, so the returned shape is unchanged. All V3 callers now target V4 (SupportScreen, TicketListView, DeskCalendarView, DeskSettings MetricsTab); the SDK mapper already pointed at V4. V3 is left untouched.

Same change as the main PR #1774, cherry-picked onto `release-20260909`. 6 files, +257/-37.