### PR TITLE
fix: XYNE-63240 stamp initial_message_md at write time so conversations cannot render empty [release-20260911]

### DIFF
--- a/apps/backend/src/database/repositories/conversationRepository.ts
+++ b/apps/backend/src/database/repositories/conversationRepository.ts
@@ -206,6 +206,66 @@ export class ConversationRepository extends BaseRepository<Conversation, CreateC
     return result;
   }
 
+  /**
+   * One conversations write for a thread reply.
+   *
+   * The reply count bump, the replies_md append and the lastActivityAt patch
+   * used to be three separate commits against the same row. Each conversations write is replayed
+   * through every subscribed Zero pipeline, so collapsing them cuts the fan-out
+   * per reply by three. replyCount uses an atomic increment rather than the
+   * previous read-then-write, which also removes a lost-update race between
+   * concurrent replies.
+   */
+  async findRepliesMd(conversationId: string): Promise<string | null> {
+    const row = await this.db.conversation.findUnique({
+      where: { conversationId },
+      select: { replies_md: true },
+    });
+    return row?.replies_md ?? null;
+  }
+
+  async applyThreadReply(params: {
+    conversationId: string;
+    repliesMd: string | null;
+    lastActivityAt: Date;
+    replyCreatedAt?: Date | null;
+    markParticipantsRead?: boolean;
+  }): Promise<Conversation> {
+    const { conversationId, repliesMd, lastActivityAt, replyCreatedAt, markParticipantsRead } =
+      params;
+
+    const result = await this.db.conversation.update({
+      where: { conversationId },
+      data: {
+        replyCount: { increment: 1 },
+        lastActivityAt,
+        replies_md: repliesMd,
+      },
+    });
+
+    if (replyCreatedAt) {
+      await this.db.conversationParticipant.updateMany({
+        where: {
+          conversationId,
+          OR: [{ lastReplyAt: null }, { lastReplyAt: { lt: replyCreatedAt } }],
+        },
+        data: { lastReplyAt: replyCreatedAt },
+      });
+
+      if (markParticipantsRead) {
+        await this.db.conversationParticipant.updateMany({
+          where: {
+            conversationId,
+            OR: [{ lastReadAt: null }, { lastReadAt: { lt: replyCreatedAt } }],
+          },
+          data: { lastReadAt: replyCreatedAt },
+        });
+      }
+    }
+
+    return result;
+  }
+
   async decrementReplyCount(conversationId: string): Promise<Conversation> {
     const conversation = await this.findById(conversationId);
     if (!conversation) {

--- a/apps/backend/src/database/repositories/conversationRepository.ts
+++ b/apps/backend/src/database/repositories/conversationRepository.ts
@@ -10,6 +10,12 @@ export interface CreateConversationInput {
   channelId: string;
   createdBy: string;
   initialMessageId: string;
+  /**
+   * Snapshot of the initial message, built with buildInitialMessageMd. The V3
+   * read path renders from this and has no join to fall back on, so a
+   * conversation created without it shows an empty message.
+   */
+  initial_message_md?: string | null;
   parentMessageId?: string;
   pinned?: boolean;
   doNotPostToChannel?: boolean;
@@ -73,6 +79,9 @@ export class ConversationRepository extends BaseRepository<Conversation, CreateC
         workspaceId: channel.workspaceId,
         createdBy: data.createdBy,
         initialMessageId: data.initialMessageId,
+        ...(data.initial_message_md !== undefined && {
+          initial_message_md: data.initial_message_md,
+        }),
         parentMessageId: data.parentMessageId,
         pinned: data.pinned || false,
         ...(data.doNotPostToChannel !== undefined && {

--- a/apps/backend/src/database/repositories/messageRepository.ts
+++ b/apps/backend/src/database/repositories/messageRepository.ts
@@ -7,6 +7,8 @@ import { getMessageContentLength, MAX_MESSAGE_CONTENT_LENGTH, MessageType } from
 
 //import { extractAllMentions } from '@/utils/mentionParser';
 export interface CreateMessageInput {
+  /** Caller-supplied id, so a conversation can reference the message before it exists. */
+  messageId?: string;
   conversationId: string;
   childConversationId?: string;
   senderId: string;
@@ -171,6 +173,7 @@ export class MessageRepository extends BaseRepository<Message, CreateMessageInpu
      const workspaceId = await this.resolveMessageWorkspaceId(data);
      const result = await this.db.message.create({
         data: {
+          ...(data.messageId && { messageId: data.messageId }),
           conversationId: data.conversationId,
           senderId: data.senderId,
           workspaceId,

--- a/apps/backend/src/migration/scripts/bulkIngestConversationSlack.ts
+++ b/apps/backend/src/migration/scripts/bulkIngestConversationSlack.ts
@@ -24,7 +24,7 @@
  */
 import { logger } from '../../utils/logger';
 import { ExternalEntityType, MessageDirection, MessageType } from '@xyne/shared';
-import { serializeInitialMessageMd, serializeRepliesMd, serializeParentMessageMd, type InitialMessageSummary } from '@xyne/shared';
+import { buildInitialMessageMd, serializeRepliesMd, serializeParentMessageMd, type InitialMessageSummary } from '@xyne/shared';
 import { createId } from '@paralleldrive/cuid2';
 import { replaceCustomEmojiShortcodesWithImg } from '@/utils/customEmojiUtils';
 import { isSupportedMimeType } from '@/services/fileProcessor';
@@ -276,16 +276,16 @@ export async function bulkIngestConversationSlack(input: IngestConversationSlack
         }
         content = await applyCustomEmojis(content);
         parentRef = { messageId: parentMsgId, senderId, content, createdAt };
-        const summary: InitialMessageSummary = {
-          messageId: parentMsgId, conversationId: convId, senderId, content, msgType: MessageType.USER as InitialMessageSummary['msgType'],
-          hasAttachment: parentFiles.length > 0, edited: false, isDeleted: false, showInChannel: false, visibleTo: null,
-          createdAt: createdAt.getTime(), metadata: JSON.stringify({ contentFormat: 'html' }), nudgeCount: 0, isSent: true,
-          reactions_md: null, link_preview_md: null, childConversationId: null,
-        };
+        const initialMessageMd = buildInitialMessageMd({
+          messageId: parentMsgId, conversationId: convId, senderId, content,
+          msgType: MessageType.USER as InitialMessageSummary['msgType'],
+          hasAttachment: parentFiles.length > 0, nudgeCount: 0, isSent: true,
+          createdAt: createdAt.getTime(), metadata: { contentFormat: 'html' },
+        });
         convRows.push({
           conversationId: convId, channelId, workspaceId, createdBy: senderId, initialMessageId: parentMsgId,
           pinned: !!m.isPinned, createdAt, lastActivityAt, replyCount,
-          initial_message_md: serializeInitialMessageMd(summary), replies_md: repliesMd,
+          initial_message_md: initialMessageMd, replies_md: repliesMd,
         }); pending++;
         msgRows.push({
           messageId: parentMsgId, conversationId: convId, senderId, workspaceId, content, msgType: 'USER',
@@ -330,17 +330,18 @@ export async function bulkIngestConversationSlack(input: IngestConversationSlack
             entityId: replyMsgId, messageId: replyMsgId, direction: MessageDirection.INCOMING, entityType: 'MESSAGE',
           }); pending++;
           if (childConvId) {
-            const childSummary: InitialMessageSummary = {
-              messageId: replyMsgId, conversationId: childConvId, senderId: replySender, content, msgType: MessageType.USER as InitialMessageSummary['msgType'],
-              hasAttachment: replyFiles.length > 0, edited: false, isDeleted: false, showInChannel: true, visibleTo: null,
-              createdAt: replyCreatedAt.getTime(), metadata: JSON.stringify({ contentFormat: 'html' }), nudgeCount: 0, isSent: true,
-              reactions_md: null, link_preview_md: null, childConversationId: childConvId,
-            };
+            const childInitialMessageMd = buildInitialMessageMd({
+              messageId: replyMsgId, conversationId: childConvId, senderId: replySender, content,
+              msgType: MessageType.USER as InitialMessageSummary['msgType'],
+              hasAttachment: replyFiles.length > 0, showInChannel: true, nudgeCount: 0, isSent: true,
+              createdAt: replyCreatedAt.getTime(), metadata: { contentFormat: 'html' },
+              childConversationId: childConvId,
+            });
             convRows.push({
               conversationId: childConvId, channelId, workspaceId, createdBy: replySender, initialMessageId: replyMsgId,
               parentMessageId: parentRef.messageId, pinned: false, createdAt: replyCreatedAt, lastActivityAt: replyCreatedAt,
               replyCount: r.externalThreadId === lastReplyExternalId ? 0 : 1,
-              initial_message_md: serializeInitialMessageMd(childSummary),
+              initial_message_md: childInitialMessageMd,
               parent_message_md: serializeParentMessageMd({
                 messageId: parentRef.messageId, conversationId: convId, senderId: parentRef.senderId,
                 content: parentRef.content, msgType: MessageType.USER, createdAt: parentRef.createdAt.getTime(),

--- a/apps/backend/src/services/conversationService.ts
+++ b/apps/backend/src/services/conversationService.ts
@@ -783,12 +783,21 @@ export class ConversationService {
       await messageMetadataService.syncParentMessageMd(childConversationId);
     }
 
-    await this.conversationRepository.incrementReplyCount(
+    // Single conversations write: replyCount, lastActivityAt and replies_md were
+    // three separate commits against this row, each replayed through every
+    // subscribed Zero pipeline. replies_md is read immediately before the write
+    // so the lost-update window stays as narrow as the previous append's was.
+    const replyAppliedAt = new Date();
+    await this.conversationRepository.applyThreadReply({
       conversationId,
-      createdAt === undefined ? undefined : message.createdAt,
+      repliesMd: messageMetadataService.buildRepliesMdAfterReply(
+        await this.conversationRepository.findRepliesMd(conversationId),
+        userId,
+      ),
+      lastActivityAt: lastActivityAt ?? replyAppliedAt,
+      replyCreatedAt: createdAt === undefined ? replyAppliedAt : message.createdAt,
       markParticipantsRead,
-    );
-    await messageMetadataService.addReply(conversationId, userId);
+    });
 
     // Update reply count for previous message's child conversation if it exists
     // This matches the mutator logic - get the most recent previous message and check if it has showInChannel
@@ -801,13 +810,6 @@ export class ConversationService {
     if (mostRecentPrevMsg?.showInChannel && mostRecentPrevMsg.childConversationId) {
       await this.conversationRepository.update(mostRecentPrevMsg.childConversationId, {
         replyCount: 1,
-      });
-    }
-
-    // Update last activity for the conversation
-    if (lastActivityAt) {
-      await this.conversationRepository.update(conversationId, {
-        lastActivityAt: lastActivityAt,
       });
     }
 

--- a/apps/backend/src/services/conversationService.ts
+++ b/apps/backend/src/services/conversationService.ts
@@ -772,10 +772,14 @@ export class ConversationService {
         createdBy: userId,
         createdAt: message.createdAt,
         initialMessageId: message.messageId,
+        initial_message_md: buildInitialMessageMd({
+          ...message,
+          msgType: message.msgType as MessageType,
+          createdAt: message.createdAt.getTime(),
+        }),
         parentMessageId: conversation.initialMessageId,
         pinned: false,
       });
-      await messageMetadataService.syncInitialMessageMd(childConversationId);
       await messageMetadataService.syncParentMessageMd(childConversationId);
     }
 

--- a/apps/backend/src/services/conversationService.ts
+++ b/apps/backend/src/services/conversationService.ts
@@ -18,7 +18,7 @@ import { ChannelParticipantRepository } from '@/database/repositories/channelPar
 import { ConversationParticipantRepository } from '@/database/repositories/conversationParticipantRepository';
 import { UserRepository } from '@/database/repositories/users';
 import { Conversation, Message } from '@prisma/client';
-import { ConversationParticipation, MessageType, AttachmentEntityType, ChannelScopeType, ChannelRole, VespaInsertionStatus, VespaOperationType } from '@xyne/shared';
+import { ConversationParticipation, MessageType, AttachmentEntityType, ChannelScopeType, ChannelRole, VespaInsertionStatus, VespaOperationType, buildInitialMessageMd } from '@xyne/shared';
 import { uploadFiles, UploadedFileResult } from '@/services/fileUploadService';
 import { websocketService } from './websocketService';
 import { redisService } from './redisService';
@@ -388,34 +388,57 @@ export class ConversationService {
 
     const messageContent = await replaceEmojisInContent(content?.trim() || '');
 
-    // First create the message
-    const messageData: CreateMessageInput = {
-      conversationId: 'temp', // Will be updated after conversation creation
-      senderId: userId,
-      content: messageContent,
-      msgType: msgType || MessageType.USER,
-      hasAttachment: processedFiles.length > 0,
-      metadata: {
-        ...messageMetadata,
-        contentFormat: isMarkdown ? 'markdown' : 'html',
-      },
-      ...(createdAt && { createdAt }),
+    // Both ids are minted here so the conversation can carry a complete
+    // initial_message_md on its INSERT. The alternative — insert a placeholder,
+    // then patch initialMessageId, then patch the md — is three commits, and
+    // between the first and the last the conversation is live with no message
+    // body for every subscriber.
+    const conversationId = uuidv4();
+    const messageId = uuidv4();
+    const resolvedMsgType = msgType || MessageType.USER;
+    const messageCreatedAt = createdAt ?? new Date();
+    const resolvedMessageMetadata = {
+      ...messageMetadata,
+      contentFormat: isMarkdown ? 'markdown' : 'html',
     };
 
-    // Create a placeholder conversation first
+    const messageData: CreateMessageInput = {
+      messageId,
+      conversationId,
+      senderId: userId,
+      content: messageContent,
+      msgType: resolvedMsgType,
+      hasAttachment: processedFiles.length > 0,
+      metadata: resolvedMessageMetadata,
+      createdAt: messageCreatedAt,
+    };
+
     const conversationData: CreateConversationInput = {
+      conversationId,
       channelId,
       createdBy: userId,
-      initialMessageId: 'temp', // Will be updated after message creation
+      initialMessageId: messageId,
+      initial_message_md: buildInitialMessageMd({
+        messageId,
+        conversationId,
+        workspaceId: channel.workspaceId,
+        senderId: userId,
+        content: messageContent,
+        msgType: resolvedMsgType,
+        hasAttachment: processedFiles.length > 0,
+        createdAt: messageCreatedAt.getTime(),
+        metadata: resolvedMessageMetadata,
+        // Mirror the messages column defaults the insert below relies on, so the
+        // snapshot matches the row it describes.
+        isSent: true,
+        nudgeCount: 0,
+      }),
       metadata,
       pinned: pinned || false,
       ...(createdAt && { createdAt }),
     };
 
     const conversation = await this.conversationRepository.create(conversationData);
-
-    // Update message with real conversation ID
-    messageData.conversationId = conversation.conversationId;
     const message = await this.messageRepository.create(messageData);
 
     if (await this.userRepository.findById(userId)) {
@@ -485,12 +508,6 @@ export class ConversationService {
         error
       );
     });
-
-    // Update conversation with real initial message ID
-    await this.conversationRepository.update(conversation.conversationId, {
-      initialMessageId: message.messageId,
-    });
-    await messageMetadataService.syncInitialMessageMd(conversation.conversationId);
 
     if (
       !suppressAutomations &&

--- a/apps/backend/src/services/jiraMigrationImportService.ts
+++ b/apps/backend/src/services/jiraMigrationImportService.ts
@@ -9,7 +9,7 @@ import { resolveFormFieldDefinitionsForForm } from '@/utils/fieldDefinition';
 import { EntitySequenceService } from '@/services/entitySequenceService';
 import { randomUUID } from 'crypto';
 import {
-  serializeInitialMessageMd,
+  buildInitialMessageMd,
   serializeTicketMd,
   type InitialMessageSummary,
   type TicketCardSummary,
@@ -1617,27 +1617,11 @@ export class JiraMigrationImportService {
 
     await syncConversationTicketMdFromPrismaTicket(db as any, ticket);
     if (initialMessage) {
-      const summaryData: InitialMessageSummary = {
-        messageId: initialMessage.messageId,
-        conversationId: initialMessage.conversationId,
-        senderId: initialMessage.senderId,
-        content: initialMessage.content,
+      const md = buildInitialMessageMd({
+        ...initialMessage,
         msgType: initialMessage.msgType as InitialMessageSummary['msgType'],
-        hasAttachment: initialMessage.hasAttachment,
-        edited: initialMessage.edited,
-        isDeleted: initialMessage.isDeleted,
-        showInChannel: initialMessage.showInChannel,
-        visibleTo: initialMessage.visibleTo,
         createdAt: initialMessage.createdAt.getTime(),
-        metadata: initialMessage.metadata ? JSON.stringify(initialMessage.metadata) : null,
-        nudgeCount: initialMessage.nudgeCount,
-        isSent: initialMessage.isSent,
-        reactions_md: initialMessage.reactions_md,
-        link_preview_md: initialMessage.link_preview_md,
-        childConversationId: initialMessage.childConversationId,
-      };
-
-      const md = serializeInitialMessageMd(summaryData);
+      });
       if (md) {
         await db.conversation.update({
           where: { conversationId },
@@ -3318,7 +3302,7 @@ export class JiraMigrationImportService {
 	                },
 	              });
 	
-	              const initialMessageMd = serializeInitialMessageMd({
+	              const initialMessageMd = buildInitialMessageMd({
 	                messageId: initialMessageId,
 	                conversationId: generatedConversationId,
 	                senderId: initialTicketMessageSenderId,

--- a/apps/backend/src/services/messageMetadataService.ts
+++ b/apps/backend/src/services/messageMetadataService.ts
@@ -70,29 +70,10 @@ export class MessageMetadataService {
     return hasReactions;
   }
 
-  /**
-   * Add a reply to conversation's replies_md
-   * Called when a thread reply is created
-   */
-  async addReply(conversationId: string, replierUserId: string): Promise<void> {
-    const conversation = await this.prisma.conversation.findUnique({
-      where: { conversationId },
-      select: { replies_md: true }
-    });
-
-    const data = parseRepliesMd(conversation?.replies_md);
-    const updatedData = addReplyToData(data, replierUserId);
-    const updatedMd = serializeRepliesMd(updatedData);
-
-    await this.prisma.conversation.update({
-      where: { conversationId },
-      data: { replies_md: updatedMd }
-    });
-
-    logger.info('[MessageMetadataService] Added reply to replies_md', {
-      conversationId, replierUserId
-    });
+  buildRepliesMdAfterReply(currentMd: string | null | undefined, replierUserId: string): string | null {
+    return serializeRepliesMd(addReplyToData(parseRepliesMd(currentMd), replierUserId));
   }
+
 
   /**
    * Rebuild replies_md from remaining replies in the conversation

--- a/apps/backend/src/services/messageMetadataService.ts
+++ b/apps/backend/src/services/messageMetadataService.ts
@@ -9,7 +9,7 @@ import {
   parseRepliesMd,
   serializeRepliesMd,
   addReplyToData,
-  serializeInitialMessageMd,
+  buildInitialMessageMd,
   serializeParentMessageMd,
 } from '@xyne/shared';
 import type { InitialMessageSummary, ParentMessageSummary } from '@xyne/shared';
@@ -166,27 +166,11 @@ export class MessageMetadataService {
 
     if (!message) return;
 
-    const summary: InitialMessageSummary = {
-      messageId: message.messageId,
-      conversationId: message.conversationId,
-      senderId: message.senderId,
-      content: message.content,
+    const md = buildInitialMessageMd({
+      ...message,
       msgType: message.msgType as InitialMessageSummary['msgType'],
-      hasAttachment: message.hasAttachment,
-      edited: message.edited,
-      isDeleted: message.isDeleted,
-      showInChannel: message.showInChannel,
-      visibleTo: message.visibleTo,
       createdAt: message.createdAt.getTime(),
-      metadata: message.metadata ? JSON.stringify(message.metadata) : null,
-      nudgeCount: message.nudgeCount,
-      isSent: message.isSent,
-      reactions_md: message.reactions_md,
-      link_preview_md: message.link_preview_md,
-      childConversationId: message.childConversationId,
-    };
-
-    const md = serializeInitialMessageMd(summary);
+    });
     if (conversation.initial_message_md === md) return;
 
     await this.prisma.conversation.update({

--- a/apps/backend/src/services/notificationService.ts
+++ b/apps/backend/src/services/notificationService.ts
@@ -18,7 +18,7 @@ import { resolveSdlcNavTarget } from '@/sdlc/sdlcNavTarget';
 import { resolveWorkspaceIdFromModel } from '@/database/tenant/workspace-utils';
 import * as notificationFilterService from './notificationFilterService';
 import type { PrefetchedFilterData } from './notificationFilterService';
-import { serializeInitialMessageMd,
+import { buildInitialMessageMd,
   isDeskChannelType,
   type InitialMessageSummary,
   ChannelScopeType,
@@ -70,26 +70,11 @@ async function fetchConversationForNotification(conversationId: string) {
         where: { messageId: conversation.initialMessageId },
       });
       if (message) {
-        const summary: InitialMessageSummary = {
-          messageId: message.messageId,
-          conversationId: message.conversationId,
-          senderId: message.senderId,
-          content: message.content,
+        initialMessageMd = buildInitialMessageMd({
+          ...message,
           msgType: message.msgType as InitialMessageSummary['msgType'],
-          hasAttachment: message.hasAttachment,
-          edited: message.edited,
-          isDeleted: message.isDeleted,
-          showInChannel: message.showInChannel,
-          visibleTo: message.visibleTo,
           createdAt: message.createdAt.getTime(),
-          metadata: message.metadata ? JSON.stringify(message.metadata) : null,
-          nudgeCount: message.nudgeCount,
-          isSent: message.isSent,
-          reactions_md: message.reactions_md,
-          link_preview_md: message.link_preview_md,
-          childConversationId: message.childConversationId,
-        };
-        initialMessageMd = serializeInitialMessageMd(summary);
+        });
       }
     }
 

--- a/apps/backend/src/services/recordingSharingService.ts
+++ b/apps/backend/src/services/recordingSharingService.ts
@@ -4,7 +4,7 @@ import {
   addReplyToData,
   EntityUserAccess,
   parseRepliesMd,
-  serializeInitialMessageMd,
+  buildInitialMessageMd,
   serializeRepliesMd,
   ShareableEntityType,
   type GrantableEntityUserAccess,
@@ -315,7 +315,7 @@ export class RecordingSharingService {
     };
 
     // Store the initial message snapshot for conversation lists.
-    const initialMessageMd = serializeInitialMessageMd({
+    const initialMessageMd = buildInitialMessageMd({
       messageId,
       conversationId,
       workspaceId: actor.workspaceId,
@@ -328,7 +328,7 @@ export class RecordingSharingService {
       showInChannel: false,
       visibleTo: null,
       createdAt: now.getTime(),
-      metadata: JSON.stringify(metadata),
+      metadata,
       nudgeCount: null,
       isSent: true,
       reactions_md: null,
@@ -431,7 +431,7 @@ export class RecordingSharingService {
       },
     });
     // Update the conversation preview tombstone.
-    const tombstoneMd = serializeInitialMessageMd({
+    const tombstoneMd = buildInitialMessageMd({
       messageId: post.messageId,
       conversationId: post.conversationId,
       workspaceId: message.workspaceId,

--- a/apps/backend/src/zero/mutation-sync/handlers/conversations.ts
+++ b/apps/backend/src/zero/mutation-sync/handlers/conversations.ts
@@ -2,10 +2,10 @@ import type { Transaction } from '@rocicorp/zero';
 import { MessageType, Schema } from '@xyne/shared';
 import { zql } from '../../queries';
 import {
-  serializeInitialMessageMd,
+  buildInitialMessageMd,
   serializeParentMessageMd,
 } from '@xyne/shared';
-import type { InitialMessageSummary, ParentMessageSummary } from '@xyne/shared';
+import type { ParentMessageSummary } from '@xyne/shared';
 import { BaseMutationSyncHandler } from '../base-handler';
 
 export class ConversationsMutationSyncHandler extends BaseMutationSyncHandler {
@@ -14,47 +14,6 @@ export class ConversationsMutationSyncHandler extends BaseMutationSyncHandler {
   }
 }
 
-function buildInitialMessageSummary(
-  message: {
-    messageId: string;
-    conversationId: string;
-    senderId: string;
-    content: string;
-    msgType: MessageType;
-    hasAttachment: boolean;
-    edited: boolean;
-    isDeleted: boolean;
-    showInChannel: boolean;
-    visibleTo: string | null;
-    createdAt: number;
-    metadata: unknown;
-    nudgeCount: number | null;
-    isSent: boolean;
-    reactions_md: string | null;
-    link_preview_md: string | null;
-    childConversationId: string | null;
-  },
-): InitialMessageSummary {
-  return {
-    messageId: message.messageId,
-    conversationId: message.conversationId,
-    senderId: message.senderId,
-    content: message.content,
-    msgType: message.msgType,
-    hasAttachment: message.hasAttachment,
-    edited: message.edited,
-    isDeleted: message.isDeleted,
-    showInChannel: message.showInChannel,
-    visibleTo: message.visibleTo,
-    createdAt: message.createdAt,
-    metadata: message.metadata ? JSON.stringify(message.metadata) : null,
-    nudgeCount: message.nudgeCount,
-    isSent: message.isSent,
-    reactions_md: message.reactions_md,
-    link_preview_md: message.link_preview_md,
-    childConversationId: message.childConversationId,
-  };
-}
 
 function buildParentMessageSummary(
   message: {
@@ -104,7 +63,7 @@ async function handleConversationInsert(
     if (message) {
       await tx.mutate.conversations.update({
         conversationId,
-        initial_message_md: serializeInitialMessageMd(buildInitialMessageSummary(message)),
+        initial_message_md: buildInitialMessageMd(message),
       });
     }
   }

--- a/apps/backend/src/zero/mutation-sync/handlers/messages.ts
+++ b/apps/backend/src/zero/mutation-sync/handlers/messages.ts
@@ -3,10 +3,10 @@ import { MessageType, Schema } from '@xyne/shared';
 import { zql } from '../../queries';
 import {
   serializeRepliesMd,
-  serializeInitialMessageMd,
+  buildInitialMessageMd,
   serializeParentMessageMd,
 } from '@xyne/shared';
-import type { InitialMessageSummary, ParentMessageSummary } from '@xyne/shared';
+import type { ParentMessageSummary } from '@xyne/shared';
 import type { MessagePreviousValue } from '../types';
 import { BaseMutationSyncHandler } from '../base-handler';
 
@@ -28,47 +28,25 @@ export class MessagesMutationSyncHandler extends BaseMutationSyncHandler {
   }
 }
 
-function buildInitialMessageSummary(
-  message: {
-    messageId: string;
-    conversationId: string;
-    senderId: string;
-    content: string;
-    msgType: MessageType;
-    hasAttachment: boolean;
-    edited: boolean;
-    isDeleted: boolean;
-    showInChannel: boolean;
-    visibleTo: string | null;
-    createdAt: number;
-    metadata: unknown;
-    nudgeCount: number | null;
-    isSent: boolean;
-    reactions_md: string | null;
-    link_preview_md: string | null;
-    childConversationId: string | null;
-  },
-): InitialMessageSummary {
-  return {
-    messageId: message.messageId,
-    conversationId: message.conversationId,
-    senderId: message.senderId,
-    content: message.content,
-    msgType: message.msgType,
-    hasAttachment: message.hasAttachment,
-    edited: message.edited,
-    isDeleted: message.isDeleted,
-    showInChannel: message.showInChannel,
-    visibleTo: message.visibleTo,
-    createdAt: message.createdAt,
-    metadata: message.metadata ? JSON.stringify(message.metadata) : null,
-    nudgeCount: message.nudgeCount,
-    isSent: message.isSent,
-    reactions_md: message.reactions_md,
-    link_preview_md: message.link_preview_md,
-    childConversationId: message.childConversationId,
-  };
-}
+type InitialMessageRow = {
+  messageId: string;
+  conversationId: string;
+  senderId: string;
+  content: string;
+  msgType: MessageType;
+  hasAttachment: boolean;
+  edited: boolean;
+  isDeleted: boolean;
+  showInChannel: boolean;
+  visibleTo: string | null;
+  createdAt: number;
+  metadata: unknown;
+  nudgeCount: number | null;
+  isSent: boolean;
+  reactions_md: string | null;
+  link_preview_md: string | null;
+  childConversationId: string | null;
+};
 
 function buildParentMessageSummary(
   message: {
@@ -91,12 +69,11 @@ function buildParentMessageSummary(
 }
 
 async function syncInitialMessageMd(
-  message: Parameters<typeof buildInitialMessageSummary>[0],
+  message: InitialMessageRow,
   conversation: { conversationId: string; initial_message_md: string | null },
   tx: Transaction<Schema>,
 ): Promise<void> {
-  const summary = buildInitialMessageSummary(message);
-  const md = serializeInitialMessageMd(summary);
+  const md = buildInitialMessageMd(message);
 
   if (conversation.initial_message_md === md) return;
 

--- a/apps/backend/src/zero/mutation-sync/handlers/reactions.ts
+++ b/apps/backend/src/zero/mutation-sync/handlers/reactions.ts
@@ -6,9 +6,8 @@ import {
   parseReactionsMd,
   removeReactionFromData,
   serializeReactionsMd,
-  serializeInitialMessageMd,
+  buildInitialMessageMd,
 } from '@xyne/shared';
-import type { InitialMessageSummary } from '@xyne/shared';
 import type { ReactionPreviousValue } from '../types';
 import { BaseMutationSyncHandler } from '../base-handler';
 
@@ -40,27 +39,7 @@ async function syncInitialMessageMdAfterReaction(
 
   if (conversations.length === 0) return;
 
-  const summary: InitialMessageSummary = {
-    messageId: message.messageId,
-    conversationId: message.conversationId,
-    senderId: message.senderId,
-    content: message.content,
-    msgType: message.msgType,
-    hasAttachment: message.hasAttachment,
-    edited: message.edited,
-    isDeleted: message.isDeleted,
-    showInChannel: message.showInChannel,
-    visibleTo: message.visibleTo,
-    createdAt: message.createdAt,
-    metadata: message.metadata ? JSON.stringify(message.metadata) : null,
-    nudgeCount: message.nudgeCount,
-    isSent: message.isSent,
-    reactions_md: updatedReactionsMd,
-    link_preview_md: message.link_preview_md,
-    childConversationId: message.childConversationId,
-  };
-
-  const md = serializeInitialMessageMd(summary);
+  const md = buildInitialMessageMd({ ...message, reactions_md: updatedReactionsMd });
 
   for (const conversation of conversations) {
     if (conversation.initial_message_md === md) continue;

--- a/packages/shared/src/messages/pendingRows.ts
+++ b/packages/shared/src/messages/pendingRows.ts
@@ -2,7 +2,7 @@ import type {
   Conversation,
   ThreadConversation,
 } from '../machines/queryCacheMachine.js';
-import { serializeInitialMessageMd } from '../utils/activityMetadataParser.js';
+import { buildInitialMessageMd } from '../utils/activityMetadataParser.js';
 import { AttachmentEntityType } from '../zero/schema.js';
 import type { PendingAttachment, PendingMessage } from './pending.js';
 
@@ -49,7 +49,7 @@ export function buildPendingChannelConversation(
   const attachmentRows = buildAttachmentRows(entry);
   const hasAttachment = attachmentRows.length > 0;
 
-  const initial_message_md = serializeInitialMessageMd({
+  const initial_message_md = buildInitialMessageMd({
     messageId: entry.messageId,
     conversationId: entry.conversationId,
     workspaceId: entry.workspaceId,
@@ -57,17 +57,7 @@ export function buildPendingChannelConversation(
     content: entry.content,
     msgType: entry.type,
     hasAttachment,
-    edited: false,
-    isDeleted: false,
-    showInChannel: false,
-    visibleTo: null,
     createdAt: entry.timestamp,
-    metadata: null,
-    nudgeCount: null,
-    isSent: false,
-    reactions_md: null,
-    link_preview_md: null,
-    childConversationId: null,
   });
 
   return {

--- a/packages/shared/src/utils/activityMetadataParser.ts
+++ b/packages/shared/src/utils/activityMetadataParser.ts
@@ -614,6 +614,64 @@ export function serializeInitialMessageMd(
   return lines.join('\n');
 }
 
+/**
+ * Input for `buildInitialMessageMd`. Every field the message row does not yet
+ * define at creation time carries a default, so a caller about to insert the
+ * message can build the md without reading the row back.
+ */
+export interface InitialMessageMdInput {
+  messageId: string;
+  conversationId: string;
+  senderId: string;
+  content: string;
+  msgType: MessageType;
+  createdAt: number;
+  workspaceId?: string | null;
+  hasAttachment?: boolean;
+  edited?: boolean;
+  isDeleted?: boolean;
+  showInChannel?: boolean;
+  visibleTo?: string | null;
+  metadata?: unknown;
+  nudgeCount?: number | null;
+  isSent?: boolean;
+  reactions_md?: string | null;
+  link_preview_md?: string | null;
+  childConversationId?: string | null;
+}
+
+/**
+ * The single builder for `conversations.initial_message_md`.
+ *
+ * Every writer — Zero mutators, mutation-sync handlers, Prisma services,
+ * migration scripts — must go through this. Divergence is not a type error:
+ * a writer that serializes differently silently rewrites the md on every
+ * conversation it touches, and each of those writes fans out through every
+ * subscribed Zero pipeline.
+ */
+export function buildInitialMessageMd(msg: InitialMessageMdInput): string | null {
+  return serializeInitialMessageMd({
+    messageId: msg.messageId,
+    conversationId: msg.conversationId,
+    workspaceId: msg.workspaceId ?? null,
+    senderId: msg.senderId,
+    content: msg.content,
+    msgType: msg.msgType,
+    hasAttachment: msg.hasAttachment ?? false,
+    edited: msg.edited ?? false,
+    isDeleted: msg.isDeleted ?? false,
+    showInChannel: msg.showInChannel ?? false,
+    visibleTo: msg.visibleTo ?? null,
+    createdAt: msg.createdAt,
+    metadata: msg.metadata ? JSON.stringify(msg.metadata) : null,
+    nudgeCount: msg.nudgeCount ?? null,
+    isSent: msg.isSent ?? false,
+    reactions_md: msg.reactions_md ?? null,
+    link_preview_md: msg.link_preview_md ?? null,
+    childConversationId: msg.childConversationId ?? null,
+  });
+}
+
 // ==========================================================================
 // PARENT MESSAGE SNAPSHOT
 // ==========================================================================

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -73,7 +73,7 @@ import { createForwardedMessageXml, parseForwardedMessageXml } from '../forwarde
 import { getNudgeActionBehavior } from '../nudges.js';
 import {
   parseTicketMd,
-  serializeInitialMessageMd,
+  buildInitialMessageMd,
   serializeParentMessageMd,
 } from '../utils/activityMetadataParser.js';
 import {
@@ -212,42 +212,6 @@ export function isAttachmentUploadInFlight(attachment: {
   );
 }
 
-/** Build initial_message_md from message data. Single helper for all conversation creation sites. */
-function buildInitialMessageMd(msg: {
-  messageId: string;
-  conversationId: string;
-  workspaceId?: string | null;
-  senderId: string;
-  content: string;
-  msgType: MessageTypeEnum;
-  hasAttachment?: boolean;
-  showInChannel?: boolean;
-  visibleTo?: string | null;
-  createdAt: number;
-  metadata?: unknown;
-  childConversationId?: string | null;
-}): string | null {
-  return serializeInitialMessageMd({
-    messageId: msg.messageId,
-    conversationId: msg.conversationId,
-    workspaceId: msg.workspaceId ?? null,
-    senderId: msg.senderId,
-    content: msg.content,
-    msgType: msg.msgType,
-    hasAttachment: msg.hasAttachment ?? false,
-    edited: false,
-    isDeleted: false,
-    showInChannel: msg.showInChannel ?? false,
-    visibleTo: msg.visibleTo ?? null,
-    createdAt: msg.createdAt,
-    metadata: msg.metadata ? JSON.stringify(msg.metadata) : null,
-    nudgeCount: null,
-    isSent: false,
-    reactions_md: null,
-    link_preview_md: null,
-    childConversationId: msg.childConversationId ?? null,
-  });
-}
 
 /** Build parent_message_md from an existing message row. */
 function buildParentMessageMd(msg: {


### PR DESCRIPTION
Backport of #1749 to `release-20260911`.

## The problem

`conversations.initialMessageId` is `NOT NULL` but `conversations.initial_message_md` is nullable — and on the V3 read path the md is the **only** source of the message body. `channelConversationsPaginatedV3`, `channelLatestMultipleConversationsV3` and `dmChannelsLatestMessagesPaginated` carry no `.related('initialMessage')`, and `getInitialMessageFromConversation` returns `null` rather than looking the message up. A conversation whose md is missing renders as an empty message.

`createConversationWithMessage` wrote the row three times per message — INSERT with `initialMessageId: 'temp'`, UPDATE to the real id, UPDATE to add the md — with no `$transaction` anywhere in the chain. Between the first commit and the last, the conversation is live and visible with no body.

## What this changes

| path | conversations updates |
|---|---|
| `createConversationWithMessage` | 3 → **1** |
| `addMessageToConversation`, plain reply | 3 → **1** |
| `addMessageToConversation`, `replyBroadcast` child | 3 → **2** |

Both blank-content windows are closed: every conversation these paths create now carries a complete snapshot on its INSERT.

Fewer writes also means less Zero fan-out — the `conversations` table has by far the highest per-change IVM cost of any table, so this is the write path that matters.

## Verification on this branch

The defect was confirmed present on `release-20260911` before porting, not assumed:

- `conversationService.ts:409` still has `initialMessageId: 'temp'`
- zero `$transaction` in the create chain
- `initial_message_md` still nullable while `initialMessageId` is `NOT NULL`
- the V3 queries still carry no `initialMessage` join
- `messages.isSent` still defaults to `true` and `nudgeCount` to `0`, which is what the explicit values in the snapshot rely on

All five commits cherry-picked cleanly and the resulting diff is byte-identical to #1749 (+252 −295, 14 files).

Typechecks were baselined against `origin/release-20260911` itself rather than against main: 25 pre-existing errors before and after, none introduced. Dashboard unchanged apart from the pre-existing unbuilt `@xyne/workflow-ui`. `pnpm --filter @xyne/shared test` green.

No runtime or DB testing.

## Review notes

See #1749 for the full discussion. The points most worth a second pair of eyes:

- **`isSent: true` / `nudgeCount: 0` are passed explicitly** in the snapshot to match the `messages` column defaults. The old code picked these up implicitly by reading the row back after inserting; the builder's own defaults are `false`/`null` and would have disagreed with the row. Nothing guards this coupling.
- **The `replyBroadcast` snapshot takes `conversationId` from the message row**, not the child conversation — that is what `syncInitialMessageMd` produced, and the client maps the field through, so changing it would alter where a broadcast reply navigates.
- **`replyCount` is now an atomic `{ increment: 1 }`** instead of read-then-write, removing a lost-update race between concurrent replies.
- **`addReply` is deleted** — no callers remained after the collapse.

## Not in scope

Other `initialMessageId: 'temp'` sites remain (`channelController` ×3, `conversationController` ×2, `emailService` ×3, `unifiedBotController`, `migrationCleanupController` ×2, `shareAgentConversationService`), `parent_message_md` has the same nullable-with-no-fallback shape and is unaudited, and existing null-md rows are not backfilled. Same as on the main PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdPfJkKyKNDTmpGEekTUbf
