### PR TITLE
XYNE-17198 FILE_CONTENT_ENABLED to feed Slack-migrated attac…

### DIFF
--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -232,7 +232,8 @@ const envSchema = Joi.object({
   // LiteLLM Configuration for AI Agents
   LITELLM_BASE_URL: Joi.string().default(''),
   LITELLM_API_KEY: Joi.string().allow('').default(''),
-  ENABLE_ENTITY_EXTRACTION: Joi.boolean().default(true),
+  // OFF by default — entity extraction is an opt-in LLM cost per thread.
+  ENABLE_ENTITY_EXTRACTION: Joi.boolean().default(false),
   ENTITY_EXTRACTION_MODEL: Joi.string().default('open-fast'),
   ENTITY_EXTRACTION_CONCURRENCY: Joi.number().default(2),
   // How long a thread's job sits delayed before it runs. This is the debounce
@@ -535,12 +536,12 @@ const envSchema = Joi.object({
   // (lower = higher; delete=1, so 1 puts it at the top).
   FILE_NAME_ONLY_FEED_ENABLED: Joi.boolean().default(true),
   FILE_NAME_ONLY_FEED_PRIORITY: Joi.number().default(1),
-  // Slack-migration attachment content: when true (default) migrated attachments get
-  // the normal full-content feed; when false they are fed METADATA-ONLY (name/mime/
-  // size/permissions with empty chunks), so a bulk import skips the GCS download +
-  // parse/OCR/embed entirely and files are still searchable by name. Only consulted on
+  // Slack-migration attachment content. OFF by default: migrated attachments are fed
+  // METADATA-ONLY (name/mime/size/permissions with empty chunks), so a bulk import skips
+  // the GCS download + parse/OCR/embed entirely and files are still searchable by name.
+  // Set to true to restore full-content feeds for migrated attachments. Only consulted on
   // the Slack migration paths — live uploads and KB/collections are unaffected.
-  FILE_CONTENT_ENABLED: Joi.boolean().default(true),
+  FILE_CONTENT_ENABLED: Joi.boolean().default(false),
   // Staging on the LOCAL filesystem (a tmp folder in the container). Single-pod only.
   DOCLING_ASYNC_STORAGE_ROOT: Joi.string().default('/tmp/docling-async'),
   DOCLING_KEEP_TEMP_RESULTS: Joi.boolean().default(false),

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -535,6 +535,12 @@ const envSchema = Joi.object({
   // (lower = higher; delete=1, so 1 puts it at the top).
   FILE_NAME_ONLY_FEED_ENABLED: Joi.boolean().default(true),
   FILE_NAME_ONLY_FEED_PRIORITY: Joi.number().default(1),
+  // Slack-migration attachment content: when true (default) migrated attachments get
+  // the normal full-content feed; when false they are fed METADATA-ONLY (name/mime/
+  // size/permissions with empty chunks), so a bulk import skips the GCS download +
+  // parse/OCR/embed entirely and files are still searchable by name. Only consulted on
+  // the Slack migration paths — live uploads and KB/collections are unaffected.
+  FILE_CONTENT_ENABLED: Joi.boolean().default(true),
   // Staging on the LOCAL filesystem (a tmp folder in the container). Single-pod only.
   DOCLING_ASYNC_STORAGE_ROOT: Joi.string().default('/tmp/docling-async'),
   DOCLING_KEEP_TEMP_RESULTS: Joi.boolean().default(false),
@@ -1175,6 +1181,9 @@ export const config = {
   fileNameOnlyFeed: {
     enabled: envVars.FILE_NAME_ONLY_FEED_ENABLED as boolean,
     queuePriority: envVars.FILE_NAME_ONLY_FEED_PRIORITY as number,
+  },
+  fileContentFeed: {
+    enabled: envVars.FILE_CONTENT_ENABLED as boolean,
   },
   doclingScheduler: {
     enabled: envVars.DOCLING_ASYNC_SCHEDULER_ENABLED as boolean,

--- a/apps/backend/src/migration/scripts/bulkIngestConversationSlack.ts
+++ b/apps/backend/src/migration/scripts/bulkIngestConversationSlack.ts
@@ -54,13 +54,16 @@ function enqueueMessageVespa(messageId: string, workspaceId: string | undefined,
     .catch((e) => logger.warn('[BulkIngest] vespa enqueue failed (non-fatal)', { messageId, error: e instanceof Error ? e.message : String(e) }));
 }
 
-/** Attachment full-text feed job (fileSchema) — mirrors conversationService.pushVespaJobForAttachments: supported MIME
- *  types only, backfill-routed by age, so migrated files (PDF/DOCX/TXT…) become searchable like the per-message path. */
+/** Attachment feed job (fileSchema) — mirrors conversationService.pushVespaJobForAttachments: supported MIME
+ *  types only, backfill-routed by age, so migrated files (PDF/DOCX/TXT…) become searchable like the per-message path.
+ *  FILE_CONTENT_ENABLED=false downgrades this to a single metadata-only (nameOnly) feed: the worker then skips the
+ *  GCS download + parse and never routes the file to the OCR scheduler — searchable by name, no content. */
 function enqueueAttachmentVespa(attachmentId: string, mimeType: string, workspaceId: string | undefined, createdAt: Date): void {
   if (!isSupportedMimeType(mimeType)) return;
   const historical = Date.now() - createdAt.getTime() > VESPA_BACKFILL_AGE_DAYS * 86_400_000;
   const q = historical ? vespaBackfillQueue : vespaQueue;
-  void q.addJob({ schema: fileSchema, jobType: 'feed', docId: attachmentId, app: SubApp.CHAT_ATTACHMENT, ...(workspaceId ? { workspaceId } : {}) })
+  const metadataOnly = !config.fileContentFeed.enabled;
+  void q.addJob({ schema: fileSchema, jobType: 'feed', docId: attachmentId, app: SubApp.CHAT_ATTACHMENT, ...(workspaceId ? { workspaceId } : {}), ...(metadataOnly ? { nameOnly: true } : {}) })
     .catch((e) => logger.warn('[BulkIngest] attachment vespa enqueue failed (non-fatal)', { attachmentId, error: e instanceof Error ? e.message : String(e) }));
 }
 

--- a/apps/backend/src/migration/scripts/ingestConversationSlack.ts
+++ b/apps/backend/src/migration/scripts/ingestConversationSlack.ts
@@ -499,6 +499,7 @@ export async function ingestConversationSlack(
           isAddingParticipant: false,
           pinned: isPinned || false,
           suppressAutomations: true, // migrated history must never fire workflows/automations
+          isMigrationImport: true, // FILE_CONTENT_ENABLED=false ⇒ attachments feed metadata-only
         });
 
         message = result.message;
@@ -521,6 +522,7 @@ export async function ingestConversationSlack(
           isAddingParticipant: false,
           markParticipantsRead: true,
           suppressAutomations: true, // migrated history must never fire workflows/automations
+          isMigrationImport: true, // FILE_CONTENT_ENABLED=false ⇒ attachments feed metadata-only
         });
 
         message = result.message;

--- a/apps/backend/src/services/conversationService.ts
+++ b/apps/backend/src/services/conversationService.ts
@@ -89,6 +89,8 @@ export interface CreateConversationWithMessageParams {
   suppressAutomations?: boolean;
   /** Caller replays MessagesSideEffectHandler.onInsert itself, which already emits MESSAGE_RECEIVED for the initial message — don't emit it twice. */
   emitsMessageReceivedViaSideEffects?: boolean;
+  /** Slack migration import: with FILE_CONTENT_ENABLED=false, attachment Vespa feeds are downgraded to metadata-only. */
+  isMigrationImport?: boolean;
 }
 
 export interface AddMessageToConversationParams {
@@ -109,6 +111,8 @@ export interface AddMessageToConversationParams {
   markParticipantsRead?: boolean;
   /** Migration import: skip live-only side effects (TICKET_COMMENTED automations, meet-link extraction) so bulk-imported history never fires workflows. */
   suppressAutomations?: boolean;
+  /** Slack migration import: with FILE_CONTENT_ENABLED=false, attachment Vespa feeds are downgraded to metadata-only. */
+  isMigrationImport?: boolean;
 }
 
 export interface UpdateMessageParams {
@@ -274,12 +278,24 @@ export class ConversationService {
     attachments: Array<{ id: string; mimetype: string }>,
     userId: string,
     workspaceId?: string,
-    createdAt?: Date
+    createdAt?: Date,
+    // Slack migration import. With FILE_CONTENT_ENABLED=false such attachments get a
+    // single metadata-only feed (nameOnly) instead of the full-content one: the worker
+    // then skips the GCS download + parse (mapper) and never routes the file to the OCR
+    // scheduler, so the file is searchable by name with none of the parse cost.
+    isMigrationImport = false,
   ): Promise<void> {
     if (attachments.length === 0) return;
 
     // Filter only supported MIME types (PDF, DOCX, TXT, MD, etc.)
     const supportedAttachments = attachments.filter(att => isSupportedMimeType(att.mimetype));
+
+    const metadataOnly = isMigrationImport && !config.fileContentFeed.enabled;
+    if (metadataOnly) {
+      logger.info(
+        `[ConversationService] FILE_CONTENT_ENABLED=false — feeding ${supportedAttachments.length} migrated attachment(s) metadata-only (no content)`
+      );
+    }
 
     const queue = this.pickVespaQueue(createdAt);
     for (const attachment of supportedAttachments) {
@@ -289,6 +305,7 @@ export class ConversationService {
         docId: attachment.id,
         app: SubApp.CHAT_ATTACHMENT,
         ...(workspaceId ? { workspaceId } : {}),
+        ...(metadataOnly ? { nameOnly: true } : {}),
       }).catch(async (error) => {
         logger.error(`[ConversationService] Error queuing Vespa job for attachment ${attachment.id}:`, error);
         // Log failed insertion to Postgres
@@ -343,6 +360,7 @@ export class ConversationService {
       pinned,
       suppressAutomations = false,
       emitsMessageReceivedViaSideEffects = false,
+      isMigrationImport = false,
     } = params;
 
     // Check if channel exists
@@ -472,7 +490,7 @@ export class ConversationService {
 
       if (savedAttachments.length > 0) {
         const attachments = savedAttachments.map(a => ({ id: a.id, mimetype: a.mimetype }));
-        this.pushVespaJobForAttachments(attachments, userId, channel?.workspaceId, message.createdAt).catch(error => {
+        this.pushVespaJobForAttachments(attachments, userId, channel?.workspaceId, message.createdAt, isMigrationImport).catch(error => {
           logger.error(`[ConversationService] Error pushing Vespa job for attachments in conversation ${conversation.conversationId}:`, error);
         });
       }
@@ -584,6 +602,7 @@ export class ConversationService {
       isAddingParticipant = true,
       markParticipantsRead = false,
       suppressAutomations = false,
+      isMigrationImport = false,
     } = params;
 
     const conversation = await this.conversationRepository.findById(conversationId);
@@ -711,7 +730,7 @@ export class ConversationService {
 
       if (savedAttachments.length > 0) {
         const attachments = savedAttachments.map(a => ({ id: a.id, mimetype: a.mimetype }));
-        this.pushVespaJobForAttachments(attachments, userId, channel?.workspaceId, message.createdAt).catch(error => {
+        this.pushVespaJobForAttachments(attachments, userId, channel?.workspaceId, message.createdAt, isMigrationImport).catch(error => {
           logger.error(`[ConversationService] Error pushing Vespa job for attachments in message ${message.messageId}:`, error);
         });
       }


### PR DESCRIPTION
…hments metadata-only

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
