### PR TITLE
feat: XYNE-59714 ask ai event bus (#1770)

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1042,6 +1042,9 @@ export class App {
       // Close tag generation pipeline queue
       await tagGenerationPipeline.close();
 
+      const { shutdownWorkflows } = await import('@/workflowsV2/runtime');
+      await shutdownWorkflows();
+
       // Shutdown notification service
       await notificationService.shutdown();
 

--- a/apps/backend/src/workflowsV2/adapters/event-bus.ts
+++ b/apps/backend/src/workflowsV2/adapters/event-bus.ts
@@ -1,0 +1,107 @@
+/**
+ * Redis-backed {@link EventBusAdapter} — how a live execution's events reach a
+ * browser that is connected to a different process than the one running the step.
+ */
+import type { Redis } from 'ioredis';
+import type {
+  BusEvent,
+  BusListener,
+  EventBusAdapter,
+  EventTopic,
+  Unsubscribe,
+} from '@xyne/workflow-sdk';
+import { createRedisClient } from '@/services/redisFactory';
+import { logger } from '@/utils/logger';
+
+const CHANNEL_PREFIX = 'workflows:events:';
+
+const channelFor = (topic: EventTopic): string => `${CHANNEL_PREFIX}${topic}`;
+
+interface TopicState {
+  readonly listeners: Set<BusListener>;
+  readonly ready: Promise<void>;
+}
+
+export class RedisEventBus implements EventBusAdapter {
+  private readonly publisher: Redis;
+  private readonly subscriber: Redis;
+  private readonly topics = new Map<EventTopic, TopicState>();
+
+  constructor() {
+    this.publisher = createRedisClient('workflows-events-pub');
+    this.subscriber = createRedisClient('workflows-events-sub');
+    this.subscriber.on('message', (channel: string, payload: string) => {
+      this.dispatch(channel, payload);
+    });
+  }
+
+  async publish(topic: EventTopic, event: BusEvent): Promise<void> {
+    await this.publisher.publish(channelFor(topic), JSON.stringify(event));
+  }
+
+  async subscribe(topic: EventTopic, listener: BusListener): Promise<Unsubscribe> {
+    let state = this.topics.get(topic);
+    if (!state) {
+      state = {
+        listeners: new Set(),
+        ready: this.subscriber.subscribe(channelFor(topic)).then(() => undefined),
+      };
+      this.topics.set(topic, state);
+    }
+    const own = state;
+    own.listeners.add(listener);
+
+    try {
+      await own.ready;
+    } catch (err) {
+      this.detach(topic, listener, own);
+      throw err;
+    }
+
+    return () => this.detach(topic, listener, own);
+  }
+
+  async close(): Promise<void> {
+    this.topics.clear();
+    await Promise.allSettled([this.publisher.quit(), this.subscriber.quit()]);
+  }
+
+  private detach(topic: EventTopic, listener: BusListener, state: TopicState): void {
+    if (this.topics.get(topic) !== state) return;
+    state.listeners.delete(listener);
+    if (state.listeners.size > 0) return;
+
+    this.topics.delete(topic);
+    void this.subscriber.unsubscribe(channelFor(topic)).catch((err: unknown) => {
+      logger.warn(`[workflows] event bus unsubscribe failed for ${topic}`, {
+        message: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
+
+  private dispatch(channel: string, payload: string): void {
+    if (!channel.startsWith(CHANNEL_PREFIX)) return;
+    const topic = channel.slice(CHANNEL_PREFIX.length) as EventTopic;
+
+    const state = this.topics.get(topic);
+    if (!state) return;
+
+    let event: BusEvent;
+    try {
+      event = JSON.parse(payload) as BusEvent;
+    } catch {
+      logger.warn(`[workflows] event bus received unparseable payload on ${topic}`);
+      return;
+    }
+
+    for (const listener of [...state.listeners]) {
+      try {
+        listener(event);
+      } catch (err: unknown) {
+        logger.warn(`[workflows] event bus listener threw for ${topic}`, {
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+}

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -129,6 +129,8 @@
     "@xyflow/react": "^12.11.2",
     "@xyne/icons": "workspace:*",
     "@xyne/shared": "workspace:*",
+    "@xyne/workflow-sdk": "3.2.36",
+    "@xyne/workflow-ui": "1.3.35",
     "@y-sweet/client": "^0.9.1",
     "ag-grid-community": "^35.0.0",
     "ag-grid-react": "^35.0.0",

--- a/apps/xyne-claw-auth/backend/src/mcp/adapters/xyne-workflows.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/adapters/xyne-workflows.ts
@@ -1,7 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { resolve, dirname } from "node:path";
 import type { StdioMcpAdapter } from "../types.js";
-import { WORKFLOW_WRITE_TOOL_NAMES } from "../servers/xyne-workflows-tools.js";
 
 const SERVER_PATH = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -12,7 +11,7 @@ export const xyneWorkflowsAdapter: StdioMcpAdapter = {
   transport: "stdio",
   type: "xyne-workflows",
   healthCheck: { name: "workflow_catalog", params: {} },
-  writeTools: [...WORKFLOW_WRITE_TOOL_NAMES],
+  writeTools: [],
   credentialFields: [],
   buildCommand(credentials) {
     const url = String(

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-workflows-tools.test.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-workflows-tools.test.ts
@@ -57,10 +57,12 @@ describe("tool surface", () => {
     expect(mod.WORKFLOW_TOOL_NAMES).toHaveLength(mod.tools.length);
   });
 
-  it("gates exactly the tools that mutate or execute", async () => {
+  it("records exactly the tools that mutate or execute", async () => {
     const mod = await import("./xyne-workflows-tools.js");
-    // Reads must NOT be gated — an approval card on every lookup would train users to
-    // click through them, which is how a real write slips past.
+    // The adapter does not gate on this today (see its `writeTools`), but the list
+    // is what gating would use, so it has to stay honest about which tools mutate.
+    // Reads must never appear here — an approval card on every lookup would train
+    // users to click through them, which is how a real write slips past.
     expect([...mod.WORKFLOW_WRITE_TOOL_NAMES].sort()).toEqual(
       ["workflow_create", "workflow_run", "workflow_update"],
     );


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
