### PR TITLE
feat: XYNE-63309 screen-recordings in scribe

### DIFF
--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -1764,6 +1764,7 @@ export const callRecordingTable = table("call_recordings")
     storagePath: string().optional(),
     segmentPrefix: string().optional(),
     messageId: string().optional(),
+    attachmentId: string().optional(),
     startedAt: number(),
     endedAt: number().optional(),
     createdAt: number(),

--- a/apps/backend/prisma/migrations/20260911091721_attachment_recordings/migration.sql
+++ b/apps/backend/prisma/migrations/20260911091721_attachment_recordings/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "non_zero"."call_recordings" ADD COLUMN     "attachmentId" TEXT;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -2932,6 +2932,7 @@ model CallRecording {
   storagePath   String?                          // final MP4 object key, set only on UPLOADED (read by all consumers)
   segmentPrefix String?                          // HLS segment dir, set at start; deleted after a successful stitch
   messageId     String?                          // thread message this recording is posted under
+  attachmentId  String?                          // RECORDING message_attachments row (note-taker recordings)
   startedAt     DateTime                         // Set explicitly in code (no DB default — team convention)
   endedAt       DateTime?
   createdAt     DateTime                         // Set explicitly in code (no DB default — team convention)

--- a/apps/backend/src/controllers/attachmentController.ts
+++ b/apps/backend/src/controllers/attachmentController.ts
@@ -19,8 +19,33 @@ import { fileSchema, SubApp } from '@/vespa/src/types';
 import { DatabaseClient } from '../database/client';
 import { NAMESPACE } from '@/vespa/vespaConfig';
 import { isSupportedMimeType } from '@/services/fileProcessor';
+import { repositories } from '@/database/repositories';
+import { callShareService } from '@/services/callShareService';
 
 const db = DatabaseClient.getInstance();
+
+const TRANSCRIPTION_BUCKET_TYPES = new Set(['transcript', 'identified_transcript', 'recording']);
+const NO_CACHE_TYPES = new Set(['transcript', 'identified_transcript']);
+
+const getAttachmentType = (attachment: MessageAttachment): string =>
+  (attachment.metadata as { type?: string } | null)?.type ?? '';
+
+/** Transcripts and call recordings live in the transcription bucket. */
+const getAttachmentStorage = (attachment: MessageAttachment): typeof storageService =>
+  TRANSCRIPTION_BUCKET_TYPES.has(getAttachmentType(attachment))
+    ? getStorageService(config.gcs.transcriptionBucketName)
+    : storageService;
+
+/** Transcripts can be rewritten, so they are never cached; other files are. */
+const setAttachmentCacheHeaders = (res: Response, attachment: MessageAttachment): void => {
+  if (NO_CACHE_TYPES.has(getAttachmentType(attachment))) {
+    res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.setHeader('Pragma', 'no-cache');
+    res.setHeader('Expires', '0');
+  } else {
+    res.setHeader('Cache-Control', 'private, max-age=3600');
+  }
+};
 
 export class AttachmentController {
   private messageAttachmentRepository: MessageAttachmentRepository;
@@ -97,6 +122,7 @@ export class AttachmentController {
    *  2. DRAFT / DELAYED_MESSAGE — only the creator may read it.
    *  3. Chat attachments (those carrying a conversationId) — the caller must be
    *     a participant of the owning channel. Mirrors streamAttachment.
+   *  4. RECORDING — the caller must be able to view the call's recordings.
    * Non-chat types without a conversation (TICKET, EMAIL, FORM_ENTITY_VALUE,
    * IMPACT, …) are bounded by the workspace check only, preserving existing
    * in-workspace access.
@@ -152,6 +178,26 @@ export class AttachmentController {
           body: { error: 'Forbidden', message: 'You do not have permission to access this attachment' },
         };
       }
+    }
+
+    // 2.6) Note-taker recordings — same rule as the recording download endpoints.
+    if (attachment.entityType === AttachmentEntityType.RECORDING) {
+      const recording = await repositories.callRecordings.findById(attachment.entityId);
+      const call = recording ? await repositories.calls.findById(recording.callId) : null;
+      if (!call || call.workspaceId !== workspaceId) {
+        return { ok: false, status: 404, body: { error: 'Attachment not found' } };
+      }
+      if (!(await callShareService.canViewRecordings(call, userId))) {
+        logger.warn(
+          `Unauthorized recording attachment access: user ${userId} -> ${attachment.id} (call ${call.id})`,
+        );
+        return {
+          ok: false,
+          status: 403,
+          body: { error: 'Forbidden', message: 'You do not have permission to access this attachment' },
+        };
+      }
+      return { ok: true };
     }
 
     // 3) Conversation-backed (chat/DM/transcript) attachments — must participate.
@@ -295,11 +341,7 @@ export class AttachmentController {
         return;
       }
 
-      // Transcripts live in a separate bucket
-      const meta = attachment.metadata as { type?: string };
-      const service = meta?.type === 'transcript' || meta?.type === 'identified_transcript'
-        ? getStorageService(config.gcs.transcriptionBucketName)
-        : storageService;
+      const service = getAttachmentStorage(attachment);
 
       logger.info(`Streaming attachment ${attachmentId} from path: ${filePath}`);
 
@@ -312,14 +354,7 @@ export class AttachmentController {
         filename: attachment.originalFilename,
       });
 
-      // Disable caching for transcripts (they can be updated), cache other files
-      if (meta?.type === 'transcript' || meta?.type === 'identified_transcript') {
-        res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
-        res.setHeader('Pragma', 'no-cache');
-        res.setHeader('Expires', '0');
-      } else {
-        res.setHeader('Cache-Control', 'private, max-age=3600');
-      }
+      setAttachmentCacheHeaders(res, attachment);
 
       // Stream the file
       res.send(buffer);
@@ -436,11 +471,7 @@ export class AttachmentController {
         return;
       }
 
-      // Route transcript/recording attachments to their dedicated bucket
-      const meta = attachment.metadata as { type?: string };
-      const service = meta?.type === 'transcript' || meta?.type === 'identified_transcript' || meta?.type === 'recording'
-        ? getStorageService(config.gcs.transcriptionBucketName)
-        : storageService;
+      const service = getAttachmentStorage(attachment);
 
       const fileExists = await service.fileExists(filePath);
       if (!fileExists) {
@@ -465,13 +496,7 @@ export class AttachmentController {
         });
         res.setHeader('Content-Length', fileSize);
         res.setHeader('Accept-Ranges', 'bytes');
-        if (meta?.type === 'transcript' || meta?.type === 'identified_transcript') {
-          res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
-          res.setHeader('Pragma', 'no-cache');
-          res.setHeader('Expires', '0');
-        } else {
-          res.setHeader('Cache-Control', 'private, max-age=3600');
-        }
+        setAttachmentCacheHeaders(res, attachment);
 
         const stream = await service.createReadStream(filePath);
         stream.pipe(res);
@@ -524,13 +549,7 @@ export class AttachmentController {
       res.setHeader('Content-Length', chunkSize);
       res.setHeader('Content-Range', `bytes ${start}-${end}/${fileSize}`);
       res.setHeader('Accept-Ranges', 'bytes');
-      if (meta?.type === 'transcript' || meta?.type === 'identified_transcript') {
-        res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
-        res.setHeader('Pragma', 'no-cache');
-        res.setHeader('Expires', '0');
-      } else {
-        res.setHeader('Cache-Control', 'private, max-age=3600');
-      }
+      setAttachmentCacheHeaders(res, attachment);
 
       const stream = await service.createReadStream(filePath, { start, end });
       stream.pipe(res);

--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -26,7 +26,7 @@ import { scheduledCallNotificationService } from '@/services/scheduledCallNotifi
 import { normalizeStoragePath } from '@xyne/storage';
 import { sdlcCallLinkSchema, type SdlcCallLink } from '@xyne/shared';
 import { callRecordingService } from '@/services/callRecordingService';
-import { isRecording } from '@/utils/callTypeUtils';
+import { isRecording, isRecordingType } from '@/utils/callTypeUtils';
 import { config } from '@/config/env';
 import { callDocumentService, numberTranscriptSegments, buildParticipantMap } from '@/services/callDocumentService';
 import {
@@ -415,6 +415,7 @@ export class CallController {
         artifactMessageId,
         sdlcLink,
         summaryModelPreference,
+        recordingType,
       } = req.body;
       // Recording summary LLM tier the client carried from its localStorage;
       // stamped onto the detailed summary canvas so headless call-end
@@ -441,6 +442,10 @@ export class CallController {
       if (isHeadless) {
         if (!['AUDIO', 'VIDEO'].includes(callType)) {
           res.status(400).json({ success: false, error: 'Invalid call type' });
+          return;
+        }
+        if (recordingType !== undefined && !isRecordingType(recordingType)) {
+          res.status(400).json({ success: false, error: `Invalid recordingType. Must be one of: ${Object.values(RecordingType).join(', ')}` });
           return;
         }
 
@@ -519,6 +524,7 @@ export class CallController {
           workspaceId: req.user!.workspaceId,
           notesCanvasId,
           detailedSummaryCanvasId,
+          ...(recordingType && { recordingType }),
           ...(channelId && conversationId ? { channelId, conversationId } : {}),
           ...(headlessAgentName && { agentName: headlessAgentName }),
         });
@@ -1550,6 +1556,8 @@ export class CallController {
               : null,
           citationSegments,
           hasRecording: !!uploadedRecording,
+          recordingType: uploadedRecording?.recordingType ?? null,
+          attachmentId: uploadedRecording?.attachmentId ?? null,
         },
       });
     } catch (error) {
@@ -2703,21 +2711,7 @@ export class CallController {
    */
   private async assertCanViewCallRecordings(callId: string, userId: string): Promise<boolean> {
     const call = await repositories.calls.findByExternalId(callId);
-    if (!call) return false;
-    if (call.createdByUserId === userId) return true;
-    if (
-      call.callType === CallType.HEADLESS &&
-      call.workspaceId &&
-      (await callShareService.canView(call, userId, call.workspaceId))
-    ) {
-      return true;
-    }
-    const participant = await repositories.calls.findParticipant(call.id, userId);
-    if (participant) return true;
-    if (call.channelId) {
-      return repositories.channelParticipants.isParticipant(call.channelId, userId);
-    }
-    return false;
+    return !!call && callShareService.canViewRecordings(call, userId);
   }
 
   /**
@@ -2737,7 +2731,7 @@ export class CallController {
       return;
     }
 
-    if (!Object.values(RecordingType).includes(recordingType)) {
+    if (!isRecordingType(recordingType)) {
       res.status(400).json({ success: false, error: `Invalid recordingType. Must be one of: ${Object.values(RecordingType).join(', ')}` });
       return;
     }
@@ -3072,6 +3066,10 @@ export class CallController {
     });
 
     await repositories.entityAccess.deleteForResource(ShareableEntityType.NOTE_TAKER, call.id);
+
+    // Recording attachments aren't linked to the call, so remove them before it cascades away.
+    const recordings = await repositories.callRecordings.listByCallId(call.id);
+    await repositories.messageAttachments.deleteByRecordingIds(recordings.map(recording => recording.id));
 
     // Delete the call record
     await repositories.calls.delete(call.id);

--- a/apps/backend/src/controllers/livekitWebhookController.ts
+++ b/apps/backend/src/controllers/livekitWebhookController.ts
@@ -114,12 +114,10 @@ class LiveKitWebhookController {
 
     try {
       // Global routing: NOTE_TAKER (HEADLESS / "Xyne Oats") rooms never have a
-      // channel/message/conversation, so every event type for them is handled
-      // entirely by noteTakerWebhookController instead of the channel-based
-      // handlers below. This check must run before the switch so no event type
-      // (room_finished, participant_left, track_published, egress_*, etc.) ever
-      // falls through to the channel-based DB operations, which don't apply.
-      if (await this.isNoteTakerRoom(event)) {
+      // channel/message/conversation, so their events go to noteTakerWebhookController.
+      // Egress events are shared: callRecordingService handles them by egressId.
+      const isEgressEvent = event.event === 'egress_started' || event.event === 'egress_ended';
+      if (!isEgressEvent && (await this.isNoteTakerRoom(event))) {
         await noteTakerWebhookController.handleEvent(event);
         res.status(200).json({ success: true });
         return;

--- a/apps/backend/src/controllers/noteTakerWebhookController.ts
+++ b/apps/backend/src/controllers/noteTakerWebhookController.ts
@@ -10,6 +10,7 @@ import { callRecordingService } from '@/services/callRecordingService';
 import { livekitService } from '@/services/liveKitService';
 import { emitCallStarted, emitCallEnded } from '@/automations/triggers/call.trigger';
 import { buildCallInviteUrl } from '@/utils/urlUtils';
+import { isRecordingType } from '@/utils/callTypeUtils';
 
 // Deferred the same way as the conversation-based flow's fallback reconcile —
 // see livekitWebhookController's former room_finished comment for the full
@@ -50,8 +51,7 @@ class NoteTakerWebhookController {
 
       case 'egress_started':
       case 'egress_ended':
-        // callRecordingService's egress handling is already channel/message-agnostic
-        // (keyed purely by egressId), so it's shared as-is — see livekitWebhookController.
+        // Handled for every room type by livekitWebhookController.
         return;
 
       default:
@@ -111,6 +111,10 @@ class NoteTakerWebhookController {
     const threadChannelId =
       typeof roomMetadata.channelId === 'string' ? roomMetadata.channelId : undefined;
     const messageId = conversationId && threadChannelId ? uuidv4() : undefined;
+    const requestedRecordingType = roomMetadata.recordingType;
+    const recordingType = isRecordingType(requestedRecordingType)
+      ? requestedRecordingType
+      : RecordingType.AUDIO_ONLY;
 
     if (!workspaceId) {
       logger.error(`[NoteTaker Webhook] Missing workspaceId in room metadata for ${roomName}`);
@@ -222,14 +226,14 @@ class NoteTakerWebhookController {
     // handleParticipantLeft / handleRoomFinished below
     // (noteTakerTranscriptService.shareThreadRecordingIfLinked).
 
-    // Auto-start an audio recording for the whole call — note-taker calls have
+    // Auto-start a recording for the whole call — note-taker calls have
     // no manual "start recording" UI action, so this replaces that trigger.
     // Stopped automatically when the creator leaves. Non-fatal: a failure here shouldn't block call
     // creation or the transcription pipeline.
     try {
       await callRecordingService.startRecording({
         call,
-        recordingType: RecordingType.AUDIO_ONLY,
+        recordingType,
         startedBy: createdBy,
       });
     } catch (recordingError) {

--- a/apps/backend/src/database/repositories/callRecordingRepository.ts
+++ b/apps/backend/src/database/repositories/callRecordingRepository.ts
@@ -121,6 +121,10 @@ export class CallRecordingRepository {
     await this.db.callRecording.update({ where: { id }, data: { messageId } });
   }
 
+  async setAttachmentId(id: string, attachmentId: string): Promise<void> {
+    await this.db.callRecording.update({ where: { id }, data: { attachmentId } });
+  }
+
   async rename(id: string, name: string): Promise<CallRecording> {
     return this.db.callRecording.update({ where: { id }, data: { name } });
   }

--- a/apps/backend/src/database/repositories/messageAttachmentRepository.ts
+++ b/apps/backend/src/database/repositories/messageAttachmentRepository.ts
@@ -191,6 +191,17 @@ export class MessageAttachmentRepository {
     });
   }
 
+  /** Removes the attachments owned by note-taker recordings. */
+  async deleteByRecordingIds(recordingIds: string[]): Promise<void> {
+    if (recordingIds.length === 0) return;
+    await this.db.messageAttachment.deleteMany({
+      where: {
+        entityId: { in: recordingIds },
+        entityType: AttachmentEntityType.RECORDING,
+      },
+    });
+  }
+
   async findByTicketId(ticketId: string): Promise<MessageAttachment[]> {
     return await this.db.messageAttachment.findMany({
       where: {

--- a/apps/backend/src/services/callRecordingService.ts
+++ b/apps/backend/src/services/callRecordingService.ts
@@ -10,10 +10,20 @@ import { getStorageService } from '@/services/storage';
 import { livekitService } from '@/services/liveKitService';
 import { stitchHlsToMp4 } from '@/utils/ffmpeg';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service.js';
-import { MessageType, AttachmentEntityType, CallType, RecordingType } from '@xyne/shared';
+import { MessageType, AttachmentEntityType, RecordingType } from '@xyne/shared';
+import { isRecording } from '@/utils/callTypeUtils';
+import type { CreateMessageAttachmentInput } from '@/database/repositories/messageAttachmentRepository';
 
 /** HLS segment length. Smaller = more frequent uploads (less data lost on crash). */
 const SEGMENT_DURATION_SECONDS = 6;
+
+const recordingMimetype = (recordingType: string): string =>
+  recordingType === RecordingType.AUDIO_ONLY ? 'audio/mp4' : 'video/mp4';
+
+type RecordingAttachmentTarget = Pick<
+  CreateMessageAttachmentInput,
+  'entityType' | 'entityId' | 'conversationId' | 'workspaceId' | 'url' | 'size'
+>;
 
 export interface StartRecordingResult {
   recording: CallRecording;
@@ -314,24 +324,24 @@ class CallRecordingService {
       const localOut = path.join(workDir, 'out.mp4');
       await stitchHlsToMp4(path.join(workDir, path.basename(paths.playlistPath)), localOut);
 
-      const mimetype = recording.recordingType === RecordingType.AUDIO_ONLY ? 'audio/mp4' : 'video/mp4';
+      const mimetype = recordingMimetype(recording.recordingType);
       const buffer = await fs.readFile(localOut);
       await this.storageService.uploadFileV2(buffer, { path: paths.mp4Path, contentType: mimetype });
       if (!(await this.waitForFileExists(paths.mp4Path))) {
         throw new Error(`stitched MP4 not found at ${paths.mp4Path}`);
       }
 
+      // Before markUploaded, so a recording is never reported playable without its attachment.
+      if (isRecording(call)) {
+        await this.attachNoteTakerRecording(call, recording, paths.mp4Path, buffer.length);
+      }
+
       await repositories.callRecordings.markUploaded(recordingId, { storagePath: paths.mp4Path });
       logger.info(`[CallRecording] recording ${recordingId} UPLOADED (stitched), path=${paths.mp4Path}`);
       await this.deleteSegments(recording.segmentPrefix);
 
-      // NOTE_TAKER (headless) calls never create messages/attachments — the
-      // call_recordings row (storagePath, status=UPLOADED) is the only record
-      // of the file; getRecordingDetail/download-recording already read from
-      // this table directly, so there's nothing further to post.
-      if (call.callType === CallType.HEADLESS) {
-        logger.info(`[CallRecording] Skipping message/attachment post for HEADLESS call ${call.externalId} (recording ${recordingId})`);
-      } else {
+      // NOTE_TAKER (headless) calls have no thread to post into.
+      if (!isRecording(call)) {
         try {
           await this.postRecordingMessageAndAttachment(call, { ...recording, storagePath: paths.mp4Path });
         } catch (err) {
@@ -402,10 +412,7 @@ class CallRecordingService {
     const bot = await unifiedBotUserService.getBotByBotId('xyne-automatic', workspaceId);
     const senderId = bot?.id ?? call.createdByUserId;
 
-    const isAudio = recording.recordingType === RecordingType.AUDIO_ONLY;
-    const mimetype = isAudio ? 'audio/mp4' : 'video/mp4';
     const recordingName = recording.name?.trim() || 'Recording';
-    const displayFilename = call.title ? `${call.title} - ${recordingName}.mp4` : `${recordingName}.mp4`;
 
     // Post the per-recording thread message first so the attachment hangs off it.
     const message = await repositories.messages.create({
@@ -433,27 +440,74 @@ class CallRecordingService {
       logger.warn(`[CallRecording] Could not get file size for ${recording.storagePath}: ${err}`);
     }
 
-    await repositories.messageAttachments.create({
-      entityId: message.messageId,
-      entityType: AttachmentEntityType.CHAT,
-      workspaceId,
-      originalFilename: displayFilename,
-      size: fileSize,
-      mimetype,
-      url: recording.storagePath!,
-      uploadedByUserId: recording.startedBy ?? call.createdByUserId,
-      createdBy: recording.startedBy ?? call.createdByUserId,
-      storageProvider: config.fileStorage.provider,
-      conversationId: headMessage.conversationId,
-      metadata: {
-        callId: call.externalId,
-        recordingId: recording.id,
-        type: 'recording',
-      },
-    });
+    await repositories.messageAttachments.create(
+      this.buildRecordingAttachment(call, recording, {
+        entityType: AttachmentEntityType.CHAT,
+        entityId: message.messageId,
+        conversationId: headMessage.conversationId,
+        workspaceId,
+        url: recording.storagePath!,
+        size: fileSize,
+      }),
+    );
 
     await repositories.conversations.incrementReplyCount(headMessage.conversationId);
     logger.info(`[CallRecording] Posted recording message ${message.messageId} + attachment for recording ${recording.id}`);
+  }
+
+  /**
+   * Note-taker recordings have no thread message, so their attachment belongs to the
+   * recording itself and lets the player stream the file. Best-effort and retry-safe.
+   */
+  private async attachNoteTakerRecording(
+    call: Call,
+    recording: CallRecording,
+    storagePath: string,
+    size: number,
+  ): Promise<void> {
+    try {
+      const [existing] = await repositories.messageAttachments.findByEntityIdAndType(
+        recording.id,
+        AttachmentEntityType.RECORDING,
+      );
+      const attachment =
+        existing ??
+        (await repositories.messageAttachments.create(
+          this.buildRecordingAttachment(call, recording, {
+            entityType: AttachmentEntityType.RECORDING,
+            entityId: recording.id,
+            conversationId: null,
+            workspaceId: recording.workspaceId,
+            url: storagePath,
+            size,
+          }),
+        ));
+
+      if (recording.attachmentId !== attachment.id) {
+        await repositories.callRecordings.setAttachmentId(recording.id, attachment.id);
+      }
+    } catch (err) {
+      logger.error(`[CallRecording] Failed to attach note-taker recording ${recording.id}:`, err);
+    }
+  }
+
+  private buildRecordingAttachment(
+    call: Call,
+    recording: CallRecording,
+    target: RecordingAttachmentTarget,
+  ): CreateMessageAttachmentInput {
+    const recordingName = recording.name?.trim() || 'Recording';
+    const uploader = recording.startedBy ?? call.createdByUserId;
+
+    return {
+      ...target,
+      originalFilename: call.title ? `${call.title} - ${recordingName}.mp4` : `${recordingName}.mp4`,
+      mimetype: recordingMimetype(recording.recordingType),
+      uploadedByUserId: uploader,
+      createdBy: uploader,
+      storageProvider: config.fileStorage.provider,
+      metadata: { callId: call.externalId, recordingId: recording.id, type: 'recording' },
+    };
   }
 
   /**
@@ -502,6 +556,8 @@ class CallRecordingService {
     if (recording.segmentPrefix) {
       await this.deleteSegments(recording.segmentPrefix);
     }
+    await repositories.messageAttachments.deleteByRecordingIds([recording.id]).catch((err) =>
+      logger.warn(`[CallRecording] Could not delete attachment for recording ${recording.id}: ${err}`));
     if (recording.messageId) {
       try {
         await repositories.messageAttachments.deleteByMessageId(recording.messageId);
@@ -582,6 +638,7 @@ class CallRecordingService {
               await this.storageService.deleteFile(recording.storagePath);
             }
             await repositories.callRecordings.markExpired(recording.id);
+            await repositories.messageAttachments.deleteByRecordingIds([recording.id]);
             if (recording.messageId) {
               await repositories.messageAttachments.deleteByMessageId(recording.messageId);
               await repositories.messages.update(recording.messageId, {

--- a/apps/backend/src/services/callShareService.ts
+++ b/apps/backend/src/services/callShareService.ts
@@ -44,6 +44,12 @@ export class CallShareService {
       userId,
     });
   }
+
+  /** Who may play or download a call's recording files. */
+  async canViewRecordings(call: Call, userId: string): Promise<boolean> {
+    if (isRecording(call) && (await this.canView(call, userId, call.workspaceId))) return true;
+    return this.isCallAudience(call, userId);
+  }
 }
 
 export const callShareService = new CallShareService();

--- a/apps/backend/src/utils/callTypeUtils.ts
+++ b/apps/backend/src/utils/callTypeUtils.ts
@@ -1,4 +1,4 @@
-import { CallType } from '@xyne/shared';
+import { CallType, RecordingType } from '@xyne/shared';
 
 /**
  * Calls and recordings share the `Call` table and are told apart only by
@@ -17,4 +17,8 @@ export function isRecording(call: CallTypeCarrier | null | undefined): boolean {
 
 export function callSubject(call: CallTypeCarrier | null | undefined): 'recording' | 'call' {
   return isRecording(call) ? 'recording' : 'call';
+}
+
+export function isRecordingType(value: unknown): value is RecordingType {
+  return Object.values(RecordingType).includes(value as RecordingType);
 }

--- a/apps/dashboard/src/components/Call/CallViews/CustomLiveKitRoom.tsx
+++ b/apps/dashboard/src/components/Call/CallViews/CustomLiveKitRoom.tsx
@@ -30,8 +30,6 @@ import {
 import { useAFKDetection } from '../hooks/useAFKDetection';
 import { useUsers } from '../../../hooks/useUsers';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
-import { useScreenPickerFlag } from '../../ScreenPicker/useScreenPickerFlag';
-import { ScreenPickerModal } from '../../ScreenPicker/ScreenPickerModal';
 import { mutators } from '../../../zero/mutators';
 import { playAudio } from '../../../utils/audioPlayer';
 
@@ -64,8 +62,6 @@ export function CustomLiveKitRoom({
   externalId,
   zero,
 }: CustomLiveKitRoomProps): React.ReactElement {
-  // Sync custom screen picker on/off from CAC — only active while in a call
-  useScreenPickerFlag();
   const isSavingWhiteboardRef = useRef(false);
 
   // Subscribe to room state from global XState machine using a single snapshot
@@ -606,7 +602,6 @@ export function CustomLiveKitRoom({
             onTicketCreated={handleTicketCreated}
           />
         )}
-        <ScreenPickerModal />
       </>
     );
   }
@@ -703,7 +698,6 @@ export function CustomLiveKitRoom({
           onTicketCreated={handleTicketCreated}
         />
       )}
-      <ScreenPickerModal />
     </>
   );
 }

--- a/apps/dashboard/src/components/FileViewer/VideoViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/VideoViewer.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback, useImperativeHandle } from 'react';
 import { Play, Pause, Volume2, VolumeX, Maximize2, Minimize2, Settings } from 'lucide-react';
 import { BaseViewerProps } from './utils';
-import { BASE_URL, apiInstance } from '../../services/clients/apiClient';
+import { apiInstance, getAttachmentStreamUrl } from '../../services/clients/apiClient';
 import { useScope, useShortcutById } from '../../shortcuts';
 import { usePlatform } from '../../hooks/usePlatform';
 import { useMobileZoom } from '../../hooks/useMobileZoom';
@@ -23,6 +23,8 @@ interface VideoViewerProps extends BaseViewerProps {
   menuContent?: React.ReactNode;
   initialTime?: number;
   autoPlay?: boolean;
+  /** Immersive mode renders at the video's natural size; this scales it up to fill the viewer. */
+  fillContainer?: boolean;
 }
 
 const VideoViewer = React.forwardRef<HTMLVideoElement, VideoViewerProps>(
@@ -36,6 +38,7 @@ const VideoViewer = React.forwardRef<HTMLVideoElement, VideoViewerProps>(
       menuContent,
       initialTime,
       autoPlay = false,
+      fillContainer = false,
       disableGestures,
       onInteractionStateChange,
     },
@@ -77,7 +80,7 @@ const VideoViewer = React.forwardRef<HTMLVideoElement, VideoViewerProps>(
     const streamUrl = React.useMemo((): string => {
       if (attachmentId) {
         // Use the streaming endpoint for range request support
-        return `${BASE_URL}/attachments/${attachmentId}/stream`;
+        return getAttachmentStreamUrl(attachmentId);
       }
       // Fallback: create object URL from File
       if (source instanceof File) {
@@ -564,7 +567,10 @@ const VideoViewer = React.forwardRef<HTMLVideoElement, VideoViewerProps>(
           crossOrigin='use-credentials'
           className={cn(
             isImmersiveMode
-              ? 'relative z-10 max-h-full max-w-full h-auto w-auto'
+              ? cn(
+                  'relative z-10',
+                  fillContainer ? 'h-full w-full' : 'max-h-full max-w-full h-auto w-auto',
+                )
               : width && height
                 ? 'w-full h-full'
                 : 'max-w-full max-h-full',

--- a/apps/dashboard/src/components/Recording/RecordingCameraBubble/RecordingCameraBubble.tsx
+++ b/apps/dashboard/src/components/Recording/RecordingCameraBubble/RecordingCameraBubble.tsx
@@ -1,0 +1,134 @@
+/**
+ * RecordingCameraBubble - Floating preview of the recording's camera, shown on every page.
+ * Drag it anywhere, or maximize it to full screen (Esc exits).
+ */
+
+import { useEffect, useRef, useState, type ReactElement, type RefObject } from 'react';
+import { Track, type Room } from 'livekit-client';
+import { Maximize2, Minimize2 } from 'lucide-react';
+import { useRecordingStore } from '../../../hooks/useRecordingStore';
+import { useDraggableOverlay } from '../../../hooks/useDraggableOverlay';
+import { cn } from '../../../utils/classNames';
+
+const TILE_SIZE_PX = 200;
+const TILE_CLASS = 'touch-none rounded-2xl shadow-2xl ring-1 ring-foreground/10';
+const DEFAULT_POSITION_CLASS =
+  'bottom-[calc(85px+env(safe-area-inset-bottom))] left-4 min-[700px]:bottom-6 min-[700px]:left-6';
+const TRACK_CATEGORY = 'RecordingCameraBubble';
+
+const useLocalCameraPreview = (
+  room: Room | null,
+  enabled: boolean,
+): RefObject<HTMLVideoElement | null> => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    const track = room?.localParticipant.getTrackPublication(Track.Source.Camera)?.videoTrack;
+    if (!enabled || !video || !track) return;
+
+    track.attach(video);
+    return (): void => {
+      track.detach(video);
+    };
+  }, [room, enabled]);
+
+  return videoRef;
+};
+
+const useEscapeKey = (enabled: boolean, onEscape: () => void): void => {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') onEscape();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return (): void => document.removeEventListener('keydown', handleKeyDown);
+  }, [enabled, onEscape]);
+};
+
+export function RecordingCameraBubble(): ReactElement | null {
+  const room = useRecordingStore(context => context.room);
+  const status = useRecordingStore(context => context.status);
+  const isCameraEnabled = useRecordingStore(context => context.isCameraEnabled);
+  const [isMaximized, setIsMaximized] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { position, isDragging, hasDragged, handleMouseDown, handleTouchStart } =
+    useDraggableOverlay(containerRef, { x: 0, y: 0 });
+
+  const isPaused = status === 'paused';
+  const isVisible = !!room && isCameraEnabled && (status === 'recording' || isPaused);
+  const videoRef = useLocalCameraPreview(room, isVisible);
+
+  useEscapeKey(isMaximized, () => setIsMaximized(false));
+
+  useEffect(() => {
+    if (!isVisible) setIsMaximized(false);
+  }, [isVisible]);
+
+  if (!isVisible) return null;
+
+  const tileStyle = {
+    width: TILE_SIZE_PX,
+    height: TILE_SIZE_PX,
+    ...(hasDragged ? { left: position.x, bottom: position.y } : {}),
+  };
+
+  return (
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div
+      ref={containerRef}
+      onMouseDown={isMaximized ? undefined : handleMouseDown}
+      onTouchStart={isMaximized ? undefined : handleTouchStart}
+      style={isMaximized ? undefined : tileStyle}
+      className={cn(
+        'group fixed z-50 select-none overflow-hidden bg-black',
+        isMaximized && 'inset-0',
+        !isMaximized && TILE_CLASS,
+        !isMaximized && !hasDragged && DEFAULT_POSITION_CLASS,
+        !isMaximized && (isDragging ? 'cursor-grabbing' : 'cursor-grab'),
+      )}
+      title={isMaximized ? undefined : 'Camera preview — drag to move'}
+      data-testid='recording-camera-bubble'
+    >
+      <video
+        ref={videoRef}
+        muted
+        playsInline
+        autoPlay
+        className={cn('size-full -scale-x-100', isMaximized ? 'object-contain' : 'object-cover')}
+        aria-label='Camera preview'
+      >
+        <track kind='captions' />
+      </video>
+
+      {isPaused && (
+        <div className='pointer-events-none absolute inset-0 flex items-center justify-center bg-black/60 text-xs font-medium text-white'>
+          Paused
+        </div>
+      )}
+
+      <button
+        type='button'
+        onMouseDown={event => event.stopPropagation()}
+        onTouchStart={event => event.stopPropagation()}
+        onClick={() => setIsMaximized(maximized => !maximized)}
+        className={cn(
+          'absolute flex items-center justify-center rounded-lg bg-black/60 text-white backdrop-blur-sm transition-opacity hover:bg-black/80 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70',
+          isMaximized
+            ? 'right-4 top-4 size-10'
+            : 'right-2 top-2 size-7 min-[700px]:opacity-0 min-[700px]:group-hover:opacity-100',
+        )}
+        aria-label={isMaximized ? 'Exit full screen camera preview' : 'Full screen camera preview'}
+        title={isMaximized ? 'Exit full screen (Esc)' : 'Full screen'}
+        data-track-category={TRACK_CATEGORY}
+        data-track-name={isMaximized ? 'minimize_camera_bubble' : 'maximize_camera_bubble'}
+      >
+        {isMaximized ? <Minimize2 size={18} /> : <Maximize2 size={14} />}
+      </button>
+    </div>
+  );
+}
+
+export default RecordingCameraBubble;

--- a/apps/dashboard/src/components/ScreenPicker/ScreenPickerHost.tsx
+++ b/apps/dashboard/src/components/ScreenPicker/ScreenPickerHost.tsx
@@ -1,0 +1,12 @@
+import type { ReactElement } from 'react';
+import { ScreenPickerModal } from './ScreenPickerModal';
+import { useScreenPickerFlag } from './useScreenPickerFlag';
+
+/**
+ * Electron routes every getDisplayMedia request (calls and recordings) to this picker,
+ * so it is mounted once at the app root rather than inside a feature.
+ */
+export function ScreenPickerHost(): ReactElement {
+  useScreenPickerFlag();
+  return <ScreenPickerModal />;
+}

--- a/apps/dashboard/src/components/ui/AudioPlayer/useAudioPlayback.ts
+++ b/apps/dashboard/src/components/ui/AudioPlayer/useAudioPlayback.ts
@@ -5,6 +5,9 @@
  * detail bar, which mirrors the live control bar's layout — can drive the same audio
  * without duplicating the load/release logic.
  *
+ * With `src` (a range-capable stream URL) playback starts without downloading the file;
+ * if the stream can't play, it falls back to downloading it once through `onLoad`.
+ *
  *   idle → (toggle) → loading → playing ↔ paused
  *                            → idle (on error / ended)
  */
@@ -16,6 +19,7 @@ export type AudioPlayState = 'idle' | 'loading' | 'playing' | 'paused';
 
 export interface UseAudioPlaybackOptions {
   onLoad: (signal: AbortSignal) => Promise<Blob>;
+  src?: string | undefined;
   initialDurationSec?: number | undefined;
   showToastOnError?: boolean;
 }
@@ -31,8 +35,11 @@ export interface UseAudioPlaybackReturn {
   setPlaybackRate: (rate: number) => void;
 }
 
+const isAbortError = (err: unknown): boolean => err instanceof Error && err.name === 'AbortError';
+
 export function useAudioPlayback({
   onLoad,
+  src,
   initialDurationSec = 0,
   showToastOnError = false,
 }: UseAudioPlaybackOptions): UseAudioPlaybackReturn {
@@ -43,6 +50,7 @@ export function useAudioPlayback({
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const blobUrlRef = useRef<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const streamFailedRef = useRef(false);
 
   // Releases the current Audio element: stops playback, detaches the media
   // resource (removeAttribute('src')+load() frees the decoder and makes the
@@ -70,6 +78,56 @@ export function useAudioPlayback({
     return (): void => releaseRef.current();
   }, []);
 
+  const startAudio = async (url: string, isStream: boolean): Promise<void> => {
+    const audio = new Audio();
+    // Must be set before src so the credentialed range requests pass CORS.
+    if (isStream) audio.crossOrigin = 'use-credentials';
+    audio.src = url;
+    audio.playbackRate = playbackRate;
+    audioRef.current = audio;
+
+    let hasStarted = false;
+    audio.addEventListener('loadedmetadata', () => {
+      if (isFinite(audio.duration)) setDuration(audio.duration);
+    });
+    audio.addEventListener('timeupdate', () => setCurrentTime(audio.currentTime));
+    audio.addEventListener('playing', () => {
+      hasStarted = true;
+      setState('playing');
+    });
+    audio.addEventListener('pause', () => {
+      if (!audio.ended) setState('paused');
+    });
+    audio.addEventListener('ended', () => {
+      setState('idle');
+      setCurrentTime(0);
+    });
+    audio.addEventListener('error', () => {
+      if (hasStarted) setState('idle');
+    });
+
+    await audio.play();
+  };
+
+  const loadAndPlay = async (): Promise<void> => {
+    if (src && !streamFailedRef.current) {
+      try {
+        await startAudio(src, true);
+        return;
+      } catch (err: unknown) {
+        if (isAbortError(err)) throw err;
+        streamFailedRef.current = true;
+        releaseAudio();
+      }
+    }
+
+    abortRef.current = new AbortController();
+    const blob = await onLoad(abortRef.current.signal);
+    const url = URL.createObjectURL(blob);
+    blobUrlRef.current = url;
+    await startAudio(url, false);
+  };
+
   const toggle = async (): Promise<void> => {
     if (state === 'playing') {
       audioRef.current?.pause();
@@ -86,31 +144,9 @@ export function useAudioPlayback({
     setState('loading');
     releaseAudio(); // free the previous element + blob before creating new ones
     try {
-      abortRef.current = new AbortController();
-      const blob = await onLoad(abortRef.current.signal);
-      const url = URL.createObjectURL(blob);
-      blobUrlRef.current = url;
-
-      const audio = new Audio(url);
-      audio.playbackRate = playbackRate;
-      audioRef.current = audio;
-
-      audio.addEventListener('loadedmetadata', () => {
-        if (isFinite(audio.duration)) setDuration(audio.duration);
-      });
-      audio.addEventListener('timeupdate', () => setCurrentTime(audio.currentTime));
-      audio.addEventListener('playing', () => setState('playing'));
-      audio.addEventListener('pause', () => {
-        if (!audio.ended) setState('paused');
-      });
-      audio.addEventListener('ended', () => {
-        setState('idle');
-        setCurrentTime(0);
-      });
-
-      await audio.play();
+      await loadAndPlay();
     } catch (err: unknown) {
-      if (err instanceof Error && err.name === 'AbortError') return;
+      if (isAbortError(err)) return;
       setState('idle');
       if (showToastOnError) toast.error('Failed to load recording');
     }

--- a/apps/dashboard/src/components/ui/MessageBubble/InlineVideoPreview.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/InlineVideoPreview.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BASE_URL } from '../../../services/clients/apiClient';
+import { getAttachmentStreamUrl } from '../../../services/clients/apiClient';
 import { recordingService } from '../../../services/Recording/recordingService';
 
 interface InlineVideoPreviewProps {
@@ -29,8 +29,7 @@ export function InlineVideoPreview({
   // endpoint can serve the file: playback starts on the first chunk and seeking
   // works, instead of waiting for the whole recording to download. If that
   // request fails the effect below falls back to the blob download.
-  const streamUrl =
-    attachmentId && !streamFailed ? `${BASE_URL}/attachments/${attachmentId}/stream` : null;
+  const streamUrl = attachmentId && !streamFailed ? getAttachmentStreamUrl(attachmentId) : null;
 
   React.useEffect(() => {
     // Streaming path needs no blob — skip the download entirely.

--- a/apps/dashboard/src/hooks/useRecordingStore.ts
+++ b/apps/dashboard/src/hooks/useRecordingStore.ts
@@ -6,6 +6,14 @@ import { recordingStore as _rawStore } from '../stores/recordingStore';
 import { calculateRecordingElapsedMs } from '../utils/recordingUtils';
 import { formatDuration } from '../utils/dateUtils';
 import { setWorkspaceSwitchToast } from '../utils/workspaceSwitchToast';
+import { Track } from 'livekit-client';
+import { toast } from 'sonner';
+import { logger, Event } from '../utils/logger';
+import {
+  isLocalVideoEnabled,
+  toggleLocalVideo,
+  type RecordingVideoSource,
+} from '../utils/recordingMedia';
 
 interface RecordingStoreSnapshot {
   status: 'active' | 'done' | 'error' | 'stopped';
@@ -36,6 +44,7 @@ export type RecordingStoreEvent =
     }
   | { type: 'pauseRecording' }
   | { type: 'resumeRecording' }
+  | { type: 'syncLocalMedia'; room: unknown }
   | { type: 'stopRecording'; silent?: boolean }
   | { type: 'setStatus'; status: RecordingState['status'] }
   | { type: 'error'; error: string }
@@ -120,6 +129,59 @@ export function stopRecordingForNavigation(): void {
     description: `Recording saved (${durationMs ? formatDuration(durationMs) : 'Unknown duration'})`,
   });
   stopRecordingForTeardown({ silent: true });
+}
+
+async function toggleRecordingVideo(source: RecordingVideoSource): Promise<void> {
+  const { room, status } = store.getSnapshot().context;
+  if (!room || status !== 'recording') return;
+
+  const isCamera = source === Track.Source.Camera;
+  const wasEnabled = isLocalVideoEnabled(room, source);
+
+  try {
+    await toggleLocalVideo(room, source);
+  } catch (error) {
+    logger.error(Event.RECORDING_ERROR, {
+      error: `${isCamera ? 'Camera' : 'Screen share'} toggle failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    });
+    // Dismissing the screen picker also rejects, so only camera failures are surfaced.
+    if (isCamera && !wasEnabled) {
+      toast.error('Could not turn on camera', {
+        description: 'Please check your camera permission and try again',
+      });
+    }
+  } finally {
+    store.send({ type: 'syncLocalMedia', room });
+  }
+}
+
+export function toggleRecordingCamera(): void {
+  void toggleRecordingVideo(Track.Source.Camera);
+}
+
+export function toggleRecordingScreenShare(): void {
+  void toggleRecordingVideo(Track.Source.ScreenShare);
+}
+
+export interface RecordingVideoControls {
+  isCameraEnabled: boolean;
+  isScreenShareEnabled: boolean;
+  onToggleCamera: () => void;
+  onToggleScreenShare: () => void;
+}
+
+export function useRecordingVideoControls(): RecordingVideoControls {
+  const isCameraEnabled = useRecordingStore(ctx => ctx.isCameraEnabled);
+  const isScreenShareEnabled = useRecordingStore(ctx => ctx.isScreenShareEnabled);
+
+  return {
+    isCameraEnabled,
+    isScreenShareEnabled,
+    onToggleCamera: toggleRecordingCamera,
+    onToggleScreenShare: toggleRecordingScreenShare,
+  };
 }
 
 export interface UseTranscriptStreamReturn {

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -131,6 +131,8 @@ import CallDetailScreen from './CallDetailScreen/CallDetailScreen';
 import RecordingsRoute from './RecordingsRoute/RecordingsRoute';
 import RecordingDetailRoute from './RecordingDetailRoute/RecordingDetailRoute';
 import { RecordingOverlay } from '../components/Recording/RecordingOverlay/RecordingOverlay';
+import { RecordingCameraBubble } from '../components/Recording/RecordingCameraBubble/RecordingCameraBubble';
+import { ScreenPickerHost } from '../components/ScreenPicker/ScreenPickerHost';
 import { useRecordingVersion } from '../hooks/useRecordingVersion';
 import { stopRecordingForTeardown } from '../hooks/useRecordingStore';
 import { isElectronApp } from '../utils/electronApp';
@@ -972,6 +974,8 @@ const AppRoot = (): ReactElement => {
                           ) : (
                             <RecordingOverlay />
                           )}
+                          <RecordingCameraBubble />
+                          <ScreenPickerHost />
                           <GlobalUploadProgress />
                           <NotificationHandler />
                           <ElectronBadgeSync />

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -633,6 +633,8 @@ export default function RecordingDetailV2Screen(): ReactElement {
               ? {
                   ...current,
                   hasRecording: !!fresh.hasRecording,
+                  recordingType: fresh.recordingType ?? current.recordingType ?? null,
+                  attachmentId: fresh.attachmentId ?? current.attachmentId ?? null,
                   durationMs: fresh.durationMs ?? current.durationMs,
                 }
               : current,

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/LiveRecordingControlBar.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/LiveRecordingControlBar.tsx
@@ -29,6 +29,10 @@ import { useAudioPlayback } from '../../../components/ui/AudioPlayer/useAudioPla
 import type { RecordingDetail } from '../../../services/Recording/recordingService';
 import type { MarkedMoment } from '../../../stores/recordingStore';
 import { parseMarkedItems, type MarkedItem, type MarkedItemType } from './markedItems';
+import { isVideoRecordingType } from '../../../utils/recordingMedia';
+import { getAttachmentStreamUrl } from '../../../services/clients/apiClient';
+import { useRecordingVideo } from '../useRecordingVideo';
+import { InlineRecordingVideo, RecordingVideoDialog, RecordingVideoToggle } from './RecordingVideo';
 
 const TIMELINE_WINDOW_MS = 40 * 60 * 1000; // 40 min fixed window for the live timeline
 
@@ -385,12 +389,23 @@ const RecordedTimelineBar = ({
       ? new Date(recording.endedAt).getTime() - new Date(recording.startedAt).getTime()
       : null);
 
+  const title = recording.title ?? 'Recording';
+  const streamAttachmentId = onLoadAudio ? (recording.attachmentId ?? null) : null;
+
   const playback = useAudioPlayback({
     onLoad: onLoadAudio ?? EMPTY_AUDIO_LOADER,
+    src: streamAttachmentId ? getAttachmentStreamUrl(streamAttachmentId) : undefined,
     initialDurationSec: fallbackDurationMs ? fallbackDurationMs / 1000 : undefined,
     showToastOnError: true,
   });
   const shouldReduceMotion = useReducedMotion();
+  const video = useRecordingVideo({
+    isAvailable: !!onLoadAudio && isVideoRecordingType(recording.recordingType),
+    title,
+    attachmentId: streamAttachmentId,
+    onLoad: onLoadAudio,
+    playback,
+  });
 
   // Prefer the media's own duration once it has loaded — the call's wall-clock span
   // can differ from the recorded audio by a second or two. It can also be unknown for
@@ -408,17 +423,19 @@ const RecordedTimelineBar = ({
   // load, the recording simply has no playable audio (e.g. older recordings) — show
   // an alert-triangle instead of a spinner that would otherwise never resolve.
   const showAudioUnavailable = !onLoadAudio && !isStitching && isAudioUnavailable;
-  const audioControlLabel = isStitching
-    ? 'Preparing audio'
-    : showAudioUnavailable
-      ? 'Recording is not available for playback.'
-      : !onLoadAudio
-        ? 'Audio is unavailable for this recording'
-        : playback.state === 'loading'
-          ? 'Loading audio'
-          : isPlaying
-            ? 'Pause recording'
-            : 'Play recording';
+  const audioControlLabel = video.isOpen
+    ? 'Playing in the video player'
+    : isStitching
+      ? 'Preparing audio'
+      : showAudioUnavailable
+        ? 'Recording is not available for playback.'
+        : !onLoadAudio
+          ? 'Audio is unavailable for this recording'
+          : playback.state === 'loading'
+            ? 'Loading audio'
+            : isPlaying
+              ? 'Pause recording'
+              : 'Play recording';
   const audioIconKey = isAudioBusy
     ? 'loading'
     : showAudioUnavailable
@@ -428,9 +445,11 @@ const RecordedTimelineBar = ({
         : 'play';
 
   const selectMarker =
-    playback.canSeek || onMarkerSelect
+    playback.canSeek || onMarkerSelect || video.isOpen
       ? (item: MarkedItem): void => {
-          if (playback.canSeek) playback.seek(item.timestampSeconds);
+          if (!video.seek(item.timestampSeconds) && playback.canSeek) {
+            playback.seek(item.timestampSeconds);
+          }
           onMarkerSelect?.(item);
         }
       : null;
@@ -449,7 +468,7 @@ const RecordedTimelineBar = ({
         variant='outline'
         size='icon'
         onClick={() => void playback.toggle()}
-        disabled={!onLoadAudio || playback.state === 'loading'}
+        disabled={!onLoadAudio || playback.state === 'loading' || video.isOpen}
         aria-busy={isAudioBusy}
         className='size-8 rounded-full border-border bg-card text-muted-foreground hover:text-foreground'
         aria-label={audioControlLabel}
@@ -483,6 +502,16 @@ const RecordedTimelineBar = ({
 
   return (
     <div className='mb-6 rounded-2xl border border-border bg-card px-5 py-4'>
+      {video.isOpen && (
+        <InlineRecordingVideo
+          ref={video.inlineRef}
+          video={video.source}
+          title={title}
+          initialTime={video.inlineStartSec}
+          onExpand={video.openDialog}
+        />
+      )}
+
       <div className='flex min-h-11 items-center gap-4'>
         {showAudioUnavailable ? (
           <Tooltip content='Recording is not available for playback.'>{playButton}</Tooltip>
@@ -554,12 +583,25 @@ const RecordedTimelineBar = ({
           {formatElapsedTime(durationMs)}
         </span>
 
+        {video.isAvailable && (
+          <RecordingVideoToggle isOpen={video.isOpen} onToggle={video.toggle} />
+        )}
+
         <RecordingVisualizer
           isAnimated={false}
           className='h-7 w-14 justify-center rounded-lg border border-border px-2'
           {...(onOpenTranscript ? { onClick: onOpenTranscript } : {})}
         />
       </div>
+
+      {video.dialogStartSec !== null && video.source.status === 'ready' && (
+        <RecordingVideoDialog
+          title={title}
+          video={video.source}
+          initialTime={video.dialogStartSec}
+          onClose={video.closeDialog}
+        />
+      )}
 
       {/* Legend only when there's something to explain; speed only once audio can load. */}
       {(markedTypes.size > 0 || onLoadAudio) && (

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingVideo.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingVideo.tsx
@@ -1,0 +1,143 @@
+import { forwardRef, useRef, type ReactElement } from 'react';
+import { AlertTriangle, Spinner } from '@xyne/icons';
+import { Video, VideoOff } from 'lucide-react';
+import { Button } from '../../../components/ui/Button/Button';
+import { Dialog } from '../../../components/ui/Dialog';
+import VideoViewer from '../../../components/FileViewer/VideoViewer';
+import useMeasure from '../../../hooks/useMeasure';
+import type { ReadyRecordingVideoSource, RecordingVideoSource } from '../useRecordingVideo';
+
+interface ViewerSourceProps {
+  source: File | null;
+  attachmentId?: string;
+  fileName: string;
+}
+
+/** A stream plays straight from the attachment endpoint; a file plays from memory. */
+const getViewerSourceProps = (
+  video: ReadyRecordingVideoSource,
+  title: string,
+): ViewerSourceProps =>
+  video.kind === 'stream'
+    ? { source: null, attachmentId: video.attachmentId, fileName: `${title}.mp4` }
+    : { source: video.file, fileName: video.file.name };
+
+const VideoStatus = ({ failed }: { failed: boolean }): ReactElement => (
+  <div className='flex h-full items-center justify-center gap-2 text-sm text-white/70'>
+    {failed ? (
+      <>
+        <AlertTriangle size={16} />
+        <span>Could not load the video for this recording.</span>
+      </>
+    ) : (
+      <>
+        <Spinner size={16} className='animate-spin' />
+        <span>Loading video…</span>
+      </>
+    )}
+  </div>
+);
+
+interface RecordingVideoToggleProps {
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+export const RecordingVideoToggle = ({
+  isOpen,
+  onToggle,
+}: RecordingVideoToggleProps): ReactElement => {
+  const label = isOpen ? 'Hide video' : 'Show video';
+
+  return (
+    <Button
+      type='button'
+      variant='outline'
+      size='icon'
+      onClick={onToggle}
+      className='size-8 shrink-0 rounded-full border-border bg-card text-muted-foreground hover:text-foreground'
+      aria-label={label}
+      aria-pressed={isOpen}
+      title={label}
+      data-track-category='RecordingDetailV2'
+      data-track-name={isOpen ? 'hide_recording_video' : 'show_recording_video'}
+    >
+      {isOpen ? <VideoOff size={14} /> : <Video size={14} />}
+    </Button>
+  );
+};
+
+interface InlineRecordingVideoProps {
+  video: RecordingVideoSource;
+  title: string;
+  initialTime: number;
+  onExpand: () => void;
+}
+
+/** Explicit width/height keep VideoViewer in inline mode, where expand calls `onExpand`. */
+export const InlineRecordingVideo = forwardRef<HTMLVideoElement, InlineRecordingVideoProps>(
+  ({ video, title, initialTime, onExpand }, ref) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const { width, height } = useMeasure({ ref: containerRef, observeResize: true });
+    const hasSize = width > 0 && height > 0;
+
+    return (
+      <div
+        ref={containerRef}
+        className='mb-4 aspect-video max-h-[420px] w-full overflow-hidden rounded-xl bg-black'
+      >
+        {video.status === 'ready' && hasSize ? (
+          <VideoViewer
+            ref={ref}
+            {...getViewerSourceProps(video, title)}
+            width={Math.floor(width)}
+            height={Math.floor(height)}
+            initialTime={initialTime}
+            autoPlay
+            onExpand={onExpand}
+          />
+        ) : (
+          <VideoStatus failed={video.status === 'failed'} />
+        )}
+      </div>
+    );
+  },
+);
+InlineRecordingVideo.displayName = 'InlineRecordingVideo';
+
+interface RecordingVideoDialogProps {
+  title: string;
+  video: ReadyRecordingVideoSource;
+  initialTime: number;
+  onClose: (currentTime: number) => void;
+}
+
+export const RecordingVideoDialog = ({
+  title,
+  video,
+  initialTime,
+  onClose,
+}: RecordingVideoDialogProps): ReactElement => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const close = (): void => onClose(videoRef.current?.currentTime ?? initialTime);
+
+  return (
+    <Dialog
+      open
+      onOpenChange={open => !open && close()}
+      title={title}
+      mobileVariant='dialog'
+      className='aspect-video w-[min(95vw,calc(90vh*16/9))] max-w-none overflow-hidden rounded-2xl bg-black p-0'
+      testId='recording-video-dialog'
+    >
+      <VideoViewer
+        ref={videoRef}
+        {...getViewerSourceProps(video, title)}
+        initialTime={initialTime}
+        autoPlay
+        fillContainer
+        onExpand={close}
+      />
+    </Dialog>
+  );
+};

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/useRecordingVideo.ts
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/useRecordingVideo.ts
@@ -1,0 +1,134 @@
+import { useEffect, useRef, useState, type RefObject } from 'react';
+import type { UseAudioPlaybackReturn } from '../../components/ui/AudioPlayer/useAudioPlayback';
+
+export type RecordingVideoSource =
+  | { status: 'loading' }
+  | { status: 'ready'; kind: 'stream'; attachmentId: string }
+  | { status: 'ready'; kind: 'file'; file: File }
+  | { status: 'failed' };
+
+export type ReadyRecordingVideoSource = Extract<RecordingVideoSource, { status: 'ready' }>;
+
+type RecordingLoader = (signal: AbortSignal) => Promise<Blob>;
+
+interface UseRecordingVideoOptions {
+  isAvailable: boolean;
+  title: string;
+  /** Streams the recording when set; otherwise it is downloaded with `onLoad`. */
+  attachmentId: string | null;
+  onLoad: RecordingLoader | undefined;
+  playback: UseAudioPlaybackReturn;
+}
+
+export interface RecordingVideo {
+  isAvailable: boolean;
+  isOpen: boolean;
+  source: RecordingVideoSource;
+  inlineRef: RefObject<HTMLVideoElement | null>;
+  inlineStartSec: number;
+  dialogStartSec: number | null;
+  toggle: () => void;
+  openDialog: () => void;
+  closeDialog: (currentTime: number) => void;
+  /** Seeks the shown video; returns false when there is none, so the audio should seek. */
+  seek: (seconds: number) => boolean;
+}
+
+/** Downloads the recording once, the first time `enabled` is true, and keeps it. */
+const useDownloadedVideo = (
+  onLoad: RecordingLoader | undefined,
+  enabled: boolean,
+  title: string,
+): RecordingVideoSource => {
+  const [video, setVideo] = useState<RecordingVideoSource>({ status: 'loading' });
+  // The loader is recreated on every parent render; read the latest without re-downloading.
+  const latest = useRef({ onLoad, title });
+  useEffect(() => {
+    latest.current = { onLoad, title };
+  });
+
+  const hasFile = video.status === 'ready';
+
+  useEffect(() => {
+    const { onLoad: load, title: name } = latest.current;
+    if (!enabled || hasFile || !load) return;
+
+    const controller = new AbortController();
+    setVideo({ status: 'loading' });
+    load(controller.signal)
+      .then(blob => {
+        const file = new File([blob], `${name}.mp4`, { type: blob.type || 'video/mp4' });
+        setVideo({ status: 'ready', kind: 'file', file });
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setVideo({ status: 'failed' });
+      });
+
+    return (): void => controller.abort();
+  }, [enabled, hasFile]);
+
+  return video;
+};
+
+/** Hands playback between the timeline audio, the inline video and the expanded dialog. */
+export const useRecordingVideo = ({
+  isAvailable,
+  title,
+  attachmentId,
+  onLoad,
+  playback,
+}: UseRecordingVideoOptions): RecordingVideo => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [inlineStartSec, setInlineStartSec] = useState(0);
+  const [dialogStartSec, setDialogStartSec] = useState<number | null>(null);
+  const inlineRef = useRef<HTMLVideoElement>(null);
+  const isShown = isAvailable && isOpen;
+  const downloaded = useDownloadedVideo(onLoad, isShown && !attachmentId, title);
+  const source: RecordingVideoSource = attachmentId
+    ? { status: 'ready', kind: 'stream', attachmentId }
+    : downloaded;
+
+  const toggle = (): void => {
+    if (isOpen) {
+      const time = inlineRef.current?.currentTime;
+      if (time !== undefined && playback.canSeek) playback.seek(time);
+      setIsOpen(false);
+      return;
+    }
+
+    if (playback.state === 'playing') void playback.toggle();
+    setInlineStartSec(playback.currentTime);
+    setIsOpen(true);
+  };
+
+  const openDialog = (): void => {
+    const video = inlineRef.current;
+    video?.pause();
+    setDialogStartSec(video?.currentTime ?? inlineStartSec);
+  };
+
+  const closeDialog = (currentTime: number): void => {
+    setDialogStartSec(null);
+    if (inlineRef.current) inlineRef.current.currentTime = currentTime;
+  };
+
+  const seek = (seconds: number): boolean => {
+    const video = isShown ? inlineRef.current : null;
+    if (!video) return false;
+    video.currentTime = seconds;
+    return true;
+  };
+
+  return {
+    isAvailable,
+    isOpen: isShown,
+    source,
+    inlineRef,
+    inlineStartSec,
+    dialogStartSec,
+    toggle,
+    openDialog,
+    closeDialog,
+    seek,
+  };
+};

--- a/apps/dashboard/src/routes/RecordingsScreen/RecordingsScreen.tsx
+++ b/apps/dashboard/src/routes/RecordingsScreen/RecordingsScreen.tsx
@@ -23,6 +23,7 @@ import { ConnectionState } from 'livekit-client';
 import { formatDistanceToNow } from 'date-fns';
 import {
   useRecordingStore,
+  useRecordingVideoControls,
   sendRecordingEvent,
   useTranscriptStream,
 } from '../../hooks/useRecordingStore';
@@ -163,6 +164,7 @@ export default function RecordingsScreen(): ReactElement {
   const room = useRecordingStore(ctx => ctx.room);
   const activeLayout = useRecordingStore(ctx => ctx.activeLayout);
   const isTranscriptMinimized = useRecordingStore(ctx => ctx.isTranscriptMinimized);
+  const videoControls = useRecordingVideoControls();
 
   const [isCreatingCanvas, setIsCreatingCanvas] = useState(false);
   const [canvasCreationFailed, setCanvasCreationFailed] = useState(false);
@@ -593,7 +595,7 @@ export default function RecordingsScreen(): ReactElement {
                 </div>
               </div>
               <p className='text-sm text-muted-foreground '>
-                Your audio recordings with automatic transcription
+                Your screen and audio recordings with automatic transcription
               </p>
             </div>
 
@@ -907,6 +909,7 @@ export default function RecordingsScreen(): ReactElement {
         onStop={handleStopRecording}
         onPause={handlePauseRecording}
         onResume={handleResumeRecording}
+        {...videoControls}
       />
 
       {/* ─── Save Title Modal (after stopping) ───── */}

--- a/apps/dashboard/src/routes/RecordingsScreen/components/RecordingControlBar.tsx
+++ b/apps/dashboard/src/routes/RecordingsScreen/components/RecordingControlBar.tsx
@@ -4,10 +4,22 @@
  */
 
 import { ReactElement, useEffect, useState, useRef } from 'react';
-import { Loader2, Pause, Play } from 'lucide-react';
+import {
+  Loader2,
+  Monitor,
+  MonitorOff,
+  Pause,
+  Play,
+  Video,
+  VideoOff,
+  type LucideIcon,
+} from 'lucide-react';
 import { calculateRecordingElapsedMs, formatElapsedTime } from '../../../utils/recordingUtils';
+import { canShareScreen } from '../../../utils/recordingMedia';
+import { cn } from '../../../utils/classNames';
 import { Waveform } from '../../../utils/recordingWaveform';
 import { ShortcutTooltip } from '../../../components/ui/ShortcutTooltip';
+import type { RecordingVideoControls } from '../../../hooks/useRecordingStore';
 
 /**
  * Returns true when the dashboard is running inside a mobile browser or
@@ -31,7 +43,50 @@ function useMobileWebPadding(): boolean {
   return isMobileWeb;
 }
 
-interface RecordingControlBarProps {
+interface MediaToggleButtonProps {
+  isOn: boolean;
+  disabled: boolean;
+  onClick: () => void;
+  onLabel: string;
+  offLabel: string;
+  onIcon: LucideIcon;
+  offIcon: LucideIcon;
+  trackName: string;
+}
+
+function MediaToggleButton({
+  isOn,
+  disabled,
+  onClick,
+  onLabel,
+  offLabel,
+  onIcon,
+  offIcon,
+  trackName,
+}: MediaToggleButtonProps): ReactElement {
+  const Icon = isOn ? onIcon : offIcon;
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        'flex items-center justify-center w-10 h-10 rounded-full border border-border transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+        isOn
+          ? 'bg-foreground text-background hover:bg-foreground/85'
+          : 'bg-foreground/15 text-foreground hover:bg-foreground/25',
+      )}
+      title={isOn ? onLabel : offLabel}
+      aria-pressed={isOn}
+      data-track-category='RecordingControlBar'
+      data-track-name={`${trackName}_${isOn ? 'off' : 'on'}`}
+    >
+      <Icon className='w-5 h-5' />
+    </button>
+  );
+}
+
+interface RecordingControlBarProps extends RecordingVideoControls {
   isRecording: boolean;
   isPaused: boolean;
   isStarting: boolean;
@@ -51,10 +106,14 @@ export function RecordingControlBar({
   startTime,
   pauseStartedAt,
   accumulatedPausedMs,
+  isCameraEnabled,
+  isScreenShareEnabled,
   onStart,
   onStop,
   onPause,
   onResume,
+  onToggleCamera,
+  onToggleScreenShare,
 }: RecordingControlBarProps): ReactElement {
   const [elapsed, setElapsed] = useState(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -97,7 +156,7 @@ export function RecordingControlBar({
           </span>
         )}
 
-        {/* Pause/Resume and Stop buttons (visible when recording) */}
+        {/* Pause/Resume, camera, screen share and Stop buttons (visible when recording) */}
         {isRecording ? (
           <>
             <button
@@ -114,6 +173,30 @@ export function RecordingControlBar({
                 <Pause className='w-5 h-5 text-foreground' />
               )}
             </button>
+
+            <MediaToggleButton
+              isOn={isCameraEnabled}
+              disabled={isPaused}
+              onClick={onToggleCamera}
+              onLabel='Turn off camera'
+              offLabel='Turn on camera'
+              onIcon={Video}
+              offIcon={VideoOff}
+              trackName='camera'
+            />
+
+            {canShareScreen() && (
+              <MediaToggleButton
+                isOn={isScreenShareEnabled}
+                disabled={isPaused}
+                onClick={onToggleScreenShare}
+                onLabel='Stop sharing screen'
+                offLabel='Share screen'
+                onIcon={Monitor}
+                offIcon={MonitorOff}
+                trackName='screen_share'
+              />
+            )}
 
             <button
               onClick={onStop}

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/NoteTakerOverlay.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/NoteTakerOverlay.tsx
@@ -9,7 +9,7 @@ import {
   type TouchEvent as ReactTouchEvent,
 } from 'react';
 import { ChevronDown, Flag, PauseBig, PlayBig, Spinner, StopBig, CloudDisabled } from '@xyne/icons';
-import { Maximize2 } from 'lucide-react';
+import { Maximize2, Monitor, MonitorOff, Video, VideoOff, type LucideIcon } from 'lucide-react';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { useWorkspaceNavigate } from '../../../hooks/useWorkspaceNavigate';
 import { Button } from '../../../components/ui/Button/Button';
@@ -27,10 +27,12 @@ import {
   setLiveRecordingV2Tab,
 } from '../../../utils/recordingTabPreference';
 import { canvasService } from '../../../services/Canvas/canvasService';
+import type { RecordingVideoControls } from '../../../hooks/useRecordingStore';
+import { canShareScreen } from '../../../utils/recordingMedia';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
-interface NoteTakerOverlayProps {
+interface NoteTakerOverlayProps extends RecordingVideoControls {
   status: RecordingState['status'];
   startTime: number | null;
   pauseStartedAt: number | null;
@@ -63,7 +65,7 @@ interface RecordingPanelHeaderProps {
   onTitleUpdated?: ((title: string) => void) | undefined;
 }
 
-interface RecordingControlBarProps {
+interface RecordingControlBarProps extends RecordingVideoControls {
   recordingId: string | null;
   isPaused: boolean;
   markedCount: number;
@@ -71,6 +73,17 @@ interface RecordingControlBarProps {
   onResume: () => void;
   onStop: () => void;
   onMarkMoment: () => void;
+}
+
+interface MediaToggleButtonProps {
+  isOn: boolean;
+  disabled: boolean;
+  onClick: () => void;
+  onLabel: string;
+  offLabel: string;
+  onIcon: LucideIcon;
+  offIcon: LucideIcon;
+  trackName: string;
 }
 
 interface NotesTabProps {
@@ -306,6 +319,43 @@ const MarkMomentButton = ({
   );
 };
 
+const MediaToggleButton = ({
+  isOn,
+  disabled,
+  onClick,
+  onLabel,
+  offLabel,
+  onIcon,
+  offIcon,
+  trackName,
+}: MediaToggleButtonProps): ReactElement => {
+  const Icon = isOn ? onIcon : offIcon;
+  const label = isOn ? onLabel : offLabel;
+
+  return (
+    <Button
+      type='button'
+      variant='ghost'
+      size='iconSm'
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        'rounded-xl transition-colors',
+        isOn
+          ? 'bg-foreground text-background hover:bg-foreground/85 hover:text-background'
+          : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+      )}
+      aria-label={label}
+      aria-pressed={isOn}
+      title={label}
+      data-track-category={TRACK_CATEGORY}
+      data-track-name={`${trackName}_${isOn ? 'off' : 'on'}`}
+    >
+      <Icon size={17} />
+    </Button>
+  );
+};
+
 const RecordingControlBar = ({
   recordingId,
   isPaused,
@@ -314,6 +364,10 @@ const RecordingControlBar = ({
   onResume,
   onStop,
   onMarkMoment,
+  isCameraEnabled,
+  isScreenShareEnabled,
+  onToggleCamera,
+  onToggleScreenShare,
 }: RecordingControlBarProps): ReactElement => {
   const navigate = useWorkspaceNavigate();
 
@@ -343,6 +397,28 @@ const RecordingControlBar = ({
         <span>Full screen</span>
       </Button>
       <div className='flex flex-1 shrink-0 items-center justify-end gap-1.5'>
+        <MediaToggleButton
+          isOn={isCameraEnabled}
+          disabled={isPaused}
+          onClick={onToggleCamera}
+          onLabel='Turn off camera'
+          offLabel='Turn on camera'
+          onIcon={Video}
+          offIcon={VideoOff}
+          trackName='camera'
+        />
+        {canShareScreen() && (
+          <MediaToggleButton
+            isOn={isScreenShareEnabled}
+            disabled={isPaused}
+            onClick={onToggleScreenShare}
+            onLabel='Stop sharing screen'
+            offLabel='Share screen'
+            onIcon={Monitor}
+            offIcon={MonitorOff}
+            trackName='screen_share'
+          />
+        )}
         <MarkMomentButton markedCount={markedCount} onMarkMoment={onMarkMoment} />
         <Button
           type='button'
@@ -632,6 +708,7 @@ export function NoteTakerOverlay({
   onMinimize,
   onExpand,
   onTitleUpdated,
+  ...videoControls
 }: NoteTakerOverlayProps): ReactElement | null {
   const shouldReduceMotion = useReducedMotion();
 
@@ -869,6 +946,7 @@ export function NoteTakerOverlay({
               onResume={onResume}
               onStop={onStop}
               onMarkMoment={onMarkMoment}
+              {...videoControls}
             />
           </div>
         </section>

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/NoteTakerOverlayHost.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/NoteTakerOverlayHost.tsx
@@ -5,7 +5,11 @@ import { AnimatePresence } from 'framer-motion';
 import { toast } from 'sonner';
 import { refreshOatsRecordings } from '../../../hooks/usePaginatedOatsRecordings';
 import { useMarkMoment } from '../../../hooks/useMarkMoment';
-import { sendRecordingEvent, useRecordingStore } from '../../../hooks/useRecordingStore';
+import {
+  sendRecordingEvent,
+  useRecordingStore,
+  useRecordingVideoControls,
+} from '../../../hooks/useRecordingStore';
 import { recordingService } from '../../../services/Recording/recordingService';
 import { isElectronApp } from '../../../utils/electronApp';
 import {
@@ -29,6 +33,7 @@ export function NoteTakerOverlayHost(): ReactElement {
   const transcripts = useRecordingStore(context => context.transcripts);
   const markedMoments = useRecordingStore(context => context.markedMoments);
   const isMinimized = useRecordingStore(context => context.isTranscriptMinimized);
+  const videoControls = useRecordingVideoControls();
   const { markMoment } = useMarkMoment();
   const { showOfflineBanner } = useZeroOfflineState();
   const isActive = status === 'recording' || status === 'paused';
@@ -135,6 +140,7 @@ export function NoteTakerOverlayHost(): ReactElement {
             onPause={() => sendRecordingEvent({ type: 'pauseRecording' })}
             onResume={() => sendRecordingEvent({ type: 'resumeRecording' })}
             onMarkMoment={markMoment}
+            {...videoControls}
             isMinimized={isMinimized}
             onMinimize={handleMinimize}
             onExpand={handleExpand}

--- a/apps/dashboard/src/services/Recording/recordingService.ts
+++ b/apps/dashboard/src/services/Recording/recordingService.ts
@@ -5,8 +5,8 @@
 
 import { apiInstance } from '../clients/apiClient';
 import { AxiosResponse } from 'axios';
-import type { DefaultOutlet, GrantableEntityUserAccess, RecordingType } from '@xyne/shared';
-import { CallType, CallVisibility } from '@xyne/shared';
+import type { DefaultOutlet, GrantableEntityUserAccess } from '@xyne/shared';
+import { CallType, CallVisibility, RecordingType } from '@xyne/shared';
 import { getSummaryModelPreference } from '../../hooks/useSummaryModelPreference';
 
 export interface RecordingSession {
@@ -219,6 +219,10 @@ export interface RecordingDetail extends Recording {
   /** Google Docs exported from this recording, newest first. Absent on legacy responses. */
   googleDocs?: RecordingGoogleDocLink[];
   hasRecording?: boolean;
+  /** Null until a recording has been uploaded. */
+  recordingType?: RecordingType | null;
+  /** Streamable attachment for the recording; null for recordings uploaded before streaming. */
+  attachmentId?: string | null;
   linkedTicketId?: string | null;
   linkedTicketMessageId?: string | null;
 }
@@ -300,6 +304,7 @@ class RecordingService {
       {
         isHeadless: true,
         callType: CallType.AUDIO,
+        recordingType: RecordingType.AUDIO_SCREEN,
         sttModel: params?.sttModel || 'google',
         // Ferry the browser-local summary tier onto the recording so the
         // headless call-end auto-generation can honour a 'thinking' default;

--- a/apps/dashboard/src/services/clients/apiClient.ts
+++ b/apps/dashboard/src/services/clients/apiClient.ts
@@ -19,6 +19,10 @@ import {
 // Define the base URL
 export const BASE_URL = API_BASE_URL;
 
+/** Range-capable media endpoint; the element must use `crossOrigin='use-credentials'`. */
+export const getAttachmentStreamUrl = (attachmentId: string): string =>
+  `${BASE_URL}/attachments/${attachmentId}/stream`;
+
 // Cache regex patterns to avoid recompilation on each call
 const URL_SANITIZATION_PATTERNS = [
   {

--- a/apps/dashboard/src/stores/recordingStore.ts
+++ b/apps/dashboard/src/stores/recordingStore.ts
@@ -12,6 +12,7 @@ import {
   type RemoteParticipant,
 } from 'livekit-client';
 import { recordingService } from '../services/Recording/recordingService';
+import { getLocalVideoState, setLocalVideoMuted } from '../utils/recordingMedia';
 import { toast } from 'sonner';
 import { logger, Event } from '../utils/logger';
 import { formatDuration, normalizeTimestamp } from '../utils/dateUtils';
@@ -108,6 +109,8 @@ export interface RecordingState {
   activeLayout: RecordingLayout;
   isTranscriptMinimized: boolean;
   agentLeft: boolean;
+  isCameraEnabled: boolean;
+  isScreenShareEnabled: boolean;
 }
 
 const initialContext: RecordingState = {
@@ -136,6 +139,8 @@ const initialContext: RecordingState = {
   activeLayout: 'transcript',
   isTranscriptMinimized: false,
   agentLeft: false,
+  isCameraEnabled: false,
+  isScreenShareEnabled: false,
 };
 
 const ACTIVE_STATUSES: ReadonlySet<RecordingStatus> = new Set(['recording', 'paused', 'stopping']);
@@ -397,11 +402,17 @@ export const recordingStore = createStore({
         }
       };
 
+      const handleLocalTracksChanged = (): void => {
+        recordingStore.send({ type: 'syncLocalMedia', room });
+      };
+
       room.on(RoomEvent.DataReceived, handleDataReceived);
       room.on(RoomEvent.ParticipantDisconnected, handleParticipantDisconnected);
       room.on(RoomEvent.ParticipantConnected, handleParticipantConnected);
       room.on(RoomEvent.Disconnected, handleRoomDisconnected);
       room.on(RoomEvent.RoomMetadataChanged, handleRoomMetadataChanged);
+      room.on(RoomEvent.LocalTrackPublished, handleLocalTracksChanged);
+      room.on(RoomEvent.LocalTrackUnpublished, handleLocalTracksChanged);
 
       transcriptUnsubscribe = (): void => {
         clearAgentLeftTimer();
@@ -410,6 +421,8 @@ export const recordingStore = createStore({
         room.off(RoomEvent.ParticipantConnected, handleParticipantConnected);
         room.off(RoomEvent.Disconnected, handleRoomDisconnected);
         room.off(RoomEvent.RoomMetadataChanged, handleRoomMetadataChanged);
+        room.off(RoomEvent.LocalTrackPublished, handleLocalTracksChanged);
+        room.off(RoomEvent.LocalTrackUnpublished, handleLocalTracksChanged);
       };
 
       playAudio(AUDIO_PATHS.RECORDING_START);
@@ -437,9 +450,10 @@ export const recordingStore = createStore({
       const pauseStartedAt = Date.now();
       if (context.room) {
         void context.room.localParticipant.setMicrophoneEnabled(false);
+        setLocalVideoMuted(context.room, true);
       }
       toast.info('Recording paused', {
-        description: 'Microphone is muted',
+        description: 'Microphone and video are muted',
         duration: 2000,
       });
       return {
@@ -455,6 +469,7 @@ export const recordingStore = createStore({
       const resumedAt = Date.now();
       if (context.room) {
         void context.room.localParticipant.setMicrophoneEnabled(true);
+        setLocalVideoMuted(context.room, false);
       }
       toast.success('Recording resumed', {
         duration: 2000,
@@ -468,6 +483,9 @@ export const recordingStore = createStore({
           (context.pauseStartedAt !== null ? resumedAt - context.pauseStartedAt : 0),
       };
     },
+
+    syncLocalMedia: (context, event: { room: Room }): RecordingState =>
+      context.room === event.room ? { ...context, ...getLocalVideoState(event.room) } : context,
 
     stopRecording: (context, event?: { silent?: boolean }): RecordingState => {
       const durationMs = context.startTime
@@ -533,6 +551,8 @@ export const recordingStore = createStore({
         activeLayout: 'transcript',
         isTranscriptMinimized: false,
         agentLeft: false,
+        isCameraEnabled: false,
+        isScreenShareEnabled: false,
       };
     },
 
@@ -566,6 +586,8 @@ export const recordingStore = createStore({
         accumulatedPausedMs: 0,
         error: event.error,
         agentLeft: false,
+        isCameraEnabled: false,
+        isScreenShareEnabled: false,
       };
     },
 
@@ -600,6 +622,8 @@ export const recordingStore = createStore({
         activeLayout: 'transcript',
         isTranscriptMinimized: false,
         agentLeft: false,
+        isCameraEnabled: false,
+        isScreenShareEnabled: false,
       };
     },
 

--- a/apps/dashboard/src/utils/recordingMedia.ts
+++ b/apps/dashboard/src/utils/recordingMedia.ts
@@ -1,0 +1,97 @@
+import { Track, type Room } from 'livekit-client';
+import { RecordingType } from '@xyne/shared';
+import {
+  CALL_MEDIA_QUALITY_CONFIG,
+  getCallMediaQualitySettings,
+  type CallMediaQuality,
+} from '../hooks/useCallMediaQualitySettings';
+
+export type RecordingVideoSource = Track.Source.Camera | Track.Source.ScreenShare;
+
+export interface LocalVideoState {
+  isCameraEnabled: boolean;
+  isScreenShareEnabled: boolean;
+}
+
+interface CaptureResolution {
+  width: number;
+  height: number;
+  frameRate: number;
+}
+
+const VIDEO_SOURCES: readonly RecordingVideoSource[] = [
+  Track.Source.Camera,
+  Track.Source.ScreenShare,
+];
+
+const pendingToggles = new Set<RecordingVideoSource>();
+
+export const isVideoRecordingType = (type: RecordingType | null | undefined): boolean =>
+  !!type && type !== RecordingType.AUDIO_ONLY;
+
+export const canShareScreen = (): boolean =>
+  typeof navigator !== 'undefined' && !!navigator.mediaDevices?.getDisplayMedia;
+
+/** Published counts as enabled, so pausing (which mutes) doesn't read as off. */
+export const isLocalVideoEnabled = (room: Room, source: RecordingVideoSource): boolean =>
+  !!room.localParticipant.getTrackPublication(source);
+
+export const getLocalVideoState = (room: Room): LocalVideoState => ({
+  isCameraEnabled: isLocalVideoEnabled(room, Track.Source.Camera),
+  isScreenShareEnabled: isLocalVideoEnabled(room, Track.Source.ScreenShare),
+});
+
+const getCaptureResolution = (quality: CallMediaQuality): CaptureResolution => {
+  const { width, height, frameRate } = CALL_MEDIA_QUALITY_CONFIG[quality];
+  return { width, height, frameRate };
+};
+
+const enableLocalVideo = async (room: Room, source: RecordingVideoSource): Promise<void> => {
+  const { videoQuality, screenShareQuality } = getCallMediaQualitySettings();
+
+  if (source === Track.Source.Camera) {
+    await room.localParticipant.setCameraEnabled(true, {
+      resolution: getCaptureResolution(videoQuality),
+    });
+  } else {
+    await room.localParticipant.setScreenShareEnabled(true, {
+      resolution: getCaptureResolution(screenShareQuality),
+    });
+  }
+};
+
+const disableLocalVideo = async (room: Room, source: RecordingVideoSource): Promise<void> => {
+  const { localParticipant } = room;
+
+  if (source === Track.Source.ScreenShare) {
+    await localParticipant.setScreenShareEnabled(false);
+    return;
+  }
+
+  // setCameraEnabled(false) only mutes; unpublish so the camera device actually stops.
+  const track = localParticipant.getTrackPublication(Track.Source.Camera)?.track;
+  if (track) await localParticipant.unpublishTrack(track);
+};
+
+/** Flips a video source on or off. Ignored while the previous toggle is still settling. */
+export const toggleLocalVideo = async (room: Room, source: RecordingVideoSource): Promise<void> => {
+  if (pendingToggles.has(source)) return;
+  pendingToggles.add(source);
+
+  try {
+    if (isLocalVideoEnabled(room, source)) {
+      await disableLocalVideo(room, source);
+    } else {
+      await enableLocalVideo(room, source);
+    }
+  } finally {
+    pendingToggles.delete(source);
+  }
+};
+
+export const setLocalVideoMuted = (room: Room, muted: boolean): void => {
+  for (const source of VIDEO_SOURCES) {
+    const publication = room.localParticipant.getTrackPublication(source);
+    void (muted ? publication?.mute() : publication?.unmute());
+  }
+};

--- a/packages/shared/src/zero/types.ts
+++ b/packages/shared/src/zero/types.ts
@@ -119,6 +119,7 @@ export enum AttachmentEntityType {
   FORM_ENTITY_VALUE = 'FORM_ENTITY_VALUE',
   WORKFLOW_STEPS = 'WORKFLOW_STEPS',
   DESK_REPORT = 'DESK_REPORT',
+  RECORDING = 'RECORDING',
 }
 
 // @ts-ignore TS1294


### PR DESCRIPTION
https://drive.google.com/file/d/1jDJWSlFl46OSNwzKUqt1nFaxdAZZOWQj/view?usp=sharing

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
