### PR TITLE
fix: XYNE-62737 switch PostHog persistence to localStorage-only (#1576)

### DIFF
--- a/apps/dashboard/src/routes/QuestionnaireScreen/QuestionnaireScreen.tsx
+++ b/apps/dashboard/src/routes/QuestionnaireScreen/QuestionnaireScreen.tsx
@@ -2,7 +2,15 @@ import { ReactElement, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Cookies from 'js-cookie';
 import { ArrowRight } from '@xyne/icons';
-import { ChevronDown, ChevronRight, ChevronUp, Folder, Loader2, UserRound } from 'lucide-react';
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  Folder,
+  Loader2,
+  UserRound,
+} from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
 import { useZero } from '../../hooks/useZero';
 import { useChannelByName } from '../../hooks/useChannels';
@@ -28,6 +36,27 @@ type StepKey = 'name' | 'company' | 'harness' | 'ai';
 const TEAM_SIZE_OPTIONS = ['0-10', '11-100', '100-1000', '1000+'] as const;
 type TeamSize = (typeof TEAM_SIZE_OPTIONS)[number];
 
+interface OnboardingDraft {
+  displayName?: string;
+  role?: string;
+  companyName?: string;
+  companySize?: TeamSize | '';
+  photoFileName?: string;
+}
+
+const getDraftStorageKey = (email?: string): string => `onboarding_draft_${email || 'anon'}`;
+
+const getInitialStepIndex = (): number => {
+  try {
+    const match = window.location.hash.match(/^#(\d+)$/);
+    if (!match || !match[1]) return 0;
+    const parsed = Number.parseInt(match[1], 10);
+    return Number.isNaN(parsed) || parsed < 1 ? 0 : parsed - 1;
+  } catch {
+    return 0;
+  }
+};
+
 const QuestionnaireScreen = (): ReactElement | null => {
   const navigate = useNavigate();
   const { user } = useAuth();
@@ -35,7 +64,7 @@ const QuestionnaireScreen = (): ReactElement | null => {
 
   const generalChannel = useChannelByName('general');
 
-  const [currentStep, setCurrentStep] = useState(0);
+  const [currentStep, setCurrentStep] = useState(getInitialStepIndex);
   const [isCompleting, setIsCompleting] = useState(false);
   const currentStepRef = useRef(0);
   currentStepRef.current = currentStep;
@@ -45,8 +74,12 @@ const QuestionnaireScreen = (): ReactElement | null => {
   const [companyName, setCompanyName] = useState('');
   const [companySize, setCompanySize] = useState<TeamSize | ''>('');
   const [photoPreviewUrl, setPhotoPreviewUrl] = useState<string | null>(null);
+  const [photoFileName, setPhotoFileName] = useState('');
   const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const draftStorageKey = getDraftStorageKey(user?.email);
+  const loadedDraftKeyRef = useRef<string | null>(null);
+  const hasNavigatedRef = useRef(false);
 
   const [harnesses, setHarnesses] = useState<LocalHarnessInstallation[]>([]);
   const [harnessDevice, setHarnessDevice] = useState({ name: 'This machine', platform: '' });
@@ -62,7 +95,49 @@ const QuestionnaireScreen = (): ReactElement | null => {
     ...(harnesses.length > 0 ? (['harness'] as StepKey[]) : []),
     'ai',
   ];
-  const step: StepKey = steps[currentStep] ?? 'name';
+  const clampedStep = Math.min(currentStep, steps.length - 1);
+  const step: StepKey = steps[clampedStep] ?? 'name';
+
+  useEffect(() => {
+    if (loadedDraftKeyRef.current === draftStorageKey) return;
+    loadedDraftKeyRef.current = draftStorageKey;
+    try {
+      const raw = localStorage.getItem(draftStorageKey);
+      if (!raw) return;
+      const draft = JSON.parse(raw) as OnboardingDraft;
+      if (draft.displayName) setDisplayName(draft.displayName);
+      if (draft.role) setRole(draft.role);
+      if (draft.companyName) setCompanyName(draft.companyName);
+      if (draft.companySize && (TEAM_SIZE_OPTIONS as readonly string[]).includes(draft.companySize))
+        setCompanySize(draft.companySize);
+      if (draft.photoFileName) setPhotoFileName(draft.photoFileName);
+    } catch {
+      // Ignore corrupted drafts
+    }
+  }, [draftStorageKey]);
+
+  useEffect(() => {
+    if (loadedDraftKeyRef.current !== draftStorageKey) return;
+    try {
+      const draft: OnboardingDraft = {
+        displayName,
+        role,
+        companyName,
+        companySize,
+        photoFileName,
+      };
+      localStorage.setItem(draftStorageKey, JSON.stringify(draft));
+    } catch {
+      // Storage may be unavailable (e.g. private mode); persistence is best-effort
+    }
+  }, [draftStorageKey, displayName, role, companyName, companySize, photoFileName]);
+
+  useEffect(() => {
+    const hash = `#${clampedStep + 1}`;
+    if (window.location.hash !== hash) {
+      window.history.replaceState(window.history.state, '', hash);
+    }
+  }, [clampedStep]);
 
   useEffect(() => {
     const isNewUserCookie = Cookies.get('is_new_user');
@@ -77,7 +152,13 @@ const QuestionnaireScreen = (): ReactElement | null => {
     let cancelled = false;
     void Promise.all([api.detect(), api.getStatus()])
       .then(([found, status]) => {
-        if (cancelled || currentStepRef.current > 1) return;
+        if (cancelled) return;
+        const visibleStep = (['name', 'company', 'ai'] as StepKey[])[
+          Math.min(currentStepRef.current, 2)
+        ];
+        // Don't insert the harness step under a user who has manually advanced past it this
+        // session (it would swap their view); a hash-restored step is safe to re-map.
+        if (hasNavigatedRef.current && visibleStep === 'ai') return;
         setHarnesses(found.filter(install => install.authenticated));
         setHarnessDevice({ name: machineLabel(status.deviceName), platform: status.platform });
       })
@@ -109,8 +190,10 @@ const QuestionnaireScreen = (): ReactElement | null => {
       const previewUrl = URL.createObjectURL(file);
       setPhotoPreviewUrl(previewUrl);
       await uploadProfilePictureViaApi(file);
+      setPhotoFileName(file.name);
     } catch {
       setPhotoPreviewUrl(null);
+      setPhotoFileName('');
     } finally {
       setIsUploadingPhoto(false);
       if (fileInputRef.current) fileInputRef.current.value = '';
@@ -156,6 +239,12 @@ const QuestionnaireScreen = (): ReactElement | null => {
       // Non-blocking: profile upsert failure shouldn't trap the user on the questionnaire
     }
 
+    try {
+      localStorage.removeItem(draftStorageKey);
+    } catch {
+      // Best-effort cleanup
+    }
+
     authActor.send({ type: 'COMPLETE_ONBOARDING' });
 
     const workspaceId = user?.workspaceId;
@@ -172,9 +261,10 @@ const QuestionnaireScreen = (): ReactElement | null => {
   };
 
   const handleNext = (): void => {
-    if (currentStep < steps.length - 1) {
+    if (clampedStep < steps.length - 1) {
       if (!canAdvance()) return;
-      setCurrentStep(currentStep + 1);
+      hasNavigatedRef.current = true;
+      setCurrentStep(clampedStep + 1);
       return;
     }
     void handleComplete();
@@ -186,24 +276,28 @@ const QuestionnaireScreen = (): ReactElement | null => {
         <img
           src='/svgs/xyne.svg'
           alt='Xyne'
-          className='absolute left-12 top-[34px] h-[30px] w-auto lg:left-16'
+          className='absolute left-6 top-6 h-7 w-auto md:left-12 md:top-[34px] md:h-[30px] lg:left-16'
         />
 
-        <div className='mx-auto flex h-full w-full max-w-[920px] flex-col items-center pt-[156px]'>
-          <div className='flex h-[118px] w-[118px] items-center justify-center rounded-[30px] bg-gradient-to-b from-[#FF8C8C] to-[#FF4F4F] shadow-[0_16px_40px_rgba(255,79,79,0.24)]'>
-            <img src='/svgs/icons/genius-star-white.svg' alt='' className='h-[66px] w-[66px]' />
+        <div className='mx-auto flex h-full w-full max-w-[920px] flex-col items-center justify-center px-4 pb-16 sm:px-6 md:justify-start md:pb-0 md:pt-[156px]'>
+          <div className='flex h-[84px] w-[84px] shrink-0 items-center justify-center rounded-[22px] bg-gradient-to-b from-[#FF8C8C] to-[#FF4F4F] shadow-[0_16px_40px_rgba(255,79,79,0.24)] md:h-[118px] md:w-[118px] md:rounded-[30px]'>
+            <img
+              src='/svgs/icons/genius-star-white.svg'
+              alt=''
+              className='h-[48px] w-[48px] md:h-[66px] md:w-[66px]'
+            />
           </div>
 
-          <h1 className='mt-[34px] text-center text-[40px] leading-[48px] font-bold text-[#242936]'>
+          <h1 className='mt-[24px] text-center text-[30px] leading-[38px] font-bold text-[#242936] md:mt-[34px] md:text-[40px] md:leading-[48px]'>
             Meet Xyne AI
           </h1>
-          <p className='mt-[14px] max-w-[430px] text-center text-[18px] leading-[28px] font-medium text-[#5F646D]'>
+          <p className='mt-[14px] max-w-[430px] text-center text-[16px] leading-[26px] font-medium text-[#5F646D] md:text-[18px] md:leading-[28px]'>
             It&apos;s wherever you are, and it already knows what you&apos;re looking at
           </p>
 
-          <div className='mt-[72px] grid grid-cols-2 gap-[38px]'>
+          <div className='mt-[72px] hidden grid-cols-2 gap-[38px] md:grid'>
             <div>
-              <div className='relative h-[176px] w-[400px] overflow-hidden rounded-[18px] border border-[#E1E5EC] bg-[#F8FAFD] shadow-[inset_0_-44px_62px_rgba(145,158,178,0.14)]'>
+              <div className='relative h-[176px] w-[400px] max-w-full overflow-hidden rounded-[18px] border border-[#E1E5EC] bg-[#F8FAFD] shadow-[inset_0_-44px_62px_rgba(145,158,178,0.14)]'>
                 <div className='absolute inset-x-0 top-[80px] h-px bg-[#D9DEE7]' />
                 <div className='absolute left-0 top-[97px] h-[66px] w-[338px] rounded-r-[14px] bg-white shadow-[0_13px_28px_rgba(30,41,59,0.18)]'>
                   <div className='absolute -left-[12px] top-[16px] h-[36px] w-[36px] overflow-hidden rounded-full bg-gradient-to-br from-[#98C464] to-[#DCA47C]'>
@@ -239,7 +333,7 @@ const QuestionnaireScreen = (): ReactElement | null => {
             </div>
 
             <div>
-              <div className='relative h-[176px] w-[400px] overflow-hidden rounded-[18px] border border-[#E1E5EC] bg-[#F8FAFD] shadow-[inset_0_-44px_62px_rgba(145,158,178,0.14)]'>
+              <div className='relative h-[176px] w-[400px] max-w-full overflow-hidden rounded-[18px] border border-[#E1E5EC] bg-[#F8FAFD] shadow-[inset_0_-44px_62px_rgba(145,158,178,0.14)]'>
                 <div className='absolute inset-x-0 top-[66px] h-px bg-[#D9DEE7]' />
                 <div className='absolute left-[62px] top-[58px] h-[92px] w-[342px] rounded-[14px] bg-white shadow-[0_13px_28px_rgba(30,41,59,0.18)]'>
                   <div className='absolute left-[20px] top-[23px] whitespace-nowrap text-[17px] leading-[23px] text-[#242936]'>
@@ -264,7 +358,7 @@ const QuestionnaireScreen = (): ReactElement | null => {
             type='button'
             onClick={() => void handleComplete()}
             disabled={isCompleting}
-            className='mt-[120px] inline-flex h-[56px] items-center gap-3 rounded-[12px] bg-[#FF6868] px-6 text-[18px] font-semibold text-white transition-colors hover:bg-[#FF5A5A] disabled:cursor-not-allowed disabled:opacity-60'
+            className='mt-[48px] inline-flex h-[56px] shrink-0 items-center gap-3 rounded-[12px] bg-[#FF6868] px-6 text-[18px] font-semibold text-white transition-colors hover:bg-[#FF5A5A] disabled:cursor-not-allowed disabled:opacity-60 md:mt-[120px]'
             data-track-category='Questionnaire'
             data-track-name='EnterWorkspace'
           >
@@ -325,7 +419,7 @@ const QuestionnaireScreen = (): ReactElement | null => {
               />
             </div>
 
-            <div className='mt-[46px] flex items-center justify-between'>
+            <div className='mt-[46px] flex items-center justify-between gap-3'>
               <p className='text-[14px] leading-[20px] font-semibold text-[#272B35]'>
                 Your profile photo{' '}
                 <span className='text-[#8E939D] font-normal text-[12px]'>(optional)</span>
@@ -334,12 +428,12 @@ const QuestionnaireScreen = (): ReactElement | null => {
                 type='button'
                 onClick={() => fileInputRef.current?.click()}
                 disabled={isUploadingPhoto}
-                className='inline-flex h-[32px] min-w-[78px] items-center justify-center px-3 border border-[#DDE3EC] rounded-[8px] bg-white text-[14px] leading-none text-[#272B35] hover:bg-[#F8FAFC] transition-colors disabled:opacity-50'
+                className='inline-flex h-[32px] min-w-[78px] shrink-0 items-center justify-center px-3 border border-[#DDE3EC] rounded-[8px] bg-white text-[14px] leading-none text-[#272B35] hover:bg-[#F8FAFC] transition-colors disabled:opacity-50'
                 data-track-category='Questionnaire'
                 data-track-name='UploadPhoto'
               >
                 {isUploadingPhoto ? <Loader2 className='w-4 h-4 animate-spin' /> : null}
-                Upload
+                {photoFileName ? 'Change' : 'Upload'}
               </button>
               <input
                 ref={fileInputRef}
@@ -349,6 +443,15 @@ const QuestionnaireScreen = (): ReactElement | null => {
                 className='hidden'
               />
             </div>
+
+            {photoFileName ? (
+              <div className='mt-2 flex items-center gap-1.5 md:hidden'>
+                <Check className='h-3.5 w-3.5 shrink-0 text-[#22A06B]' />
+                <span className='truncate text-[12px] leading-[16px] text-[#5F646D]'>
+                  {photoFileName}
+                </span>
+              </div>
+            ) : null}
 
             <button
               type='button'
@@ -428,7 +531,10 @@ const QuestionnaireScreen = (): ReactElement | null => {
             <div className='mt-auto mb-4 md:mb-0 flex items-center gap-5'>
               <button
                 type='button'
-                onClick={() => setCurrentStep(0)}
+                onClick={() => {
+                  hasNavigatedRef.current = true;
+                  setCurrentStep(0);
+                }}
                 className='text-[14px] text-[#8E939D] hover:text-[#272B35] transition-colors'
                 data-track-category='Questionnaire'
                 data-track-name='Step2Back'
@@ -458,7 +564,10 @@ const QuestionnaireScreen = (): ReactElement | null => {
             onSelect={setSelectedHarness}
             connected={connectedHarness}
             onConnected={setConnectedHarness}
-            onBack={() => setCurrentStep(currentStep - 1)}
+            onBack={() => {
+              hasNavigatedRef.current = true;
+              setCurrentStep(clampedStep - 1);
+            }}
             onNext={handleNext}
           />
         )}

--- a/apps/dashboard/src/services/Analytics/posthogService.ts
+++ b/apps/dashboard/src/services/Analytics/posthogService.ts
@@ -116,8 +116,13 @@ class PostHogService {
         enable_heatmaps: true,
         // Detect rage clicks / dead clicks for friction analysis.
         rageclick: true,
-        // Persist identity across reloads.
-        persistence: 'localStorage+cookie',
+        // Persist identity across reloads. Must be localStorage only: the
+        // 'localStorage+cookie' mode ships a URL-encoded JSON blob in a
+        // ph_*_posthog Cookie header on EVERY same-domain request; Cloud
+        // Armor's sqli-v422-stable ruleset (sensitivity 1) flags those JSON
+        // payloads as SQL injection and 403s the whole app for that browser.
+        // localStorage keeps persistence without ever sending state over HTTP.
+        persistence: 'localStorage',
         // Record the full session so the journey can be replayed.
         disable_session_recording: false,
         session_recording: {


### PR DESCRIPTION
* fix: XYNE-62737 switch PostHog persistence to localStorage-only

'localStorage+cookie' mode ships PostHog state as a URL-encoded JSON cookie (ph_*_posthog) attached to every same-domain request. Cloud Armor's sqli-v422-stable ruleset (sensitivity 1) flags that JSON as SQLI and denies the request with 403, killing the app for every cookied browser page/API call. localStorage persistence keeps session continuity without sending the payload over HTTP.

* chore: trigger redeploy

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
