### PR TITLE
feat: XYNE-63332 xyne automatic tile hide by default

### DIFF
--- a/apps/dashboard/src/components/Call/CallViews/MiniCallView.tsx
+++ b/apps/dashboard/src/components/Call/CallViews/MiniCallView.tsx
@@ -530,7 +530,7 @@ export function MiniCallView({
 
                 {/* Video Grid */}
                 <div
-                  className='flex-1 bg-gray-950/50 p-3 overflow-auto'
+                  className='flex-1 bg-[#131314] p-3 overflow-auto'
                   onPointerDown={(e): void => e.stopPropagation()}
                 >
                   {isWhiteboardOpen ? (

--- a/apps/dashboard/src/components/Call/CallWhiteboard/CallWhiteboardView.tsx
+++ b/apps/dashboard/src/components/Call/CallWhiteboard/CallWhiteboardView.tsx
@@ -6,6 +6,9 @@ import { ParticipantTile } from '../ParticipantTile/ParticipantTile';
 import { sortParticipants } from '../ParticipantGrid/sortParticipants';
 import { CallWhiteboard } from './CallWhiteboard';
 import { useMemo } from 'react';
+import { useSelector } from '@xstate/react';
+import { roomActor } from '../../../machines/roomMachine';
+import { filterAgentTiles } from '../../../utils/livekitAgent';
 
 interface CallWhiteboardViewProps {
   participants: ParticipantInfo[];
@@ -28,10 +31,19 @@ export function CallWhiteboardView({
   aiController,
   requestedAiController,
 }: CallWhiteboardViewProps): React.ReactElement {
-  const isAIAssistantEnabled = aiController !== null;
+  const isAIAssistantEnabled = !!aiController;
+  // Agent tile only shows once someone invokes it, and never while transcription is off.
+  const isTranscriptionEnabled = useSelector(
+    roomActor,
+    state => state.context.isTranscriptionEnabled,
+  );
   const sortedParticipants = useMemo(
-    () => sortParticipants(participants, isAIAssistantEnabled),
-    [participants, isAIAssistantEnabled],
+    () =>
+      sortParticipants(
+        filterAgentTiles(participants, isTranscriptionEnabled && isAIAssistantEnabled),
+        isAIAssistantEnabled,
+      ),
+    [participants, isAIAssistantEnabled, isTranscriptionEnabled],
   );
 
   return (
@@ -43,7 +55,7 @@ export function CallWhiteboardView({
       {showSidebar && (
         <aside
           className={cn(
-            'hidden sm:flex flex-col gap-2 sm:gap-3 p-2 sm:p-4 overflow-y-auto bg-gray-950/50 backdrop-blur-sm',
+            'hidden sm:flex flex-col gap-2 sm:gap-3 p-2 sm:p-4 overflow-y-auto bg-[#131314]',
             compact ? 'w-20' : 'w-56 md:w-64 lg:w-80',
           )}
         >

--- a/apps/dashboard/src/components/Call/ParticipantGrid/ParticipantGrid.tsx
+++ b/apps/dashboard/src/components/Call/ParticipantGrid/ParticipantGrid.tsx
@@ -9,7 +9,7 @@ import { PaginationIndicator } from './PaginationIndicator';
 import { PaginationControls } from './PaginationControls';
 import type { ParticipantInfo } from '../../../machines/roomMachine';
 import { roomActor } from '../../../machines/roomMachine';
-import { isTranscriptionAgentIdentity } from '../../../utils/livekitAgent';
+import { filterAgentTiles } from '../../../utils/livekitAgent';
 import { SpotlightView } from '../SpotlightView';
 
 interface ParticipantGridProps {
@@ -32,7 +32,7 @@ export function ParticipantGrid({
   onToggleHandRaise,
 }: ParticipantGridProps): React.ReactElement {
   // Derive AI enablement from aiController presence — same pattern as Lotus ParticipantsGrid
-  const isAIAssistantEnabled = aiController !== null;
+  const isAIAssistantEnabled = !!aiController;
   // Max 4 tiles (2x2) for compact view, 16 tiles (4x4) for full view
   const maxTiles = compact ? 4 : 16;
   // Grid gap in px, matched to the container's Tailwind gap classes below
@@ -40,19 +40,15 @@ export function ParticipantGrid({
   // solver's target since it only needs to be a close approximation).
   const gridGap = compact ? 6 : 12;
 
-  // Host kill-switch: when transcription is off the agent stays in the room but
-  // its tile is hidden (mirrors the participants-sidebar filter) so the call looks
-  // agent-free while capture is paused.
+  // The agent tile is hidden until someone invokes it via the AI button, and always
+  // while the host kill-switch has transcription off.
   const isTranscriptionEnabled = useSelector(
     roomActor,
     state => state.context.isTranscriptionEnabled,
   );
   const visibleParticipants = useMemo(
-    () =>
-      isTranscriptionEnabled
-        ? participants
-        : participants.filter(p => !isTranscriptionAgentIdentity(p.identity)),
-    [participants, isTranscriptionEnabled],
+    () => filterAgentTiles(participants, isTranscriptionEnabled && isAIAssistantEnabled),
+    [participants, isTranscriptionEnabled, isAIAssistantEnabled],
   );
 
   // Compute layout first using raw participant count — layout.maxTiles is the true

--- a/apps/dashboard/src/components/Call/ParticipantTile/ParticipantTile.tsx
+++ b/apps/dashboard/src/components/Call/ParticipantTile/ParticipantTile.tsx
@@ -202,16 +202,17 @@ export function ParticipantTile({
   };
 
   // Outer glow. Lives on the tile itself (a non-inset box-shadow paints outside
-  // the element, so nothing can cover it) and reinforces the overlay border.
+  // the element, so nothing can cover it). Kept faint — the overlay border is the
+  // real state signal; a strong glow bleeds onto neighbouring tiles.
   const getGlowClass = (): string => {
     if (hideSpeakingIndicator) {
       return '';
     }
     if (isHandRaised) {
-      return 'shadow-[0_0_0_1px_rgba(251,191,36,0.5),0_0_22px_rgba(251,191,36,0.55)]';
+      return 'shadow-[0_0_8px_rgba(251,191,36,0.2)]';
     }
     if (isSpeaking && participant.isMicrophoneEnabled) {
-      return 'shadow-[0_0_0_1px_rgba(74,222,128,0.5),0_0_22px_rgba(74,222,128,0.55)]';
+      return 'shadow-[0_0_8px_rgba(74,222,128,0.2)]';
     }
     return compact ? 'shadow-lg' : 'shadow-[0_4px_24px_rgba(0,0,0,0.45)]';
   };
@@ -342,7 +343,7 @@ export function ParticipantTile({
                   // identity colour behind the avatar — rather than that colour
                   // filling the whole cell as a flat saturated slab.
                   backgroundColor: '#1e1f20',
-                  backgroundImage: `radial-gradient(115% 95% at 50% 45%, ${colors.background} 0%, rgba(30,31,32,0) 72%)`,
+                  backgroundImage: `radial-gradient(115% 95% at 50% 45%, ${colors.background} 0%, rgba(30,31,32,0) 60%)`,
                 }
           }
         >
@@ -366,12 +367,13 @@ export function ParticipantTile({
               <div aria-hidden className='pointer-events-none absolute inset-0 bg-black/55' />
             </>
           ) : (
-            /* Halo so the avatar sits *in* the wash instead of floating on top of it. */
+            /* Faint halo so the avatar sits *in* the wash instead of floating on top
+               of it — kept low-opacity so it doesn't read as a glow. */
             <div
               aria-hidden
               className={cn(
-                'pointer-events-none absolute rounded-full blur-2xl opacity-40',
-                compact ? 'h-20 w-20' : 'h-32 w-32 sm:h-44 sm:w-44',
+                'pointer-events-none absolute rounded-full blur-2xl opacity-[0.08]',
+                compact ? 'h-16 w-16' : 'h-28 w-28 sm:h-36 sm:w-36',
               )}
               style={{ backgroundColor: colors.avatar }}
             />

--- a/apps/dashboard/src/components/Call/ScreenShareView/ScreenShareView.tsx
+++ b/apps/dashboard/src/components/Call/ScreenShareView/ScreenShareView.tsx
@@ -6,7 +6,7 @@ import type { ParticipantInfo } from '../../../machines/roomMachine';
 import { logger, Event } from '../../../utils/logger';
 import { sortParticipants } from '../ParticipantGrid/sortParticipants';
 import { isScreenShareActive } from '../../../utils/livekitScreenShare';
-import { isTranscriptionAgentIdentity } from '../../../utils/livekitAgent';
+import { filterAgentTiles } from '../../../utils/livekitAgent';
 import { SpotlightView, type SpotlightMode } from '../SpotlightView';
 
 interface ScreenShareViewProps {
@@ -39,7 +39,7 @@ export function ScreenShareView({
   onToggleHandRaise,
 }: ScreenShareViewProps): React.ReactElement {
   // Derive AI enablement from aiController presence — same pattern as ParticipantGrid
-  const isAIAssistantEnabled = aiController !== null;
+  const isAIAssistantEnabled = !!aiController;
   const callId = useSelector(roomActor, state => state.context.callId);
 
   // Discord-style "swap to main stage": clicking a non-sharing participant's
@@ -120,18 +120,15 @@ export function ScreenShareView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusedScreenShare.identity, focusedScreenShare.participant, pinnedCameraIdentity]);
 
-  // Host kill-switch: hide the agent tile from the sidebar while transcription is off.
+  // Agent tile only shows once someone invokes it, and never while transcription is off.
   const isTranscriptionEnabled = useSelector(
     roomActor,
     state => state.context.isTranscriptionEnabled,
   );
 
   // Sort sidebar: mic on → camera on → earlier joinedAt, always applied.
-  // Agent (Xyne Automatic) pinned to end unless AI assistant is enabled.
   const sortedParticipants = useMemo(() => {
-    const visible = isTranscriptionEnabled
-      ? participants
-      : participants.filter(p => !isTranscriptionAgentIdentity(p.identity));
+    const visible = filterAgentTiles(participants, isTranscriptionEnabled && isAIAssistantEnabled);
     return sortParticipants(visible, isAIAssistantEnabled);
   }, [participants, isAIAssistantEnabled, isTranscriptionEnabled]);
 

--- a/apps/dashboard/src/components/Call/SpotlightView/SpotlightView.tsx
+++ b/apps/dashboard/src/components/Call/SpotlightView/SpotlightView.tsx
@@ -261,7 +261,7 @@ export function SpotlightView({
       {showSidebar && (
         <aside
           className={cn(
-            'hidden sm:flex flex-col gap-2 sm:gap-3 p-2 sm:p-4 overflow-y-auto bg-gray-950/50 backdrop-blur-sm',
+            'hidden sm:flex flex-col gap-2 sm:gap-3 p-2 sm:p-4 overflow-y-auto bg-[#131314]',
             compact ? 'w-20' : 'w-56 md:w-64 lg:w-80',
           )}
         >

--- a/apps/dashboard/src/utils/livekitAgent.ts
+++ b/apps/dashboard/src/utils/livekitAgent.ts
@@ -6,6 +6,20 @@ export function isTranscriptionAgentIdentity(identity: string): boolean {
   return identity.startsWith('agent-');
 }
 
+/**
+ * The agent sits in every call to transcribe, so its tile is just noise until someone
+ * actually invokes it via the AI button. Callers pass `showAgent` = agent invoked
+ * (and transcription on); otherwise the agent tile is dropped from the tile list.
+ */
+export function filterAgentTiles<T extends { identity: string }>(
+  participants: T[],
+  showAgent: boolean,
+): T[] {
+  return showAgent
+    ? participants
+    : participants.filter(p => !isTranscriptionAgentIdentity(p.identity));
+}
+
 export function shouldConfirmTranscriptionAgentLeft(room: Room): boolean {
   if (room.state !== ConnectionState.Connected) return false;
 


### PR DESCRIPTION
https://drive.google.com/file/d/1hUsSIKBQpNHmI6_2iqjXp6QagYUbA0aB/view?usp=sharing

Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
