### PR TITLE
fix: warn when chat composer silently drops files over the 10-file cap

### DIFF
--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -538,6 +538,22 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
         }
 
         const filesToValidate = filesArray.slice(0, availableSlots);
+
+        // Some files were dropped because they would exceed the per-message cap.
+        // Warn explicitly so users are not silently losing attachments.
+        const droppedForLimit = filesArray.length - filesToValidate.length;
+        if (droppedForLimit > 0) {
+          logger.warn(Event.ATTACHMENT_LIMIT_REACHED, {
+            maxFiles,
+            currentCount: allAttachments.length,
+            attemptedCount: filesArray.length,
+            addedCount: filesToValidate.length,
+            droppedCount: droppedForLimit,
+          });
+          toast.warning(`Only ${maxFiles} files can be attached`, {
+            description: `${droppedForLimit} file${droppedForLimit > 1 ? 's were' : ' was'} not added.`,
+          });
+        }
         const validFiles: File[] = [];
         const rejectedFiles: Array<{ name: string; reason: string }> = [];
 


### PR DESCRIPTION
## Summary
The chat composer silently discards files beyond the 10-file cap. When a user selects more than 10 files at once from an empty composer, only the first 10 are kept and the rest are dropped with no feedback.

Root cause is in `apps/dashboard/src/components/ui/InputBox/InputBox.tsx` → `addFilesWithLimit()`: it computes `availableSlots = maxFiles - allAttachments.length` and does `filesArray.slice(0, availableSlots)`. The only user-facing warning (`toast.error('Cannot add more files')`) fires exclusively when `availableSlots <= 0` (already at the cap), so the first over-cap batch is truncated silently. `ChatInput` renders `<InputBox>` without overriding `maxFiles`, so chat uses the default of 10.

## Fix
After slicing, detect how many files were dropped for exceeding the cap and show a warning toast reporting the dropped count, plus a structured `logger.warn`. No change to the cap itself.

## PR template
1. Problem Description: Files beyond the 10-file composer cap are dropped without any warning.
2. If this is a bug fix or an enhancement, how did you identify the issue?: Reported by a user; traced to addFilesWithLimit() in InputBox.tsx.
3. Explain the solution implemented in the PR: Added a truncation check after the slice; if files were dropped, show a warning toast ("Only 10 files can be attached — N were not added.") and log it. Behaviour otherwise unchanged.
4. Documentation: N/A
5. DB Alter Details (if any): N/A
6. Data fix Details (if any): N/A
7. Environment variable Changes (if any): N/A
8. Testing: Reproduced the silent-drop logic and verified the warning fires when selecting >10 files (proof-of-test video attached in the thread). Frontend-only change mirroring existing toast.warning / logger.warn patterns.
9. Services to which this change is to be deployed: dashboard (frontend).
10. Main PR link (if this PR is raised against a release branch): N/A