### PR TITLE
fix: XYNE-63358 Add tracking for calls & recordings

### DIFF
--- a/apps/dashboard/src/components/Call/ActionModal/ActionModal.tsx
+++ b/apps/dashboard/src/components/Call/ActionModal/ActionModal.tsx
@@ -12,6 +12,8 @@ interface ActionButton {
   disabled?: boolean;
   /** Distinct analytics event name; falls back to the generic Action_Modal_Button. */
   trackName?: string;
+  /** Extra analytics context merged into this button's data-track-metadata. */
+  trackMetadata?: Record<string, unknown>;
 }
 
 interface ActionModalProps {
@@ -89,7 +91,11 @@ export const ActionModal: React.FC<ActionModalProps> = ({
               data-testid={button.testId}
               data-track-category='CALLS'
               data-track-name={button.trackName ?? 'Action_Modal_Button'}
-              data-track-metadata={JSON.stringify({ buttonLabel: button.label, modalTitle: title })}
+              data-track-metadata={JSON.stringify({
+                buttonLabel: button.label,
+                modalTitle: title,
+                ...button.trackMetadata,
+              })}
             >
               {button.label}
             </Button>

--- a/apps/dashboard/src/components/Call/CallControls/RecordingButton.tsx
+++ b/apps/dashboard/src/components/Call/CallControls/RecordingButton.tsx
@@ -91,7 +91,13 @@ export function RecordingButton({
         data-track-event='BUTTON_CLICK'
         data-track-category='CALLS'
         data-track-name='TOGGLE_RECORDING'
-        data-track-metadata={JSON.stringify({ callId, isRecording })}
+        data-track-metadata={JSON.stringify({
+          callId,
+          isRecording,
+          // One button serves both actions: when not recording this click only
+          // opens the mode picker, so the mode lands on the picker buttons below.
+          intent: isRecording ? 'stop' : 'open_mode_picker',
+        })}
       >
         {isRecording ? (
           <CircleStop
@@ -125,6 +131,10 @@ export function RecordingButton({
             className='flex items-center gap-3 w-full px-4 py-2.5 text-sm text-gray-200 hover:bg-gray-600 transition-colors text-left'
             data-track-category='CALLS'
             data-track-name='start-recording-audio-only'
+            data-track-metadata={JSON.stringify({
+              callId,
+              recordingType: RecordingType.AUDIO_ONLY,
+            })}
           >
             <Mic className='w-4 h-4 text-blue-400 flex-shrink-0' />
             <div>
@@ -138,6 +148,10 @@ export function RecordingButton({
             className='flex items-center gap-3 w-full px-4 py-2.5 text-sm text-gray-200 hover:bg-gray-600 transition-colors text-left'
             data-track-category='CALLS'
             data-track-name='start-recording-audio-screen'
+            data-track-metadata={JSON.stringify({
+              callId,
+              recordingType: RecordingType.AUDIO_SCREEN,
+            })}
           >
             <Monitor className='w-4 h-4 text-purple-400 flex-shrink-0' />
             <div>

--- a/apps/dashboard/src/components/Call/CallTrigger/CallTrigger.tsx
+++ b/apps/dashboard/src/components/Call/CallTrigger/CallTrigger.tsx
@@ -23,6 +23,12 @@ interface CallTriggerProps {
   conversationId?: string; // Optional: for thread-initiated calls
   sdlcLink?: SdlcCallLink | undefined; // Optional: SDLC entity to link the call to
   isMember: boolean; // Whether the current user is a member of the channel
+  /**
+   * Which surface rendered this trigger, for analytics. The same component backs
+   * the chat header, the mobile header and the SDLC repo header, so without this
+   * every start-call click arrives as one indistinguishable `Call_Trigger` row.
+   */
+  trackSource?: string;
 }
 
 /**
@@ -48,6 +54,7 @@ export const CallTrigger: React.FC<CallTriggerProps> = ({
   conversationId,
   sdlcLink,
   isMember,
+  trackSource = 'chat_header',
 }) => {
   const {
     handleCallClick,
@@ -131,6 +138,9 @@ export const CallTrigger: React.FC<CallTriggerProps> = ({
             isInCall,
             channelId: channelId,
             targetUserIds,
+            source: trackSource,
+            scopeType,
+            participantCount,
           })}
           className={cn(
             'flex items-center justify-center transition-colors',

--- a/apps/dashboard/src/components/Call/CallTriggerModal/CallTriggerModal.tsx
+++ b/apps/dashboard/src/components/Call/CallTriggerModal/CallTriggerModal.tsx
@@ -49,6 +49,8 @@ interface CallTriggerModalProps {
   disabled?: boolean;
   isMember: boolean;
   sdlcLink?: SdlcCallLink | undefined; // Optional: SDLC entity to link started calls to
+  /** Which surface rendered this, for analytics. Forwarded to CallTrigger. */
+  trackSource?: string;
 }
 
 export const CallTriggerModal: React.FC<CallTriggerModalProps> = ({
@@ -62,6 +64,7 @@ export const CallTriggerModal: React.FC<CallTriggerModalProps> = ({
   disabled = false,
   isMember,
   sdlcLink,
+  trackSource = 'chat_header',
 }) => {
   const { isMobile } = usePlatform();
   const usesCustomTriggerStyle = Boolean(className?.trim());
@@ -169,6 +172,7 @@ export const CallTriggerModal: React.FC<CallTriggerModalProps> = ({
         participantCount={participantCount}
         isMember={isMember}
         sdlcLink={sdlcLink}
+        trackSource={trackSource}
         {...(className ? { className } : {})}
         {...(callDisplayName && { callDisplayName })}
       />
@@ -229,7 +233,13 @@ export const CallTriggerModal: React.FC<CallTriggerModalProps> = ({
             data-track-category='CALLS'
             data-ph-capture-attribute-track-id='start_call_now'
             data-track-name='StartCallNow'
-            data-track-metadata={JSON.stringify({ channelId, targetUserIds })}
+            data-track-metadata={JSON.stringify({
+              channelId,
+              targetUserIds,
+              source: trackSource,
+              scopeType,
+              participantCount,
+            })}
           >
             <div className='rounded-md bg-border p-2'>
               <Headphones className='w-5 h-5 text-foreground' />

--- a/apps/dashboard/src/components/Call/CallViews/CustomLiveKitRoom.tsx
+++ b/apps/dashboard/src/components/Call/CallViews/CustomLiveKitRoom.tsx
@@ -566,6 +566,7 @@ export function CustomLiveKitRoom({
           onDeleteTranscriptChange={setDeleteTranscript}
           submitting={dispositionSubmitting}
           error={dispositionError}
+          trackMetadata={{ callId, participantCount: participants.length, isHost }}
         />
         <TranscriptDispositionModal
           isOpen={showDispositionModal}
@@ -663,6 +664,7 @@ export function CustomLiveKitRoom({
         onDeleteTranscriptChange={setDeleteTranscript}
         submitting={dispositionSubmitting}
         error={dispositionError}
+        trackMetadata={{ callId, participantCount: participants.length, isHost }}
       />
       <TranscriptDispositionModal
         isOpen={showDispositionModal}

--- a/apps/dashboard/src/components/Call/CallsRailHoverCard/CallsRailHoverCard.tsx
+++ b/apps/dashboard/src/components/Call/CallsRailHoverCard/CallsRailHoverCard.tsx
@@ -134,7 +134,11 @@ const ActiveCallEntry = ({ call, isCurrent }: ActiveCallEntryProps): ReactElemen
         )}
         data-track-category='App_Sidebar'
         data-track-name={isCurrent ? 'Rail_Return_To_Call' : 'Rail_Join_Call'}
-        data-track-metadata={JSON.stringify({ callId: call.externalId })}
+        data-track-metadata={JSON.stringify({
+          callId: call.externalId,
+          source: 'calls_rail',
+          isReturn: isCurrent,
+        })}
       >
         {isCurrent ? (
           <>

--- a/apps/dashboard/src/components/Call/EndCallModal/EndCallModal.tsx
+++ b/apps/dashboard/src/components/Call/EndCallModal/EndCallModal.tsx
@@ -14,6 +14,8 @@ interface EndCallModalProps {
   onDeleteTranscriptChange?: (deleteTranscript: boolean) => void;
   submitting?: boolean;
   error?: string | null;
+  /** Analytics context stamped on both end buttons (callId, participantCount, …). */
+  trackMetadata?: Record<string, unknown>;
 }
 
 /**
@@ -32,6 +34,7 @@ export function EndCallModal({
   onDeleteTranscriptChange,
   submitting = false,
   error = null,
+  trackMetadata = {},
 }: EndCallModalProps): React.ReactElement | null {
   // Don't show modal for non-hosts, just disconnect them directly
   if (!isHost) {
@@ -62,6 +65,7 @@ export function EndCallModal({
           variant: 'outline',
           disabled: submitting,
           trackName: 'END_CALL_FOR_EVERYONE',
+          trackMetadata: { ...trackMetadata, endScope: 'everyone' },
         },
         {
           label: submitting ? 'Ending…' : 'Just leave the call',
@@ -69,6 +73,7 @@ export function EndCallModal({
           className: 'bg-action-primary hover:bg-action-primary/90 text-action-primary-foreground',
           disabled: submitting,
           trackName: 'END_CALL_LEAVE_SELF',
+          trackMetadata: { ...trackMetadata, endScope: 'self' },
         },
       ]}
     />

--- a/apps/dashboard/src/components/Call/IncomingCall/IncomingCallActions.tsx
+++ b/apps/dashboard/src/components/Call/IncomingCall/IncomingCallActions.tsx
@@ -41,7 +41,14 @@ export function IncomingCallActions({
   onAccept,
   onReject,
 }: IncomingCallActionsProps): ReactElement {
-  const trackMetadata = JSON.stringify({ isInActiveCall, callId });
+  // `source` marks this as the in-app ringing card specifically. Accepts that
+  // arrive from the Electron or mobile notification never reach a DOM click, so
+  // this surface is the only one of the three that can be counted here.
+  const trackMetadata = JSON.stringify({
+    isInActiveCall,
+    callId,
+    source: 'incoming_call_modal',
+  });
 
   return (
     <div className='flex items-start justify-center gap-6'>

--- a/apps/dashboard/src/components/Call/InstantCallModal/InstantCallModal.tsx
+++ b/apps/dashboard/src/components/Call/InstantCallModal/InstantCallModal.tsx
@@ -238,6 +238,9 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
                 onClick={handleClose}
                 data-track-category='CALLS'
                 data-track-name='CANCEL_INSTANT_CALL'
+                data-track-metadata={JSON.stringify({
+                  participantCount: selectedParticipants.length,
+                })}
                 data-testid='instant-call-cancel-button'
               >
                 Cancel
@@ -248,6 +251,11 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
                 onClick={handleSubmit}
                 data-track-category='CALLS'
                 data-track-name='START_INSTANT_CALL'
+                data-track-metadata={JSON.stringify({
+                  source: 'instant_call_modal',
+                  participantCount: selectedParticipants.length,
+                  hasChannelSelection: selectedParticipants.some(v => v.startsWith('channel:')),
+                })}
                 disabled={selectedParticipants.length === 0}
                 className='rounded-lg text-[13px] bg-primary hover:bg-primary hover:opacity-80 disabled:opacity-20 disabled:cursor-not-allowed'
                 data-testid='instant-call-start-button'

--- a/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
+++ b/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
@@ -2040,6 +2040,28 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                 isSubmitting={isSubmitting}
                 label={submitLabel}
                 onCancel={handleClose}
+                trackMetadata={{
+                  // Everything worth knowing about a scheduled call is knowable
+                  // at this click and is otherwise discarded — the created call
+                  // itself is an async mutator result and never reaches the
+                  // activity table.
+                  leadTimeMinutes: startsAt
+                    ? Math.round((new Date(startsAt).getTime() - Date.now()) / 60000)
+                    : null,
+                  durationMinutes:
+                    startsAt && endsAt
+                      ? Math.round(
+                          (new Date(endsAt).getTime() - new Date(startsAt).getTime()) / 60000,
+                        )
+                      : null,
+                  isRecurring,
+                  recurrenceFrequency: isRecurring ? recurrenceFrequency : null,
+                  recurrenceDayCount: isRecurring ? recurrenceDays.length : 0,
+                  internalInviteeCount: participants?.length ?? 0,
+                  externalInviteeCount: externalEmails.length,
+                  isEditMode,
+                  step,
+                }}
               />
             </div>
           </motion.form>
@@ -2055,7 +2077,9 @@ const SubmitFooter: React.FC<{
   isSubmitting: boolean;
   label: string;
   onCancel: () => void;
-}> = ({ missingRequirements, disabled, isSubmitting, label, onCancel }) => {
+  trackMetadata: Record<string, unknown>;
+}> = ({ missingRequirements, disabled, isSubmitting, label, onCancel, trackMetadata }) => {
+  const serialisedTrackMetadata = JSON.stringify(trackMetadata);
   // The <span> lets the Tooltip pick up pointer events even when the
   // wrapped Button is disabled.
   const submitButton = (
@@ -2066,6 +2090,7 @@ const SubmitFooter: React.FC<{
         disabled={disabled}
         data-track-category='CALLS'
         data-track-name='SUBMIT_SCHEDULE_CALL'
+        data-track-metadata={serialisedTrackMetadata}
         className='rounded-lg text-[13px] px-4 h-9 text-primary-foreground bg-primary hover:bg-primary hover:opacity-80 disabled:opacity-50 disabled:cursor-not-allowed'
       >
         {label}
@@ -2082,6 +2107,7 @@ const SubmitFooter: React.FC<{
         onClick={onCancel}
         data-track-category='CALLS'
         data-track-name='CANCEL_SCHEDULE_CALL'
+        data-track-metadata={serialisedTrackMetadata}
         disabled={isSubmitting}
         type='button'
       >

--- a/apps/dashboard/src/components/Call/UpcomingCallsList/CallRow.tsx
+++ b/apps/dashboard/src/components/Call/UpcomingCallsList/CallRow.tsx
@@ -90,6 +90,14 @@ export function CallRow({
           }}
           data-track-category='CALLS'
           data-track-name='JOIN_UPCOMING_CALL'
+          data-track-metadata={JSON.stringify({
+            source: 'upcoming_calls_list',
+            callId: call.externalId,
+            callStatus: call.status,
+            minutesFromScheduledStart: call.startsAt
+              ? Math.round((Date.now() - new Date(call.startsAt).getTime()) / 60000)
+              : null,
+          })}
           className={cn(
             'shrink-0 text-sm',
             isActive

--- a/apps/dashboard/src/components/Call/UpcomingCallsList/UpcomingCallsList.tsx
+++ b/apps/dashboard/src/components/Call/UpcomingCallsList/UpcomingCallsList.tsx
@@ -85,6 +85,11 @@ export function UpcomingCallsList({
               onClick={() => onJoinCall(call)}
               data-track-category='CALLS'
               data-track-name='JOIN_UPCOMING_CALL'
+              data-track-metadata={JSON.stringify({
+                source: 'upcoming_calls_panel',
+                callId: call.externalId,
+                callStatus: call.status,
+              })}
               tabIndex={0}
               className={cn(
                 'w-full justify-center sm:w-auto sm:shrink-0 transition-opacity duration-150',

--- a/apps/dashboard/src/components/Chat/CallLayout/CallLayout.tsx
+++ b/apps/dashboard/src/components/Chat/CallLayout/CallLayout.tsx
@@ -132,6 +132,11 @@ export const CallLayout: React.FC<CallLayoutProps> = ({ callId }) => {
               trackCategory='CALLS'
               trackJoinName={userIsActiveInCall ? 'SwitchCallFromLayout' : 'JoinCallFromLayout'}
               trackRequestName='RequestToJoinCallFromLayout'
+              trackMetadata={{
+                source: 'call_layout_header',
+                callId,
+                isSwitch: userIsActiveInCall,
+              }}
               className='mx-2 shrink-0'
             />
           )}

--- a/apps/dashboard/src/components/Chat/ConversationHeader/ConversationHeader.tsx
+++ b/apps/dashboard/src/components/Chat/ConversationHeader/ConversationHeader.tsx
@@ -413,6 +413,7 @@ const ConversationHeader = ({
             callDisplayName={displayName}
             isMember={!!channelUserStatus}
             disabled={channel.isArchived}
+            trackSource='chat_header'
           />
           {!isCompact && (
             <DropdownMenu>

--- a/apps/dashboard/src/components/Chat/ConversationHeaderMobile/ConversationHeaderMobile.tsx
+++ b/apps/dashboard/src/components/Chat/ConversationHeaderMobile/ConversationHeaderMobile.tsx
@@ -303,6 +303,7 @@ const ConversationHeaderMobile = ({
               isMember={!!channelUserStatus}
               className={cn('rounded-full', floatingButtonClass)}
               disabled={channel.isArchived}
+              trackSource='chat_header_mobile'
             />
           </div>
         </div>

--- a/apps/dashboard/src/hooks/useIntentSuggestionToast.ts
+++ b/apps/dashboard/src/hooks/useIntentSuggestionToast.ts
@@ -18,6 +18,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 
 import { intentClassifier, type IntentDetection } from '../services/onDeviceIntent';
+import { globalClickTracker } from '../services/Analytics/globalClickTracker';
 
 /** What a suggestion is allowed to do. One entry per wired destination. */
 export interface IntentSuggestionActions {
@@ -128,7 +129,18 @@ export function useIntentSuggestionToast(actions: IntentSuggestionActions): void
         ? {
             action: {
               label: copy.action,
-              onClick: () => copy.run?.(latestActions.current),
+              onClick: () => {
+                // The toast action is rendered by the toast library from a
+                // {label, onClick} pair, so there is no element to hang
+                // data-track-* on and the DOM listener never sees this click.
+                globalClickTracker.trackManualEvent(
+                  'INTENT_SUGGESTION',
+                  'ACT_ON_INTENT_SUGGESTION',
+                  copy.action,
+                  { intentKey: key, action: copy.action },
+                );
+                copy.run?.(latestActions.current);
+              },
             },
           }
         : {}),

--- a/apps/dashboard/src/routes/CallDetailScreen/CallDetailScreen.tsx
+++ b/apps/dashboard/src/routes/CallDetailScreen/CallDetailScreen.tsx
@@ -38,6 +38,7 @@ import {
 import { PostRecordingToEmailModal } from '../RecordingDetailV2Screen/components/PostRecordingToEmailModal';
 import { GoogleDocPreviewModal } from '../RecordingDetailV2Screen/components/GoogleDocPreviewModal';
 import { useCallGoogleDocExport } from './useCallGoogleDocExport';
+import { globalClickTracker } from '../../services/Analytics/globalClickTracker';
 
 /** Matches the recording detail header's post button (POST_SPLIT_BUTTON_CLASS). */
 const POST_BUTTON_CLASS =
@@ -192,6 +193,24 @@ export default function CallDetailScreen(): ReactElement {
     selectedTab && availableTabIds.includes(selectedTab)
       ? selectedTab
       : (availableTabIds[0] ?? null);
+
+  // "Someone actually read the summary" is the payoff signal for the whole
+  // transcription pipeline, and it is the one call event with no click behind it
+  // — the detailed summary is the default tab and renders unprompted. Emit it
+  // once per call per mount, when the summary is genuinely on screen.
+  const summaryViewLogged = useRef<string | null>(null);
+  useEffect(() => {
+    const callExternalId = call?.externalId;
+    if (activeTab !== 'detailed-summary' || !detailedSummaryCanvasId || !callExternalId) return;
+    if (summaryViewLogged.current === callExternalId) return;
+    summaryViewLogged.current = callExternalId;
+    globalClickTracker.trackManualEvent('CALLS', 'VIEW_CALL_DETAILED_SUMMARY', undefined, {
+      callId: callExternalId,
+      hoursSinceCallEnded: call?.endedAt
+        ? Math.round((Date.now() - new Date(call.endedAt).getTime()) / 3600000)
+        : null,
+    });
+  }, [activeTab, detailedSummaryCanvasId, call?.externalId, call?.endedAt]);
 
   // Tabs come out of the call's conversation messages, so an unresolved query means
   // "not known yet" rather than "this call has nothing".

--- a/apps/dashboard/src/routes/CallHistoryScreen/CalendarCallPopup.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/CalendarCallPopup.tsx
@@ -884,6 +884,11 @@ const CalendarCallPopup = ({
               disabled={isJoinDisabled}
               data-track-category='CALLS'
               data-track-name='popup-join-call'
+              data-track-metadata={JSON.stringify({
+                source: 'call_history_calendar',
+                callId: call.externalId,
+                callStatus: call.status,
+              })}
               className={cn(
                 'w-full mt-3 h-10 flex items-center justify-center gap-1.5 rounded-xl text-sm font-medium transition-opacity',
                 isJoinDisabled

--- a/apps/dashboard/src/routes/CallHistoryScreen/CallCard.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/CallCard.tsx
@@ -490,6 +490,11 @@ export const CallCard = ({
                         }}
                         data-track-category='CALLS'
                         data-track-name='join-call'
+                        data-track-metadata={JSON.stringify({
+                          source: 'call_history_list',
+                          callId: call.externalId,
+                          callStatus: call.status,
+                        })}
                         className='size-7 flex items-center justify-center border border-border rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent'
                       >
                         <HuddleIcon size={16} />

--- a/apps/dashboard/src/routes/CallHistoryScreen/CallHistoryScreen.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/CallHistoryScreen.tsx
@@ -982,6 +982,7 @@ const CallHistoryScreen = (): ReactElement => {
               onClick={() => setIsInstantCallModalOpen(true)}
               data-track-category='CALLS'
               data-track-name='start-instant-call'
+              data-track-metadata={JSON.stringify({ source: 'call_history_tile' })}
               className='flex items-center gap-4 p-2.5 sm:p-4 rounded-xl border border-border hover:bg-accent/50 transition-colors text-left'
             >
               <div className='size-6 rounded-md bg-action-primary flex items-center justify-center shrink-0'>
@@ -1002,6 +1003,7 @@ const CallHistoryScreen = (): ReactElement => {
               onClick={() => setIsScheduleModalOpen(true)}
               data-track-category='CALLS'
               data-track-name='schedule-call'
+              data-track-metadata={JSON.stringify({ source: 'call_history_tile' })}
               className='flex items-center gap-4 p-2.5 sm:p-4 rounded-xl border border-border hover:bg-accent/50 transition-colors text-left'
             >
               <div className='size-6 rounded-md bg-blue-500 flex items-center justify-center shrink-0'>

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/SummaryTemplatesModal.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/SummaryTemplatesModal.tsx
@@ -965,6 +965,13 @@ export function SummaryTemplatesModal({
                           )}
                           data-track-category='SummaryTemplates'
                           data-track-name='SelectTemplate'
+                          data-track-metadata={JSON.stringify({
+                            templateId: template.id,
+                            previousTemplateId: draft?.id ?? null,
+                            sectionCount: Array.isArray(template.sections)
+                              ? template.sections.length
+                              : null,
+                          })}
                         >
                           <span className='flex size-7 shrink-0 items-center justify-center rounded-lg border border-border bg-background text-sm font-semibold shadow-sm'>
                             {getTemplateIcon(template.name)}
@@ -1327,6 +1334,13 @@ export function SummaryTemplatesModal({
                               className='ml-auto'
                               data-track-category='SummaryTemplates'
                               data-track-name='ToggleMandatorySection'
+                              data-track-metadata={JSON.stringify({
+                                // Without sectionKey the event cannot say WHICH
+                                // mandatory section was switched off.
+                                sectionKey: section.key,
+                                enabled: !isSectionEnabled,
+                                templateId: draft?.id ?? null,
+                              })}
                             />
                           )}
                         </div>

--- a/apps/dashboard/src/routes/RecordingsScreen/RecordingsScreen.tsx
+++ b/apps/dashboard/src/routes/RecordingsScreen/RecordingsScreen.tsx
@@ -654,6 +654,10 @@ export default function RecordingsScreen(): ReactElement {
                             className='flex-1 min-w-0 text-left p-4 cursor-pointer'
                             data-track-category='RecordingsScreen'
                             data-track-name='view_recording'
+                            data-track-metadata={JSON.stringify({
+                              recordingId: recording.id,
+                              source: 'recordings_list',
+                            })}
                           >
                             <div className='flex items-start gap-4'>
                               {/* Icon */}

--- a/apps/dashboard/src/routes/RecordingsScreen/components/RecordingControlBar.tsx
+++ b/apps/dashboard/src/routes/RecordingsScreen/components/RecordingControlBar.tsx
@@ -107,6 +107,10 @@ export function RecordingControlBar({
               title={isPaused ? 'Resume recording' : 'Pause recording'}
               data-track-category='RecordingControlBar'
               data-track-name={isPaused ? 'resume_recording' : 'pause_recording'}
+              data-track-metadata={JSON.stringify({
+                source: 'recording_control_bar',
+                elapsedMs: startTime ? Date.now() - startTime - accumulatedPausedMs : null,
+              })}
             >
               {isPaused ? (
                 <Play className='w-5 h-5 text-foreground' />
@@ -121,6 +125,11 @@ export function RecordingControlBar({
               title='Stop recording'
               data-track-category='RecordingControlBar'
               data-track-name='stop_recording'
+              data-track-metadata={JSON.stringify({
+                source: 'recording_control_bar',
+                durationMs: startTime ? Date.now() - startTime - accumulatedPausedMs : null,
+                wasPaused: accumulatedPausedMs > 0,
+              })}
             >
               {/* Square stop icon */}
               <div className='w-5 h-5 rounded-sm bg-destructive' />

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/NoteTakerOverlay.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/NoteTakerOverlay.tsx
@@ -270,6 +270,7 @@ const MarkMomentButton = ({
         title={justMarked ? 'Moment marked' : 'Mark moment'}
         data-track-category={TRACK_CATEGORY}
         data-track-name='mark_moment'
+        data-track-metadata={JSON.stringify({ markedCount })}
       >
         {justMarked && (
           <span
@@ -338,6 +339,7 @@ const RecordingControlBar = ({
         title='Open recording details'
         data-track-category={TRACK_CATEGORY}
         data-track-name='open_recording_details'
+        data-track-metadata={JSON.stringify({ recordingId })}
       >
         <Maximize2 strokeWidth={2.8} className='size-3' />
         <span>Full screen</span>
@@ -354,6 +356,7 @@ const RecordingControlBar = ({
           title={isPaused ? 'Resume recording' : 'Pause recording'}
           data-track-category={TRACK_CATEGORY}
           data-track-name={isPaused ? 'resume_recording' : 'pause_recording'}
+          data-track-metadata={JSON.stringify({ recordingId, source: 'note_taker_overlay' })}
         >
           {isPaused ? (
             <PlayBig size={17} variant='Solid' />
@@ -371,6 +374,11 @@ const RecordingControlBar = ({
           title='Stop recording'
           data-track-category={TRACK_CATEGORY}
           data-track-name='stop_recording'
+          data-track-metadata={JSON.stringify({
+            recordingId,
+            markedCount,
+            source: 'note_taker_overlay',
+          })}
         >
           <StopBig size={16} variant='Solid' />
         </Button>

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -2761,6 +2761,7 @@ export default function SdlcScreen(): ReactElement {
                   channelName={repo.name}
                   participantCount={repo.channel?.channelStats?.participantCount ?? 0}
                   callDisplayName={repo.name}
+                  trackSource='sdlc_repo_header'
                   isMember={Boolean(
                     repo.channel?.participants?.some(
                       participant => participant.userId === auth.userID,


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
