### PR TITLE
fix: XYNE-61736 SDLC activity owner stamping and frame route sync [backport to feature/sdlc-deploy-07]

### DIFF
--- a/apps/backend/src/controllers/livekitWebhookController.ts
+++ b/apps/backend/src/controllers/livekitWebhookController.ts
@@ -24,6 +24,7 @@ import { emitCallEnded, emitCallStarted } from '@/automations/triggers/call.trig
 import { noteTakerWebhookController } from '@/controllers/noteTakerWebhookController';
 import { buildCallInviteUrl } from '@/utils/urlUtils';
 import { isTrackInChannel } from '@/sdlc/sdlcChannelMembership';
+import { activityService } from '@/services/activity/activityService';
 
 class LiveKitWebhookController {
   private receiver: WebhookReceiver;
@@ -564,6 +565,9 @@ class LiveKitWebhookController {
                 ],
                 skipDuplicates: true,
               });
+              if (existingConversationId) {
+                await activityService.fillSdlcOwner(conversationId, channelId);
+              }
               logger.info(
                 `[LiveKit Webhook] sdlc_link_created | call=${callId} owner=${sdlcLink.ownerType}:${sdlcLink.ownerId}`,
               );

--- a/apps/backend/src/controllers/ticketController.ts
+++ b/apps/backend/src/controllers/ticketController.ts
@@ -43,6 +43,7 @@ import { config } from '../config/env';
 import { superpositionClient } from '@/services/superpositionClient';
 import { randomUUID } from 'crypto';
 import { linkCreatedEntities, resolveInheritedOwner } from '@/sdlc/entityLinkService';
+import { activityService } from '@/services/activity/activityService';
 import { entityLinkOwnerSchema, type EntityLinkOwner } from '@xyne/shared';
 import { vespaQueue } from '@/queues/vespaQueue';
 import { messageClassificationQueue } from '@/queues/messageClassificationQueue';
@@ -1301,6 +1302,10 @@ export class TicketController {
       // Post-commit + fire-and-forget so it can't delay or fail ticket creation.
       if (ticket.stageName) {
         void maybeCreateEntryApprovalRequest(ticket.id, ticket.createdBy, ticket.stageName);
+      }
+
+      if (sourceConversationId) {
+        void activityService.fillSdlcOwner(sourceConversationId, validatedConversation.channelId);
       }
 
       const ticketChannelId = sourceConversationId ? validatedConversation.channelId : channelId;

--- a/apps/backend/src/sdlc/sdlcNavTarget.ts
+++ b/apps/backend/src/sdlc/sdlcNavTarget.ts
@@ -102,6 +102,11 @@ export const sdlcConversationOwner = memoize(
   (conversationId: string) => resolveInheritedOwner(db, conversationId),
 );
 
+export const sdlcFolderTrackId = memoize(
+  (folderId: string) => folderId,
+  (folderId: string) => resolveFolderTrackId(db, folderId),
+);
+
 export const sdlcConversationTicket = memoize(
   (conversationId: string) => conversationId,
   async (conversationId: string): Promise<string | null> =>

--- a/apps/backend/src/services/activity/activityService.ts
+++ b/apps/backend/src/services/activity/activityService.ts
@@ -8,9 +8,9 @@ import {
   isSdlcChannel,
   sdlcConversationOwner,
   sdlcConversationTicket,
+  sdlcFolderTrackId,
   sdlcTicketConversation,
 } from '@/sdlc/sdlcNavTarget';
-import { resolveFolderTrackId } from '@/sdlc/entityLinkService';
 
 export interface CreateActivityParams {
   id?: string;
@@ -264,9 +264,7 @@ export class ActivityService {
         if (owner.sourceType === 'CANVAS') return { canvasId: owner.sourceId, conversationId };
         // A folder discussion opens under its parent track, as notifications route it.
         const trackId =
-          owner.sourceType === 'FOLDER'
-            ? await runAsSystem(() => resolveFolderTrackId(db, owner.sourceId))
-            : owner.sourceId;
+          owner.sourceType === 'FOLDER' ? await sdlcFolderTrackId(owner.sourceId) : owner.sourceId;
         return trackId ? { trackId, conversationId } : {};
       }
       if (row.ticketId) return {};

--- a/apps/backend/src/services/activity/activityService.ts
+++ b/apps/backend/src/services/activity/activityService.ts
@@ -10,6 +10,7 @@ import {
   sdlcConversationTicket,
   sdlcTicketConversation,
 } from '@/sdlc/sdlcNavTarget';
+import { resolveFolderTrackId } from '@/sdlc/entityLinkService';
 
 export interface CreateActivityParams {
   id?: string;
@@ -260,9 +261,13 @@ export class ActivityService {
 
       const owner = await sdlcConversationOwner(conversationId);
       if (owner) {
-        return owner.sourceType === 'CANVAS'
-          ? { canvasId: owner.sourceId, conversationId }
-          : { trackId: owner.sourceId, conversationId };
+        if (owner.sourceType === 'CANVAS') return { canvasId: owner.sourceId, conversationId };
+        // A folder discussion opens under its parent track, as notifications route it.
+        const trackId =
+          owner.sourceType === 'FOLDER'
+            ? await runAsSystem(() => resolveFolderTrackId(db, owner.sourceId))
+            : owner.sourceId;
+        return trackId ? { trackId, conversationId } : {};
       }
       if (row.ticketId) return {};
       const ticketId = await sdlcConversationTicket(conversationId);
@@ -270,6 +275,22 @@ export class ActivityService {
     } catch (error) {
       logger.error('[ActivityService] SDLC owner lookup failed', { row, error });
       return {};
+    }
+  }
+
+  /** Stamps a conversation's rows written before it had an owner. */
+  async fillSdlcOwner(conversationId: string, channelId: string): Promise<void> {
+    const { canvasId, trackId, ticketId } = await this.sdlcOwner({ channelId, conversationId });
+    if (!canvasId && !trackId && !ticketId) return;
+    try {
+      await runAsSystem(() =>
+        this.prisma.activity.updateMany({
+          where: { conversationId, canvasId: null, trackId: null, ticketId: null },
+          data: { canvasId, trackId, ticketId },
+        }),
+      );
+    } catch (error) {
+      logger.error('[ActivityService] SDLC owner fill failed', { conversationId, error });
     }
   }
 
@@ -476,6 +497,11 @@ export class ActivityService {
       const conversationSeenCutoffAt = existingActivity.conversationSeenCutoffAt
         ? null
         : activity.conversationSeenCutoffAt;
+      // The row is reused for every reaction, so one written without an owner gets it here.
+      const owned =
+        existingActivity.canvasId || existingActivity.trackId || existingActivity.ticketId
+          ? {}
+          : await this.sdlcOwner(activity);
 
       await this.prisma.activity.update({
         where: { id: existingActivity.id },
@@ -484,6 +510,7 @@ export class ActivityService {
           isRead: false,
           ...(isThreadActivity !== undefined ? { isThreadActivity } : {}),
           ...(conversationSeenCutoffAt ? { conversationSeenCutoffAt } : {}),
+          ...owned,
         },
       });
 
@@ -614,6 +641,11 @@ export class ActivityService {
         const conversationSeenCutoffAt =
           existingActivity.conversationSeenCutoffAt ??
           (await this.getConversationSeenCutoffAtForConversation(conversationId, channelId));
+        // Reused for every reply in the thread, so a row written without an owner gets it here.
+        const owned =
+          existingActivity.canvasId || existingActivity.trackId || existingActivity.ticketId
+            ? {}
+            : await this.sdlcOwner({ channelId, conversationId });
 
         await this.prisma.activity.update({
           where: { id: existingActivity.id },
@@ -623,6 +655,7 @@ export class ActivityService {
             messageId: latestReplyMessageId,
             actionSourceId: latestReplyMessageId,
             ...(conversationSeenCutoffAt ? { conversationSeenCutoffAt } : {}),
+            ...owned,
           },
         });
 

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcFrameHost.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcFrameHost.tsx
@@ -33,9 +33,8 @@ const SdlcFrameHost = (): ReactElement | null => {
   const initiateCallRef = useRef(initiateCall);
   initiateCallRef.current = initiateCall;
 
-  // Last path each side told the other, so echoes do not loop.
-  const lastFromFrameRef = useRef<string | null>(null);
-  const lastToFrameRef = useRef<string | null>(null);
+  // Where the frame is now, from its last report or our last send; sending it again only echoes.
+  const frameLocationRef = useRef<string | null>(null);
 
   const container = useMemo(() => {
     if (typeof document === 'undefined') return null;
@@ -93,8 +92,7 @@ const SdlcFrameHost = (): ReactElement | null => {
         // request a true cache-bypassing reload.
         const root = `/${workspaceId}/sdlc`;
         initialSrcRef.current = `${SDLC_APP_BASE_PATH}${root}?_reset=${Date.now()}`;
-        lastFromFrameRef.current = null;
-        lastToFrameRef.current = null;
+        frameLocationRef.current = null;
         setIsReady(false);
         setResetCount(count => count + 1);
         if (location.pathname !== root) void navigate(root, { replace: true });
@@ -103,7 +101,7 @@ const SdlcFrameHost = (): ReactElement | null => {
 
       if (message.type !== SDLC_FRAME_MESSAGE.route) return;
 
-      lastFromFrameRef.current = message.path;
+      frameLocationRef.current = message.path;
       // Only while on screen — a hidden frame must not move the address bar.
       const current = `${location.pathname}${location.search}${location.hash}`;
       if (viewport && isSdlcPath(message.path) && message.path !== current) {
@@ -124,11 +122,22 @@ const SdlcFrameHost = (): ReactElement | null => {
     // The hash carries #origin/#messageId scroll targets, so it must ride along.
     const path = `${location.pathname}${location.search}${location.hash}`;
     if (!isSdlcPath(location.pathname)) return;
-    if (path === lastFromFrameRef.current || path === lastToFrameRef.current) return;
+    if (path === frameLocationRef.current) return;
 
-    lastToFrameRef.current = path;
+    // The bare hub link means "back to SDLC", so it returns to wherever the frame already is.
+    const frameLocation = frameLocationRef.current;
+    if (
+      frameLocation &&
+      isSdlcPath(frameLocation) &&
+      /^\/[^/]+\/sdlc\/?$/.test(location.pathname)
+    ) {
+      void navigate(frameLocation, { replace: true });
+      return;
+    }
+
+    frameLocationRef.current = path;
     target.postMessage({ type: SDLC_FRAME_MESSAGE.navigate, path }, window.location.origin);
-  }, [isReady, viewport, location.pathname, location.search, location.hash]);
+  }, [isReady, viewport, location.pathname, location.search, location.hash, navigate]);
 
   if (!container || !hasActivated || !initialSrcRef.current) return null;
 

--- a/apps/dashboard/src/routes/SdlcScreen/useSdlcFrameBridge.ts
+++ b/apps/dashboard/src/routes/SdlcScreen/useSdlcFrameBridge.ts
@@ -33,9 +33,8 @@ export function useSdlcFrameBridge(): void {
   const location = useLocation();
   const navigate = useNavigate();
 
-  // Skip reporting a route the parent just asked for.
-  const lastFromParentRef = useRef<string | null>(null);
-  const lastReportedRef = useRef<string | null>(null);
+  // Where the parent is now, from its last NAVIGATE or our last report; reporting it again only echoes.
+  const parentLocationRef = useRef<string | null>(null);
 
   const enabled = isFramedSdlcSurface();
 
@@ -49,7 +48,7 @@ export function useSdlcFrameBridge(): void {
       const message = parseSdlcFrameMessage(event.data);
       if (!message || message.type !== SDLC_FRAME_MESSAGE.navigate) return;
 
-      lastFromParentRef.current = message.path;
+      parentLocationRef.current = message.path;
       void navigate(message.path);
     };
 
@@ -63,9 +62,9 @@ export function useSdlcFrameBridge(): void {
     if (!enabled) return;
 
     const path = `${location.pathname}${location.search}${location.hash}`;
-    if (path === lastFromParentRef.current || path === lastReportedRef.current) return;
+    if (path === parentLocationRef.current) return;
 
-    lastReportedRef.current = path;
+    parentLocationRef.current = path;
     window.parent.postMessage({ type: SDLC_FRAME_MESSAGE.route, path }, window.location.origin);
   }, [enabled, location.pathname, location.search, location.hash]);
 }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

Backport to `feature/sdlc-deploy-07` of two SDLC activity fixes. The deploy branch starts at `d94de0bf19` (`1.295.0-release-20260909.8`), the build the SDLC backend and frontend run in prod.

- **XYNE-60272, SDLC frame route sync (#1727, merged to main).** Clicking the same activity again after moving to another hub page (e.g. Repo Knowledge) left the hub where it was, because the host and the frame each skipped a navigation that matched the last path they had sent. Each side now tracks where the other side really is.
- **XYNE-61736, activity owner stamping (#1794, open against main).** Activities carry `canvasId` / `trackId` / `ticketId` so a click opens the right place. Reused `replied_v2` / `added_v2` rows now get the owner when updated without one; creating a ticket or starting a call from an existing thread fills that thread's empty rows; folder discussions stamp the folder's parent track instead of the folder id; the folder→track lookup is memoized.

Commits cherry-picked as-is: `b46b6dccd`, `8112c8463`, `02b87c1bd`.

## Areas Touched

- [x] `apps/backend`
- [x] `apps/dashboard`

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

A dry-run cherry-pick onto `d94de0bf19` applied all three commits with no conflicts (6 files). On main the same changes passed the backend and dashboard typecheck and pre-commit checks; they were not typechecked locally on this base, so this relies on CI. Not yet exercised in a running app.

### Automated

- [x] Not covered by tests

### Manual

1. SDLC hub → Activity → click a reply activity → move to Repo Knowledge → Activity → click the same activity again: the hub opens the activity's canvas/track thread.
2. Reply again in a thread whose `replied_v2` row had no owner: the row gets `canvasId`/`trackId` and the click opens the thread.
3. Post in a folder discussion: the activity click opens the parent track discussion.

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] No debug logging or commented-out code left behind

<details>
<summary>Debug</summary>

- Claude Code `session_01BYro9ZrUDEABaYeFrMK8NS` — `5c15eb718` — cherry-picked the SDLC frame sync and activity owner fixes onto the deploy branch.

</details>
