### PR TITLE
feat: XYNE-61401 fix search in tag and usergroup filter

### DIFF
--- a/apps/backend/src/services/vespaSearch/index.ts
+++ b/apps/backend/src/services/vespaSearch/index.ts
@@ -229,6 +229,7 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       callEndsAt,      // Call visible range end timestamp
       stage,       // Ticket stage
       assignee,    // Assigned user name
+      userGroup,   // User group ID(s) - comma-separated
       filterOnly,  // Flag for filter-only search (no query text)
       collectionId, // KB collection id(s) - comma-separated; restricts file results to those clIds
       fileId,      // KB file id(s) - comma-separated; restricts file results to those Vespa docIds (collectionItem.fileId)
@@ -916,6 +917,10 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
 
     if (assignee) {
       options.ticket.assignedTo = toFilterValues(assignee, 'assignee');
+    }
+
+    if (userGroup) {
+      options.ticket.userGroupId = toFilterValues(userGroup, 'userGroup');
     }
 
     if (subApp) {

--- a/apps/backend/src/validators/vespaSearchValidator.ts
+++ b/apps/backend/src/validators/vespaSearchValidator.ts
@@ -289,6 +289,10 @@ export const vespaSearchQuerySchema = Joi.object({
     'string.base': 'Assignee must be a string'
   }),
 
+  userGroup: Joi.string().optional().messages({
+    'string.base': 'UserGroup must be a string'
+  }),
+
   subApp: Joi.string().valid('canvas', 'transcript', 'recording', 'rca', 'collections').optional().messages({
     'string.base': 'SubApp must be a string',
     'any.only': 'SubApp must be one of: canvas, transcript, recording, rca, collections'

--- a/apps/backend/src/vespa/src/utils/YqlBuilder.ts
+++ b/apps/backend/src/vespa/src/utils/YqlBuilder.ts
@@ -112,6 +112,7 @@ export interface TicketFilters {
   createdRange?: string; // Time keyword (today, yesterday, this week, etc.)
   stage?: string[]; // Filter by ticket stage - comma-separated
   assignedTo?: string[]; // Filter by assigned user ID - comma-separated
+  userGroupId?: string[]; // Filter by user group ID - comma-separated
   // Entity filter: docs annotated with these entity names (chat_message/ticket `entityNames`).
   // AND-ed, not OR-ed — multiple entities narrow to docs mentioning every one of them.
   entityNames?: string[];
@@ -1105,6 +1106,14 @@ export class YqlBuilder {
         .map((assignedTo) => `assignedTo contains ${params.bind('assignedTo', assignedTo.trim())}`)
         .join(' or ');
       conditions.push(`(${assignees})`);
+    }
+
+    // User group filter (array - comma-separated)
+    if (filters.userGroupId && filters.userGroupId.length > 0) {
+      const userGroups = filters.userGroupId
+        .map((userGroupId) => `userGroupId contains ${params.bind('userGroupId', userGroupId.trim())}`)
+        .join(' or ');
+      conditions.push(`(${userGroups})`);
     }
 
     // Date filters (ISO or dd/mm/yy or dd mon yy - no time keywords)

--- a/apps/dashboard/src/components/Tickets/KanbanColumns/KanbanColumns.tsx
+++ b/apps/dashboard/src/components/Tickets/KanbanColumns/KanbanColumns.tsx
@@ -7,7 +7,19 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import type { Ticket, TicketTagMapping, FormEntityValues } from '@xyne/shared';
 import { TicketStatusV2 } from '@xyne/shared';
 
-type TicketWithTags = Ticket & { tagMappings?: TicketTagMapping[] };
+/**
+ * A tag as it arrives on a Vespa search row. `toTicket` (useVespaTicketSearch) builds
+ * these objects from the search context, but the raw context carries plain strings, so
+ * both forms are accepted here.
+ */
+type VespaSearchTag = string | { id?: string; name?: string; workspaceId?: string };
+
+type TicketWithTags = Ticket & {
+  /** Present on Zero/DB rows. */
+  tagMappings?: TicketTagMapping[];
+  /** Present on direct-Vespa search rows, which have no tagMappings relation. */
+  tags?: VespaSearchTag[];
+};
 import type {
   DroppableStageProps,
   SortableTicketCardProps,
@@ -254,12 +266,25 @@ const VirtualizedStageList: React.FC<{
             >
               <SortableTicketCard
                 ticket={ticket}
-                tags={((ticket as TicketWithTags).tagMappings ?? []).map(m => ({
-                  workspaceId: m.workspaceId,
-                  id: m.id,
-                  name: m.tagName,
-                  ticketId: m.ticketId,
-                }))}
+                tags={
+                  // Use tagMappings from Zero/DB, or fall back to tags from Vespa search results
+                  ((ticket as TicketWithTags).tagMappings ?? []).length > 0
+                    ? ((ticket as TicketWithTags).tagMappings ?? []).map(m => ({
+                        workspaceId: m.workspaceId,
+                        id: m.id,
+                        name: m.tagName,
+                        ticketId: m.ticketId,
+                      }))
+                    : ((ticket as TicketWithTags).tags ?? []).map(t => {
+                        const name = typeof t === 'string' ? t : (t.name ?? '');
+                        return {
+                          workspaceId: typeof t === 'string' ? '' : (t.workspaceId ?? ''),
+                          id: (typeof t === 'string' ? undefined : t.id) ?? `${ticket.id}:${name}`,
+                          name,
+                          ticketId: ticket.id,
+                        };
+                      })
+                }
                 availableTags={availableTags}
                 onLoadMoreTags={onLoadMoreTags}
                 hasMoreTags={hasMoreTags}

--- a/apps/dashboard/src/hooks/useVespaTicketSearch.ts
+++ b/apps/dashboard/src/hooks/useVespaTicketSearch.ts
@@ -20,6 +20,7 @@ interface UseVespaTicketSearchParams {
   assignee?: string;
   tags?: string;
   createdBy?: string;
+  userGroup?: string;
   dynamicFieldValues?: string[];
   dynamicFieldDateRanges?: Record<string, { start?: number; end?: number }>;
   enabled?: boolean;
@@ -191,6 +192,7 @@ export const useVespaTicketSearch = ({
   assignee,
   tags,
   createdBy,
+  userGroup,
   dynamicFieldValues = EMPTY_DYNAMIC_FIELD_VALUES,
   dynamicFieldDateRanges = {},
   enabled = true,
@@ -263,6 +265,7 @@ export const useVespaTicketSearch = ({
       if (assignee) vespaFilters.assignee = assignee;
       if (tags) vespaFilters.tags = tags;
       if (createdBy) vespaFilters.from = createdBy;
+      if (userGroup) vespaFilters.userGroup = userGroup;
       if (normalizedDynamicFieldValues.length > 0) {
         vespaFilters.dynamicFieldValues = normalizedDynamicFieldValues;
         // Only set filterOnly when true - when false, omit it so backend uses default behavior
@@ -365,6 +368,7 @@ export const useVespaTicketSearch = ({
       assignee,
       tags,
       createdBy,
+      userGroup,
       normalizedDynamicFieldValues,
       normalizedDynamicFieldDateRanges,
       safeLimit,
@@ -394,6 +398,7 @@ export const useVespaTicketSearch = ({
     if (assignee) vespaFilters.assignee = assignee;
     if (tags) vespaFilters.tags = tags;
     if (createdBy) vespaFilters.from = createdBy;
+    if (userGroup) vespaFilters.userGroup = userGroup;
     if (normalizedDynamicFieldValues.length > 0) {
       vespaFilters.dynamicFieldValues = normalizedDynamicFieldValues;
     }
@@ -414,6 +419,7 @@ export const useVespaTicketSearch = ({
     assignee,
     tags,
     createdBy,
+    userGroup,
     normalizedDynamicFieldValues,
     normalizedDynamicFieldDateRanges,
   ]);

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.utils.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.utils.ts
@@ -397,8 +397,15 @@ export const applyTicketFilters = (
       }
     }
 
-    // User groups filter
-    if (filters.userGroups && filters.userGroups.length > 0) {
+    // User groups filter.
+    //
+    // '' means the group is UNKNOWN, not absent: search-backed rows are built by toTicket
+    // (useVespaTicketSearch) from Vespa's `lean` document summary, which does not project
+    // userGroupId, so it defaults to ''. Vespa already applied this filter server-side, so
+    // such a row cannot and need not be re-judged here — dropping it emptied the board (and
+    // with it the derived group list) when switching to assignee/priority grouping while a
+    // search was active. A Zero row that genuinely has no group is null and still drops.
+    if (filters.userGroups && filters.userGroups.length > 0 && ticket.userGroupId !== '') {
       if (!ticket.userGroupId || !filters.userGroups.includes(ticket.userGroupId)) {
         return false;
       }

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
@@ -298,95 +298,46 @@ export const buildKanbanTicketsPageArgs = (
 const normalizeIdentity = (value: string | null | undefined): string =>
   (value ?? '').replace(/^user:/, '');
 
-const matchesIdentityFilter = (
-  value: string | null | undefined,
-  filterValues: string[] | undefined,
-): boolean => {
-  if (!filterValues?.length) return true;
-  const normalizedValue = normalizeIdentity(value);
-  if (!normalizedValue) return false;
-  return filterValues.some(filterValue => normalizeIdentity(filterValue) === normalizedValue);
-};
+/** The filter values this search actually pushed down into the Vespa query. */
+interface VespaPushdownFilters {
+  boardId: string | undefined;
+  priority: string | undefined;
+  assignee: string | undefined;
+  createdBy: string | undefined;
+  userGroup: string | undefined;
+  tags: string | undefined;
+  stage: string | undefined;
+}
 
-// Assignee-specific: understands the "unassigned" sentinel and invert marker.
-const matchesAssigneeFilter = (
-  value: string | null | undefined,
-  filterValues: string[] | undefined,
-): boolean => {
-  if (!filterValues?.length) return true;
-  const { inverted, includeUnassigned, ids } = parseAssigneeFilter(filterValues);
-  if (!ids.length && !includeUnassigned) return true;
-  const normalizedValue = normalizeIdentity(value);
-  const matches = normalizedValue
-    ? ids.some(id => normalizeIdentity(id) === normalizedValue)
-    : includeUnassigned;
-  return inverted ? !matches : matches;
-};
-
-const getTicketTagNames = (ticket: KanbanTicketsPageRow): Set<string> => {
-  return new Set(
-    (ticket.tagMappings ?? []).map(m => m.tagName).filter((name): name is string => Boolean(name)),
-  );
-};
-
-const getLocalVespaFilterRejectReasons = (
-  ticket: KanbanTicketsPageRow,
+// True when some active filter could NOT be expressed in the Vespa query, so its rows
+// would come back unfiltered on that dimension.
+//
+// Rows returned by Vespa are now rendered exactly as received, with no client-side
+// re-filtering. Re-checking a filter here meant reading fields the `lean` document summary
+// does not carry — userGroupId and ticketType arrive undefined — so every row failed the
+// check and correct hits were silently dropped. Rather than re-filter against data we do
+// not have, anything Vespa could not apply falls back to the Zero page, which queries the
+// database and can filter on every column.
+const hasFiltersVespaCannotApply = (
   filters: TicketFilters | undefined,
-): string[] => {
-  const reasons: string[] = [];
-
-  if (filters?.priority?.length && !filters.priority.includes(ticket.priority)) {
-    reasons.push('priority');
-  }
-  if (filters?.boards?.length && !filters.boards.includes(ticket.boardId)) {
-    reasons.push('boards');
-  }
-  if (filters?.sourceChannels?.length && !filters.sourceChannels.includes(ticket.channelId)) {
-    reasons.push('sourceChannels');
-  }
-  if (!matchesAssigneeFilter(ticket.assignedTo, filters?.assignee)) {
-    reasons.push('assignee');
-  }
-  if (!matchesIdentityFilter(ticket.createdBy, filters?.createdBy)) {
-    reasons.push('createdBy');
-  }
-  if (filters?.userGroups?.length && !filters.userGroups.includes(ticket.userGroupId)) {
-    reasons.push('userGroups');
-  }
-  if (filters?.tags?.length) {
-    const ticketTagNames = getTicketTagNames(ticket);
-    if (!filters.tags.some(tag => ticketTagNames.has(tag))) {
-      reasons.push('tags');
-    }
-  }
-  if (filters?.stages?.length && !filters.stages.includes(ticket.stageName)) {
-    reasons.push('stages');
-  }
-  if (filters?.ticketTypes?.length && !filters.ticketTypes.includes(ticket.ticketType ?? '')) {
-    reasons.push('ticketTypes');
-  }
-
-  return reasons;
-};
-
-const applyLocalVespaFilters = (
-  rows: Ticket[] | null,
-  filters: TicketFilters | undefined,
-): KanbanTicketsPageRow[] | null => {
-  if (rows === null) return null;
-
-  const keptRows: KanbanTicketsPageRow[] = [];
-
-  (rows as KanbanTicketsPageRow[]).forEach(ticket => {
-    const rejectReasons = getLocalVespaFilterRejectReasons(ticket, filters);
-    if (rejectReasons.length > 0) {
-      return;
-    }
-
-    keptRows.push(ticket);
-  });
-
-  return keptRows;
+  pushdown: VespaPushdownFilters,
+): boolean => {
+  // Never sent to Vespa by this hook — only the Zero page can honour them.
+  // (ticketTypes is absent on purpose: it is not indexed in Vespa either, but the Zero
+  // overlay in overlaidDirectVespaPage applies it on top of the search results instead.)
+  if (filters?.sourceChannels?.length) return true;
+  // Sent only in representable cases (single board, non-inverted assignee, ...); when the
+  // pushdown value is undefined the filter is active but absent from the query.
+  if (filters?.boards?.length && !pushdown.boardId) return true;
+  if (filters?.priority?.length && !pushdown.priority) return true;
+  if (filters?.assignee?.length && !pushdown.assignee) return true;
+  if (filters?.createdBy?.length && !pushdown.createdBy) return true;
+  if (filters?.userGroups?.length && !pushdown.userGroup) return true;
+  if (filters?.tags?.length && !pushdown.tags) return true;
+  // Undefined here means the column stage and the stage filter do not intersect, so no
+  // single `stage` value can express the constraint.
+  if (filters?.stages?.length && !pushdown.stage) return true;
+  return false;
 };
 
 export const useKanbanTicketsPage = (
@@ -433,16 +384,6 @@ export const useKanbanTicketsPage = (
   const effectiveVespaBoardId =
     options.boardId ??
     (options.filters?.boards?.length === 1 ? options.filters.boards[0] : undefined);
-  const shouldUseDirectVespaRows =
-    requiresVespaTicketIds &&
-    !hasZeroOnlyFilters(
-      options.filters,
-      options.zeroOnlyDynamicFieldIds,
-      options.dynamicFieldDateRanges,
-    ) &&
-    canRepresentGroupInVespa(options.groupBy, options.groupKey) &&
-    !options.showOverdueOnly;
-
   // Convert filter arrays to comma-separated strings for Vespa (only if non-empty)
   const vespaPriority =
     options.filters?.priority && options.filters.priority.length > 0
@@ -468,6 +409,11 @@ export const useKanbanTicketsPage = (
   const vespaTags =
     options.filters?.tags && options.filters.tags.length > 0
       ? options.filters.tags.join(',')
+      : undefined;
+
+  const vespaUserGroup =
+    options.filters?.userGroups && options.filters.userGroups.length > 0
+      ? options.filters.userGroups.join(',')
       : undefined;
 
   // Send bare IDs - the backend expands to all identity forms for Vespa matching.
@@ -508,6 +454,45 @@ export const useKanbanTicketsPage = (
     typeof options.groupBy === 'object' && options.groupBy?.type === 'formField';
   const skipColumnFiltersForSearch = hasSearchTerm && !isFormFieldGroupBy;
 
+  // Stage filter, pushed into the YQL the same way userGroup/tags are (the backend binds
+  // each value as `stage contains @stage_N`, OR-ed together).
+  //
+  // A stage column pins its own stage, and the user's filter narrows which stages are
+  // shown, so the real constraint is the intersection of the two. An empty intersection
+  // means the column can hold nothing — that is not expressible as a `stage` value, so
+  // vespaStage stays undefined and hasFiltersVespaCannotApply routes it to the Zero page
+  // rather than sending no stage constraint at all (which would show every stage).
+  const selectedStages = options.filters?.stages ?? [];
+  const pinnedColumnStage =
+    !skipColumnFiltersForSearch && options.columnType === 'stage' ? options.stageName : undefined;
+  const effectiveStages = pinnedColumnStage
+    ? selectedStages.length === 0 || selectedStages.includes(pinnedColumnStage)
+      ? [pinnedColumnStage]
+      : []
+    : selectedStages;
+  const vespaStage = effectiveStages.length > 0 ? effectiveStages.join(',') : undefined;
+
+  // Declared after every pushdown value above, since it requires that each active filter
+  // made it into the Vespa query — direct-Vespa rows are rendered without re-filtering.
+  const shouldUseDirectVespaRows =
+    requiresVespaTicketIds &&
+    !hasZeroOnlyFilters(
+      options.filters,
+      options.zeroOnlyDynamicFieldIds,
+      options.dynamicFieldDateRanges,
+    ) &&
+    !hasFiltersVespaCannotApply(options.filters, {
+      boardId: effectiveVespaBoardId,
+      priority: vespaPriority,
+      assignee: vespaAssignee,
+      createdBy: vespaCreatedBy,
+      userGroup: vespaUserGroup,
+      tags: vespaTags,
+      stage: vespaStage,
+    }) &&
+    canRepresentGroupInVespa(options.groupBy, options.groupKey) &&
+    !options.showOverdueOnly;
+
   // Create a search key that changes when the group context changes
   // This forces the search to re-trigger when switching views
   // When searching without column filters, use a shared key so all columns share one search call
@@ -524,6 +509,8 @@ export const useKanbanTicketsPage = (
         assignee: vespaAssignee ?? '',
         tags: vespaTags ?? '',
         createdBy: vespaCreatedBy ?? '',
+        userGroup: vespaUserGroup ?? '',
+        stage: vespaStage ?? '',
         boards: options.filters?.boards ?? [],
         stages: options.filters?.stages ?? [],
         ticketTypes: options.filters?.ticketTypes ?? [],
@@ -555,26 +542,15 @@ export const useKanbanTicketsPage = (
     ...(!skipColumnFiltersForSearch && options.columnType === 'status'
       ? { status: options.stageName }
       : {}),
-    ...(!skipColumnFiltersForSearch && options.columnType === 'stage'
-      ? { stage: options.stageName }
-      : {}),
+    // Column stage intersected with the user's stage filter (see vespaStage above).
+    ...(vespaStage ? { stage: vespaStage } : {}),
     ...(vespaPriority ? { priority: vespaPriority } : {}),
     ...(vespaAssignee ? { assignee: vespaAssignee } : {}),
     ...(vespaTags ? { tags: vespaTags } : {}),
     ...(vespaCreatedBy ? { createdBy: vespaCreatedBy } : {}),
+    ...(vespaUserGroup ? { userGroup: vespaUserGroup } : {}),
     // Skip group filters when searching (will segregate in frontend)
     ...(!skipColumnFiltersForSearch ? vespaGroupFilter : {}),
-  });
-  const localFilterKey = JSON.stringify({
-    priority: options.filters?.priority ?? [],
-    boards: options.filters?.boards ?? [],
-    assignee: options.filters?.assignee ?? [],
-    userGroups: options.filters?.userGroups ?? [],
-    createdBy: options.filters?.createdBy ?? [],
-    tags: options.filters?.tags ?? [],
-    stages: options.filters?.stages ?? [],
-    ticketTypes: options.filters?.ticketTypes ?? [],
-    sourceChannels: options.filters?.sourceChannels ?? [],
   });
   const directVespaPage = useMemo(() => {
     if (!shouldUseDirectVespaRows) return null;
@@ -592,9 +568,10 @@ export const useKanbanTicketsPage = (
       results = results.filter(ticket => ticket.channelId === options.channelId);
     }
 
-    // Apply local filters (priority, boards, assignee, etc.)
-    const filtered = applyLocalVespaFilters(results, options.filters);
-    if (!filtered) return null;
+    // Render what Vespa returned. Every active filter was pushed down into the query
+    // (shouldUseDirectVespaRows routes the rest to the Zero page), so re-filtering here
+    // would only risk dropping correct rows on fields the lean summary omits.
+    const filtered = results as KanbanTicketsPageRow[];
 
     // When searching without column filters, segregate by stage/status in frontend
     if (skipColumnFiltersForSearch) {
@@ -635,7 +612,6 @@ export const useKanbanTicketsPage = (
 
     return filtered;
   }, [
-    localFilterKey,
     options.channelId,
     options.columnType,
     options.stageName,
@@ -719,8 +695,18 @@ export const useKanbanTicketsPage = (
   }, [liveDirectRows]);
   const overlaidDirectVespaPage = useMemo(() => {
     if (!shouldUseDirectVespaRows || directVespaPage === null) return directVespaPage;
-    if (liveDirectRowsById.size === 0) return directVespaPage;
-    return directVespaPage.map(ticket => {
+    if (directVespaPage.length === 0) return directVespaPage;
+
+    // ticketType is not indexed into Vespa, so it cannot be pushed down like the other
+    // filters. It is applied here instead, against the live Zero row rather than the Vespa
+    // payload — the same overlay that already corrects stage/status. Until those rows
+    // arrive there is nothing to match on, so report loading rather than briefly rendering
+    // the unfiltered Vespa set.
+    const ticketTypes = options.filters?.ticketTypes ?? [];
+    const filterByTicketType = ticketTypes.length > 0;
+    if (liveDirectRowsById.size === 0) return filterByTicketType ? null : directVespaPage;
+
+    const overlaid = directVespaPage.map(ticket => {
       const live = liveDirectRowsById.get(ticket.id);
       if (!live) return ticket;
       return {
@@ -730,13 +716,23 @@ export const useKanbanTicketsPage = (
         boardId: live.boardId,
         priority: live.priority,
         assignedTo: live.assignedTo,
+        ticketType: live.ticketType,
       };
     });
-  }, [shouldUseDirectVespaRows, directVespaPage, liveDirectRowsById]);
+
+    if (!filterByTicketType) return overlaid;
+    // A row with no live counterpart has no type to test, so it cannot satisfy the filter.
+    return overlaid.filter(
+      ticket => liveDirectRowsById.has(ticket.id) && ticketTypes.includes(ticket.ticketType ?? ''),
+    );
+  }, [shouldUseDirectVespaRows, directVespaPage, liveDirectRowsById, options.filters?.ticketTypes]);
 
   const effectivePage = shouldUseDirectVespaRows ? overlaidDirectVespaPage : page;
+  // Keyed off the page actually rendered, not directVespaPage: the overlay also returns
+  // null while it waits for the Zero rows the ticketType filter is evaluated against, and
+  // reporting 'complete' there would render an empty board instead of a loading state.
   const effectivePageDetailsType = shouldUseDirectVespaRows
-    ? directVespaPage === null
+    ? effectivePage === null
       ? 'unknown'
       : 'complete'
     : pageDetails.type;

--- a/apps/dashboard/src/services/searchService.ts
+++ b/apps/dashboard/src/services/searchService.ts
@@ -260,6 +260,10 @@ export class SearchService {
       params['assignee'] = filters.assignee;
     }
 
+    if (filters.userGroup) {
+      params['userGroup'] = filters.userGroup;
+    }
+
     if (filters.dynamicFieldValues) {
       params['dynamicFieldValues'] = Array.isArray(filters.dynamicFieldValues)
         ? filters.dynamicFieldValues.join(',')

--- a/apps/dashboard/src/types/search.ts
+++ b/apps/dashboard/src/types/search.ts
@@ -136,6 +136,7 @@ export interface VespaSearchFilters {
   range?: string; // Time keyword (today, yesterday, this week, last 7 days, etc.)
   stage?: string; // Ticket stage
   assignee?: string; // Assigned user ID
+  userGroup?: string; // User group ID(s) - comma-separated
   dynamicFieldValues?: string | string[]; // Comma-separated or array of fieldId::value tokens
   dynamicFieldDateRanges?: Record<string, { start?: number; end?: number }>;
   subApp?: string; // Comma-separated sub-apps: 'canvas', 'transcript', 'RCA'

--- a/vespa-core/vespa/common/schemas/ticket.sd
+++ b/vespa-core/vespa/common/schemas/ticket.sd
@@ -450,6 +450,7 @@ schema ticket {
     summary replyCount {}
     summary threadSenders {}
     summary formFields {}
+    summary tags {}
     # imported from channelRef
     summary channelId {}
     summary channelName {}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
