### PR TITLE
fix: XYNE-62348 workflow execution written to both schema

### DIFF
--- a/apps/backend/scripts/cleanup-sdlc-local.ts
+++ b/apps/backend/scripts/cleanup-sdlc-local.ts
@@ -410,6 +410,7 @@ async function main(): Promise<void> {
       ['public', 'canvas_folders', 'id', folders],
       ['public', 'repos', 'id', repoIds],
       ['public', 'workflow_executions', 'id', executionIds],
+      ['workflow', 'workflow_executions', 'id', executionIds],
       ['public', 'workflows', 'id', workflowIds],
       ['public', 'channels', 'id', channelIds],
     ];

--- a/apps/backend/src/database/client.ts
+++ b/apps/backend/src/database/client.ts
@@ -8,6 +8,7 @@ import { encryptionExtension } from '@/database/prisma-encryption-extension';
 import { setupMessageMetadataSync } from './middleware/messageMetadataSync';
 import { withAclExtension } from './tenant/acl-extension';
 import { withWorkspaceStamp } from './tenant/stamp';
+import { withWorkflowExecutionDualWrite } from './workflowExecutionDualWrite';
 import { setupTicketActivityChannelSync } from './middleware/ticketActivityChannelSync';
 import { setupTicketCreatedActivity } from './middleware/ticketCreatedActivity';
 import { setupUserVespaSync } from './middleware/userVespaSync';
@@ -89,7 +90,11 @@ export class DatabaseClient {
 
       // Apply zero field encryption extension (no-op when encryptedFieldsConfig is empty)
       DatabaseClient.instance = DatabaseClient.instance.$extends(encryptionExtension) as unknown as PrismaClient;
-      DatabaseClient.wrappedInstance = withWorkspaceStamp(withAclExtension(DatabaseClient.instance));
+      // Dual write sits below the ACL layer: $transaction runs on that layer, so its
+      // transaction clients must already carry the extension.
+      DatabaseClient.wrappedInstance = withWorkspaceStamp(
+        withAclExtension(withWorkflowExecutionDualWrite(DatabaseClient.instance))
+      );
     }
 
     return DatabaseClient.wrappedInstance ?? DatabaseClient.instance;

--- a/apps/backend/src/database/repositories/workflows.ts
+++ b/apps/backend/src/database/repositories/workflows.ts
@@ -24,6 +24,7 @@ import {
 } from './workflowExecutionStateUtils';
 import { syncConversationTicketMdFromPrismaTicket } from '@/utils/ticketMd';
 import { GENERIC_RECOVERY_EXCLUDED_WORKFLOW_TYPES } from '@/workflows/polling/workflowRecoveryPolicy';
+import { workflowSchemaUpsertFrom } from '@/database/workflowExecutionDualWrite';
 
 function buildClaimQuery(workflowType?: string, tags?: string[]): string {
   const tagFilter = tags && tags.length > 0
@@ -39,7 +40,7 @@ function buildClaimQuery(workflowType?: string, tags?: string[]): string {
   return `
     WITH claimed AS (
       SELECT "id"
-      FROM "workflow_executions"
+      FROM "public"."workflow_executions"
       WHERE "status" = 'PENDING'
       ${tagFilter}
       ${typeFilter}
@@ -48,11 +49,19 @@ function buildClaimQuery(workflowType?: string, tags?: string[]): string {
       LIMIT 1
       FOR UPDATE SKIP LOCKED
     )
-    UPDATE "workflow_executions"
-    SET "status" = 'RUNNING', "updatedAt" = NOW()
-    FROM claimed
-    WHERE "workflow_executions"."id" = claimed."id"
-    RETURNING "workflow_executions"."id"
+    , updated AS (
+      UPDATE "public"."workflow_executions"
+      SET "status" = 'RUNNING', "updatedAt" = NOW()
+      FROM claimed
+      WHERE "workflow_executions"."id" = claimed."id"
+      RETURNING "workflow_executions".*
+    )
+    -- Raw SQL bypasses the dual-write extension, so copy the claimed row here.
+    -- A data-modifying CTE always runs, in the same statement as the claim.
+    , copied AS (
+      ${workflowSchemaUpsertFrom('updated')}
+    )
+    SELECT "id" FROM updated
   `
 }
 

--- a/apps/backend/src/database/workflowExecutionDualWrite.ts
+++ b/apps/backend/src/database/workflowExecutionDualWrite.ts
@@ -1,0 +1,223 @@
+import { PrismaClient } from '@prisma/client';
+import { createId } from '@paralleldrive/cuid2';
+import { logger } from '@/utils/logger';
+
+/** Every column of workflow_executions, identical in both schemas. */
+const COLUMNS = [
+  'workspaceId',
+  'id',
+  'workflowId',
+  'workflowType',
+  'context',
+  'status',
+  'output',
+  'parentWorkflowExecutionId',
+  'sourceStepsId',
+  'stepInputOverrideData',
+  'tag',
+  'createdAt',
+  'updatedAt',
+  'ignoreDuration',
+  'mode',
+  'createdBy',
+] as const;
+
+const COLUMN_LIST = COLUMNS.map((column) => `"${column}"`).join(', ');
+const UPDATE_LIST = COLUMNS.filter((column) => column !== 'id')
+  .map((column) => `"${column}" = EXCLUDED."${column}"`)
+  .join(', ');
+
+/**
+ * `INSERT INTO workflow.workflow_executions ... SELECT ... FROM <source>`, overwriting
+ * rows that already exist. `source` is any relation carrying all the columns: a table,
+ * or a CTE such as `updated` from an `UPDATE ... RETURNING *`.
+ */
+export function workflowSchemaUpsertFrom(source: string, where = ''): string {
+  return (
+    `INSERT INTO "workflow"."workflow_executions" (${COLUMN_LIST}) ` +
+    `SELECT ${COLUMN_LIST} FROM ${source} ${where} ` +
+    `ON CONFLICT ("id") DO UPDATE SET ${UPDATE_LIST}`
+  );
+}
+
+const COPY_BY_ID_SQL = workflowSchemaUpsertFrom(
+  '"public"."workflow_executions"',
+  'WHERE "id" = ANY($1::text[])'
+);
+const DELETE_BY_ID_SQL = 'DELETE FROM "workflow"."workflow_executions" WHERE "id" = ANY($1::text[])';
+const DELETE_BY_WORKFLOW_SQL =
+  'DELETE FROM "workflow"."workflow_executions" WHERE "workflowId" = ANY($1::text[])';
+
+type Row = Record<string, unknown>;
+
+/** The raw-query and lookup surface used for the copy, bound to the caller's transaction. */
+type Runner = Pick<PrismaClient, '$executeRawUnsafe' | 'workflowExecution' | 'workflow'>;
+
+/** Prisma's per-request internals; `transaction` identifies the caller's transaction. */
+type InternalParams = { transaction?: { kind: 'itx' | 'batch' } };
+
+type OperationParams = {
+  operation: string;
+  args: Row | undefined;
+  query: (args: unknown) => Promise<unknown>;
+  __internalParams?: InternalParams;
+};
+
+function idOf(where: unknown): string | null {
+  const id = (where as Row | undefined)?.id;
+  return typeof id === 'string' ? id : null;
+}
+
+/**
+ * Make sure `id` comes back from a create even when the caller selected other fields,
+ * and hide it again afterwards so the caller sees exactly what it asked for.
+ */
+function withIdSelected(args: Row | undefined): { args: Row; strip: <T>(row: T) => T } {
+  const select = args?.select as Row | undefined;
+  if (!select || select.id) return { args: args ?? {}, strip: (row) => row };
+  return {
+    args: { ...args, select: { ...select, id: true } },
+    strip: (row) => {
+      if (row && typeof row === 'object') delete (row as Row).id;
+      return row;
+    },
+  };
+}
+
+function rowsOf(data: unknown): Row[] {
+  if (Array.isArray(data)) return data as Row[];
+  return data ? [data as Row] : [];
+}
+
+export function withWorkflowExecutionDualWrite<T extends PrismaClient>(prisma: T): T {
+  const base = prisma as unknown as PrismaClient & { _createItxClient?: (tx: unknown) => Runner };
+  if (typeof base._createItxClient !== 'function') {
+    throw new Error('[workflow-executions] Prisma _createItxClient is unavailable; dual write cannot join transactions');
+  }
+
+  const runnerFor = (params: OperationParams): { runner: Runner; inTransaction: boolean } => {
+    const tx = params.__internalParams?.transaction;
+    if (tx?.kind === 'itx') return { runner: base._createItxClient!(tx), inTransaction: true };
+    return { runner: base, inTransaction: false };
+  };
+
+  const run = async (
+    runner: Runner,
+    inTransaction: boolean,
+    sql: string,
+    ids: string[],
+    operation: string
+  ): Promise<void> => {
+    if (ids.length === 0) return;
+    try {
+      await runner.$executeRawUnsafe(sql, ids);
+    } catch (error) {
+      // In a transaction, fail it so both tables roll back together.
+      if (inTransaction) throw error;
+      logger.error('[workflow-executions] copy to workflow schema failed; run the sync script', {
+        operation,
+        ids,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  return prisma.$extends({
+    query: {
+      workflowExecution: {
+        async $allOperations(params) {
+          const p = params as unknown as OperationParams;
+          const { operation, args, query } = p;
+          const { runner, inTransaction } = runnerFor(p);
+          const copy = (ids: string[]) => run(runner, inTransaction, COPY_BY_ID_SQL, ids, operation);
+
+          switch (operation) {
+            case 'create': {
+              const selected = withIdSelected(args);
+              const created = (await query(selected.args)) as Row;
+              await copy([created.id as string]);
+              return selected.strip(created);
+            }
+            case 'createManyAndReturn': {
+              const selected = withIdSelected(args);
+              const created = (await query(selected.args)) as Row[];
+              await copy(created.map((row) => row.id as string));
+              return created.map((row) => selected.strip(row));
+            }
+            case 'createMany': {
+              // createMany returns only a count, so give every row its id up front.
+              const data = rowsOf(args?.data).map((row) => (row.id ? row : { ...row, id: createId() }));
+              const result = await query({ ...args, data });
+              await copy(data.map((row) => row.id as string));
+              return result;
+            }
+            case 'update':
+            case 'upsert': {
+              const id = idOf(args?.where);
+              if (id) {
+                const result = await query(args);
+                await copy([id]);
+                return result;
+              }
+              const selected = withIdSelected(args);
+              const result = (await query(selected.args)) as Row;
+              await copy([result.id as string]);
+              return selected.strip(result);
+            }
+            case 'updateMany': {
+              // Collect the matching ids first: the update may change the very columns
+              // the filter matches on.
+              const ids = await runner.workflowExecution.findMany({
+                where: args?.where as never,
+                select: { id: true },
+              });
+              const result = await query(args);
+              await copy(ids.map((row) => row.id));
+              return result;
+            }
+            case 'delete': {
+              const id =
+                idOf(args?.where) ??
+                (await runner.workflowExecution.findFirst({ where: args?.where as never, select: { id: true } }))?.id;
+              const result = await query(args);
+              await run(runner, inTransaction, DELETE_BY_ID_SQL, id ? [id] : [], operation);
+              return result;
+            }
+            case 'deleteMany': {
+              const ids = await runner.workflowExecution.findMany({
+                where: args?.where as never,
+                select: { id: true },
+              });
+              const result = await query(args);
+              await run(runner, inTransaction, DELETE_BY_ID_SQL, ids.map((row) => row.id), operation);
+              return result;
+            }
+            default:
+              return query(args);
+          }
+        },
+      },
+      workflow: {
+        async $allOperations(params) {
+          const p = params as unknown as OperationParams;
+          const { operation, args, query } = p;
+          if (operation !== 'delete' && operation !== 'deleteMany') return query(args);
+
+          const { runner, inTransaction } = runnerFor(p);
+          const workflowIds =
+            operation === 'delete'
+              ? [
+                  idOf(args?.where) ??
+                    (await runner.workflow.findFirst({ where: args?.where as never, select: { id: true } }))?.id,
+                ].filter((id): id is string => typeof id === 'string')
+              : (await runner.workflow.findMany({ where: args?.where as never, select: { id: true } })).map(
+                  (row) => row.id
+                );
+          const result = await query(args);
+          await run(runner, inTransaction, DELETE_BY_WORKFLOW_SQL, workflowIds, `workflow.${operation}`);
+          return result;
+        },
+      },
+    },
+  }) as unknown as T;
+}

--- a/apps/backend/src/workflowsV2/adapters/persistence.ts
+++ b/apps/backend/src/workflowsV2/adapters/persistence.ts
@@ -9,7 +9,7 @@
  *
  * Storage map:
  *   workflows        -> public.workflows              (config in `context`, NOT `configuration`)
- *   executions       -> public.workflow_executions
+ *   executions       -> public.workflow_executions  (copied to workflow.workflow_executions)
  *   execution_states -> workflow.workflow_execution_states
  *   step_records     -> workflow.workflow_steps       (node-paths in `stepName`)
  *   folders          -> workflow.workflow_folders


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
