### PR TITLE
feature: xyne 63214 add ai providers from chat

### DIFF
--- a/apps/dashboard/src/components/AppSidebar/ChatQuickMenu.tsx
+++ b/apps/dashboard/src/components/AppSidebar/ChatQuickMenu.tsx
@@ -1,60 +1,9 @@
-import { createElement, useMemo, type ReactElement } from 'react';
+import { type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import {
-  ChatPlus,
-  Subtask,
-  ChatTyping,
-  BookmarkDefault,
-  SendPlaneSlant,
-  ListAiGenerated,
-} from '@xyne/icons';
-import { Radar as RadarIcon } from 'lucide-react';
-import { type PikaIconProps } from '@xyne/icons';
-import { type PikaIcon } from './navigationConfig';
 import { useAuth } from '../../hooks/useAuth';
 import { useRadarEnabled } from '../../hooks/radarCacConfig';
+import { chatNavItems } from './navigationConfig';
 import { QUICK_NAV_ROW_CLASS, QuickNavList } from './RailQuickNav';
-
-// @xyne/icons has no radar glyph, so this borrows lucide's the way
-// AudioWaveIcon does in navigationConfig — `variant` is dropped rather than
-// passed through to the <svg>.
-const RadarNavIcon = ({ variant: _variant, ...props }: PikaIconProps): ReactElement =>
-  createElement(RadarIcon, props);
-
-const CHAT_NAV_ITEMS: {
-  key: string;
-  label: string;
-  to: string;
-  icon: PikaIcon;
-  replace?: boolean;
-}[] = [
-  {
-    key: 'new-message',
-    label: 'New Message',
-    to: '/chat/search?mode=dm',
-    icon: ChatPlus,
-    replace: true,
-  },
-  { key: 'threads', label: 'Threads', to: '/chat/dir/threads', icon: Subtask },
-  { key: 'unreads', label: 'Unreads', to: '/chat/dir/unreads', icon: ChatTyping },
-  { key: 'bookmarks', label: 'Bookmarks', to: '/chat/bookmarks', icon: BookmarkDefault },
-  { key: 'drafts-sent', label: 'Drafts & Sent', to: '/chat/drafts-sent', icon: SendPlaneSlant },
-  { key: 'recap', label: 'Recap', to: '/chat/dir/recap', icon: ListAiGenerated },
-  { key: 'radar', label: 'Radar', to: '/chat/dir/radar', icon: RadarNavIcon },
-];
-
-/**
- * The rows this user may actually open. Radar's route is registered
- * unconditionally (the rollout gate lives inside RadarPanel), so the CAC check
- * has to drop the row here or people outside the rollout get a dead link.
- */
-const useChatNavItems = (): typeof CHAT_NAV_ITEMS => {
-  const radarEnabled = useRadarEnabled(useAuth().user?.email);
-  return useMemo(
-    () => CHAT_NAV_ITEMS.filter(item => item.key !== 'radar' || radarEnabled),
-    [radarEnabled],
-  );
-};
 
 export const ChatQuickMenu = ({
   prefixWs,
@@ -64,28 +13,33 @@ export const ChatQuickMenu = ({
   prefixWs: (path: string) => string;
   onNavigate?: (label: string) => void;
   onDismiss?: () => void;
-}): ReactElement => (
-  <QuickNavList heading='Chat'>
-    {useChatNavItems().map(item => {
-      const Icon = item.icon;
-      return (
-        <Link
-          key={item.key}
-          to={prefixWs(item.to)}
-          replace={item.replace ?? false}
-          onClick={() => {
-            onNavigate?.(item.label);
-            onDismiss?.();
-          }}
-          className={QUICK_NAV_ROW_CLASS}
-          data-track-category='App_Sidebar'
-          data-track-name='Chat_Quick_Nav'
-          data-track-metadata={JSON.stringify({ path: item.to, label: item.label })}
-        >
-          <Icon size={16} className='shrink-0' aria-hidden />
-          {item.label}
-        </Link>
-      );
-    })}
-  </QuickNavList>
-);
+}): ReactElement => {
+  const auth = useAuth();
+  const radarEnabled = useRadarEnabled(auth.user?.email);
+
+  return (
+    <QuickNavList heading='Chat'>
+      {chatNavItems(radarEnabled).map(item => {
+        const Icon = item.icon;
+        return (
+          <Link
+            key={item.key}
+            to={prefixWs(item.to)}
+            replace={item.replace ?? false}
+            onClick={() => {
+              onNavigate?.(item.label);
+              onDismiss?.();
+            }}
+            className={QUICK_NAV_ROW_CLASS}
+            data-track-category='App_Sidebar'
+            data-track-name='Chat_Quick_Nav'
+            data-track-metadata={JSON.stringify({ path: item.to, label: item.label })}
+          >
+            <Icon size={16} className='shrink-0' aria-hidden />
+            {item.label}
+          </Link>
+        );
+      })}
+    </QuickNavList>
+  );
+};

--- a/apps/dashboard/src/components/AppSidebar/navigationConfig.ts
+++ b/apps/dashboard/src/components/AppSidebar/navigationConfig.ts
@@ -32,8 +32,14 @@ import {
   GitBranch,
   type PikaIconProps,
   Tag,
+  ChatPlus,
+  Subtask,
+  ChatTyping,
+  BookmarkDefault,
+  SendPlaneSlant,
+  ListAiGenerated,
 } from '@xyne/icons';
-import { AudioLines } from 'lucide-react';
+import { AudioLines, Radar } from 'lucide-react';
 
 import { PATH_TO_RESOURCE } from './utils/resourceMapping';
 import { isElectronApp } from '../../utils/electronApp';
@@ -48,6 +54,87 @@ export type PikaIcon = ComponentType<PikaIconProps>;
 // pair, so `variant` is dropped here rather than passed through to the <svg>.
 const AudioWaveIcon = ({ variant: _variant, ...props }: PikaIconProps): ReactElement =>
   createElement(AudioLines, props);
+
+const RadarNavIcon = ({ variant: _variant, ...props }: PikaIconProps): ReactElement =>
+  createElement(Radar, props);
+
+export type ChatNavKey =
+  | 'new-message'
+  | 'threads'
+  | 'unreads'
+  | 'bookmarks'
+  | 'drafts-sent'
+  | 'recap'
+  | 'radar';
+
+export interface ChatNavItem {
+  key: ChatNavKey;
+  label: string;
+  to: string;
+  icon: PikaIcon;
+  trackName: string;
+  replace?: boolean;
+  sidebarTo?: string;
+  requiresRadar?: boolean;
+}
+
+export const CHAT_NAV_ITEMS: ChatNavItem[] = [
+  {
+    key: 'new-message',
+    label: 'New Message',
+    to: '/chat/search?mode=dm',
+    icon: ChatPlus,
+    trackName: 'NEW_MESSAGE',
+    replace: true,
+  },
+  {
+    key: 'threads',
+    label: 'Threads',
+    to: '/chat/dir/threads',
+    icon: Subtask,
+    trackName: 'OPEN_THREADS',
+  },
+  {
+    key: 'unreads',
+    label: 'Unreads',
+    to: '/chat/dir/unreads',
+    icon: ChatTyping,
+    trackName: 'OPEN_UNREADS',
+  },
+  {
+    key: 'bookmarks',
+    label: 'Bookmarks',
+    to: '/chat/bookmarks',
+    icon: BookmarkDefault,
+    trackName: 'OPEN_BOOKMARKS',
+  },
+  {
+    key: 'drafts-sent',
+    label: 'Drafts & Sent',
+    to: '/chat/drafts-sent',
+    icon: SendPlaneSlant,
+    trackName: 'OPEN_DRAFTS_AND_SENT',
+    sidebarTo: 'drafts-sent',
+  },
+  {
+    key: 'recap',
+    label: 'Recap',
+    to: '/chat/dir/recap',
+    icon: ListAiGenerated,
+    trackName: 'OPEN_RECAP',
+  },
+  {
+    key: 'radar',
+    label: 'Radar',
+    to: '/chat/dir/radar',
+    icon: RadarNavIcon,
+    trackName: 'OPEN_RADAR',
+    requiresRadar: true,
+  },
+];
+
+export const chatNavItems = (radarEnabled: boolean): ChatNavItem[] =>
+  CHAT_NAV_ITEMS.filter(item => !item.requiresRadar || radarEnabled);
 
 export const RAIL_SHORTCUT_LIMIT = 9;
 export const railShortcutsAvailable = (): boolean => isElectronApp();

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
@@ -9,18 +9,11 @@ import {
   type ComponentType,
 } from 'react';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
-import { Radar as RadarIcon } from 'lucide-react';
 import { useRadarEnabled } from '../../../hooks/radarCacConfig';
 import { useLastVisitedChannel } from '../../../hooks/useLastVisitedChannel';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { useShortcutById } from '../../../shortcuts';
 import {
-  ChatPlus,
-  Subtask,
-  ChatTyping,
-  BookmarkDefault,
-  SendPlaneSlant,
-  ListAiGenerated,
   ChevronRight,
   PlusDefault,
   FolderPlus,
@@ -95,6 +88,8 @@ import SortableChannelItem from './SortableChannelItem';
 import ChannelItemV2 from './ChannelItemV2';
 import Tooltip from '../../ui/Tooltip';
 import { ShortcutHint } from '../../ui/ShortcutHint';
+import type { ShortcutId } from '../../../shortcuts';
+import { chatNavItems, type ChatNavKey } from '../../AppSidebar/navigationConfig';
 import ChannelCommandMenu from './ChannelCommandMenu';
 import AppNavigator from '../../AppNavigator/AppNavigator';
 import { useThreadSidebarState } from '../../../hooks/useUnreadThreadsCount';
@@ -212,6 +207,18 @@ const GroupSettingsMenu = ({
       </DropdownMenuContent>
     </DropdownMenu>
   );
+};
+
+const CHAT_NAV_ROW_DEFAULT_CLASS = 'text-sidebar-foreground hover:text-sidebar-accent-foreground';
+
+const CHAT_NAV_TEST_IDS: Partial<Record<ChatNavKey, string>> = {
+  bookmarks: 'open-bookmarks-button',
+  'drafts-sent': 'open-drafts-and-sent-button',
+};
+
+const CHAT_NAV_SHORTCUTS: Partial<Record<ChatNavKey, ShortcutId>> = {
+  'new-message': 'global.composeMessage',
+  threads: 'global.openThreads',
 };
 
 const ChatDirectory = ({
@@ -623,6 +630,63 @@ const ChatDirectory = ({
     createDmMutation.mutate(dmRequest);
   };
 
+  const chatNavStateClass = (key: ChatNavKey): string => {
+    switch (key) {
+      case 'threads':
+        return hasUnreadThreads
+          ? 'text-sidebar-accent-foreground font-semibold'
+          : CHAT_NAV_ROW_DEFAULT_CLASS;
+      case 'unreads':
+        return location.pathname.includes('/chat/dir/unreads')
+          ? 'text-sidebar-accent-foreground font-medium bg-sidebar-accent'
+          : unreadActivityStats.hasUnread
+            ? 'text-sidebar-accent-foreground font-semibold'
+            : CHAT_NAV_ROW_DEFAULT_CLASS;
+      case 'bookmarks':
+        return overdueRemindersCount > 0
+          ? 'text-sidebar-accent-foreground font-semibold'
+          : CHAT_NAV_ROW_DEFAULT_CLASS;
+      case 'drafts-sent':
+        return location.pathname.endsWith('/chat/drafts-sent')
+          ? 'text-sidebar-accent-foreground'
+          : CHAT_NAV_ROW_DEFAULT_CLASS;
+      case 'recap':
+        return recapUnreadCount > 0
+          ? 'text-sidebar-accent-foreground font-semibold'
+          : CHAT_NAV_ROW_DEFAULT_CLASS;
+      case 'radar':
+        return location.pathname.includes('/chat/dir/radar')
+          ? 'text-sidebar-accent-foreground font-semibold bg-sidebar-accent'
+          : CHAT_NAV_ROW_DEFAULT_CLASS;
+      default:
+        return CHAT_NAV_ROW_DEFAULT_CLASS;
+    }
+  };
+
+  const chatNavBadgeCount = (key: ChatNavKey): number => {
+    switch (key) {
+      case 'threads':
+        return threadCount;
+      case 'bookmarks':
+        return overdueRemindersCount;
+      case 'recap':
+        return recapUnreadCount;
+      default:
+        return 0;
+    }
+  };
+
+  const chatNavTrackMetadata = (key: ChatNavKey): string | undefined => {
+    switch (key) {
+      case 'threads':
+        return JSON.stringify({ threadCount, hasUnreadThreads });
+      case 'bookmarks':
+        return JSON.stringify({ overdueRemindersCount });
+      default:
+        return undefined;
+    }
+  };
+
   return (
     <div className={cn('h-full w-full flex flex-col', isMobile && 'bg-sidebar')}>
       <div className='w-full h-[52px] shrink-0'>
@@ -666,189 +730,61 @@ const ChatDirectory = ({
           className='flex-1 h-full overflow-y-scroll no-scrollbar pb-[calc(2.5rem+env(safe-area-inset-bottom))] px-0.5 pt-1 outline-none'
         >
           <div className='hidden md:block'>
-            <button
-              className={cn(
-                'flex items-center justify-start gap-3 w-full px-3 py-2 text-sm font-medium tracking-[-0.14px] rounded-[10px] border border-transparent transition-colors hover:bg-sidebar-accent hover:border-sidebar-border',
-                'text-sidebar-foreground hover:text-sidebar-accent-foreground',
-              )}
-              onClick={() => {
-                void navigate('/chat/search?mode=dm', { replace: true });
-              }}
-              data-track-category='CHAT_SIDEBAR'
-              data-track-name='NEW_MESSAGE'
-            >
-              <span className='size-4 flex items-center justify-center shrink-0'>
-                <ChatPlus className='size-4' />
-              </span>
-              <span className='flex-1 min-w-0 text-left truncate block'>New Message</span>
-              <ShortcutHint shortcut='global.composeMessage' />
-            </button>
-            <button
-              className={cn(
-                'flex items-center justify-start gap-3 w-full px-3 py-2 text-sm font-medium tracking-[-0.14px] rounded-[10px] border border-transparent transition-colors hover:bg-sidebar-accent hover:border-sidebar-border',
-                hasUnreadThreads
-                  ? 'text-sidebar-accent-foreground font-semibold'
-                  : 'text-sidebar-foreground hover:text-sidebar-accent-foreground',
-              )}
-              onClick={() => {
-                void navigate('/chat/dir/threads');
-              }}
-              data-track-category='CHAT_SIDEBAR'
-              data-track-name='OPEN_THREADS'
-              data-track-metadata={JSON.stringify({ threadCount, hasUnreadThreads })}
-            >
-              <span className='size-4 flex items-center justify-center shrink-0'>
-                <Subtask className='size-4' />
-              </span>
-              <span className='flex-1 min-w-0 text-left truncate block'>Threads</span>
-              <ShortcutHint shortcut='global.openThreads' />
-              {threadCount > 0 && (
-                <span className='size-5 flex items-center justify-center shrink-0'>
-                  <Badge
-                    variant='success'
-                    className='text-xs h-[18px] px-[6px] py-[1px] bg-sidebar-primary border border-sidebar-accent-ring text-sidebar-primary-foreground'
-                  >
-                    {threadCount > 10 ? '10+' : threadCount}
-                  </Badge>
-                </span>
-              )}
-            </button>
-            <button
-              className={cn(
-                'flex items-center justify-start gap-3 w-full px-3 py-2 text-sm font-medium tracking-[-0.14px] rounded-[10px] border border-transparent transition-colors hover:bg-sidebar-accent hover:border-sidebar-border',
-                location.pathname.includes('/chat/dir/unreads')
-                  ? 'text-sidebar-accent-foreground font-medium bg-sidebar-accent'
-                  : unreadActivityStats.hasUnread
-                    ? 'text-sidebar-accent-foreground font-semibold'
-                    : 'text-sidebar-foreground hover:text-sidebar-accent-foreground',
-              )}
-              onClick={() => {
-                void navigate('/chat/dir/unreads');
-              }}
-              data-track-category='CHAT_SIDEBAR'
-              data-track-name='OPEN_UNREADS'
-            >
-              <span className='size-4 flex items-center justify-center shrink-0'>
-                <ChatTyping className='size-4' />
-              </span>
-              <span className='flex-1 min-w-0 text-left truncate block'>Unreads</span>
-            </button>
-            <button
-              className={cn(
-                'flex items-center justify-start gap-3 w-full px-3 py-2 text-sm font-medium tracking-[-0.14px] rounded-[10px] border border-transparent transition-colors hover:bg-sidebar-accent hover:border-sidebar-border',
-                overdueRemindersCount > 0
-                  ? 'text-sidebar-accent-foreground font-semibold'
-                  : 'text-sidebar-foreground hover:text-sidebar-accent-foreground',
-              )}
-              onClick={() => {
-                void navigate('/chat/bookmarks');
-              }}
-              data-testid='open-bookmarks-button'
-              data-track-category='CHAT_SIDEBAR'
-              data-track-name='OPEN_BOOKMARKS'
-              data-track-metadata={JSON.stringify({ overdueRemindersCount })}
-            >
-              <span className='size-4 flex items-center justify-center shrink-0'>
-                <BookmarkDefault className='size-4' />
-              </span>
-              <span className='flex-1 min-w-0 text-left truncate block'>Bookmarks</span>
-              {overdueRemindersCount > 0 && (
-                <span className='size-5 flex items-center justify-center shrink-0'>
-                  <Badge
-                    variant='success'
-                    className='text-xs h-[18px] px-[6px] py-[1px] bg-sidebar-primary border border-sidebar-accent-ring text-sidebar-primary-foreground'
-                  >
-                    {overdueRemindersCount > 10 ? '10+' : overdueRemindersCount}
-                  </Badge>
-                </span>
-              )}
-            </button>
-            <button
-              className={cn(
-                'flex items-center justify-start gap-3 w-full px-3 py-2 text-sm font-medium tracking-[-0.14px] rounded-[10px] border border-transparent transition-colors hover:bg-sidebar-accent hover:border-sidebar-border',
-                location.pathname.endsWith('/chat/drafts-sent')
-                  ? 'text-sidebar-accent-foreground'
-                  : 'text-sidebar-foreground hover:text-sidebar-accent-foreground',
-              )}
-              onClick={() => {
-                void navigate('drafts-sent');
-              }}
-              data-testid='open-drafts-and-sent-button'
-              data-track-category='CHAT_SIDEBAR'
-              data-track-name='OPEN_DRAFTS_AND_SENT'
-            >
-              <span className='size-4 flex items-center justify-center shrink-0'>
-                <SendPlaneSlant className='size-4' />
-              </span>
-              <span className='flex-1 min-w-0 text-left truncate block'>Drafts &amp; Sent</span>
-              <span className='flex items-center gap-2 text-sidebar-foreground'>
-                {draftsCount > 0 && (
-                  <span className='flex items-center gap-1 text-xs'>
-                    <PencilEdit size={12} />
-                    {draftsCount}
+            {chatNavItems(radarEnabled).map(item => {
+              const Icon = item.icon;
+              const shortcut = CHAT_NAV_SHORTCUTS[item.key];
+              const badgeCount = chatNavBadgeCount(item.key);
+              return (
+                <button
+                  key={item.key}
+                  className={cn(
+                    'flex items-center justify-start gap-3 w-full px-3 py-2 text-sm font-medium tracking-[-0.14px] rounded-[10px] border border-transparent transition-colors hover:bg-sidebar-accent hover:border-sidebar-border',
+                    chatNavStateClass(item.key),
+                  )}
+                  onClick={() => {
+                    const to = item.sidebarTo ?? item.to;
+                    void (item.replace ? navigate(to, { replace: true }) : navigate(to));
+                  }}
+                  onMouseEnter={item.key === 'recap' ? prefetchRecap : undefined}
+                  data-testid={CHAT_NAV_TEST_IDS[item.key]}
+                  data-track-category='CHAT_SIDEBAR'
+                  data-track-name={item.trackName}
+                  data-track-metadata={chatNavTrackMetadata(item.key)}
+                >
+                  <span className='size-4 flex items-center justify-center shrink-0'>
+                    <Icon className='size-4' />
                   </span>
-                )}
-                {pendingScheduledCount > 0 && (
-                  <span className='flex items-center gap-1 text-xs'>
-                    <ClockDefault size={12} />
-                    {pendingScheduledCount}
-                  </span>
-                )}
-              </span>
-            </button>
-            <button
-              className={cn(
-                'flex items-center justify-start gap-3 w-full px-3 py-2 text-sm font-medium tracking-[-0.14px] rounded-[10px] border border-transparent transition-colors hover:bg-sidebar-accent hover:border-sidebar-border',
-                recapUnreadCount > 0
-                  ? 'text-sidebar-accent-foreground font-semibold'
-                  : 'text-sidebar-foreground hover:text-sidebar-accent-foreground',
-              )}
-              onMouseEnter={() => {
-                // Pre-fetch recap data on hover for instant load
-                prefetchRecap();
-              }}
-              onClick={() => {
-                // Always navigate to recap page first
-                void navigate('/chat/dir/recap');
-              }}
-              data-track-category='CHAT_SIDEBAR'
-              data-track-name='OPEN_RECAP'
-            >
-              <span className='size-4 flex items-center justify-center shrink-0'>
-                <ListAiGenerated className='size-4' />
-              </span>
-              <span className='flex-1 min-w-0 text-left truncate block'>Recap</span>
-              {recapUnreadCount > 0 && (
-                <span className='size-5 flex items-center justify-center shrink-0'>
-                  <Badge
-                    variant='success'
-                    className='text-xs h-[18px] px-[6px] py-[1px] bg-sidebar-primary border border-sidebar-accent-ring text-sidebar-primary-foreground'
-                  >
-                    {recapUnreadCount > 10 ? '10+' : recapUnreadCount}
-                  </Badge>
-                </span>
-              )}
-            </button>
-            {radarEnabled && (
-              <button
-                className={cn(
-                  'flex items-center justify-start gap-3 w-full px-3 py-2 text-sm font-medium tracking-[-0.14px] rounded-[10px] border border-transparent transition-colors hover:bg-sidebar-accent hover:border-sidebar-border',
-                  location.pathname.includes('/chat/dir/radar')
-                    ? 'text-sidebar-accent-foreground font-semibold bg-sidebar-accent'
-                    : 'text-sidebar-foreground hover:text-sidebar-accent-foreground',
-                )}
-                onClick={() => {
-                  void navigate('/chat/dir/radar');
-                }}
-                data-track-category='CHAT_SIDEBAR'
-                data-track-name='OPEN_RADAR'
-              >
-                <span className='size-4 flex items-center justify-center shrink-0'>
-                  <RadarIcon className='size-4' />
-                </span>
-                <span className='flex-1 min-w-0 text-left truncate block'>Radar</span>
-              </button>
-            )}
+                  <span className='flex-1 min-w-0 text-left truncate block'>{item.label}</span>
+                  {shortcut !== undefined && <ShortcutHint shortcut={shortcut} />}
+                  {item.key === 'drafts-sent' && (
+                    <span className='flex items-center gap-2 text-sidebar-foreground'>
+                      {draftsCount > 0 && (
+                        <span className='flex items-center gap-1 text-xs'>
+                          <PencilEdit size={12} />
+                          {draftsCount}
+                        </span>
+                      )}
+                      {pendingScheduledCount > 0 && (
+                        <span className='flex items-center gap-1 text-xs'>
+                          <ClockDefault size={12} />
+                          {pendingScheduledCount}
+                        </span>
+                      )}
+                    </span>
+                  )}
+                  {badgeCount > 0 && (
+                    <span className='size-5 flex items-center justify-center shrink-0'>
+                      <Badge
+                        variant='success'
+                        className='text-xs h-[18px] px-[6px] py-[1px] bg-sidebar-primary border border-sidebar-accent-ring text-sidebar-primary-foreground'
+                      >
+                        {badgeCount > 10 ? '10+' : badgeCount}
+                      </Badge>
+                    </span>
+                  )}
+                </button>
+              );
+            })}
           </div>
 
           <div className='py-3 w-full hidden md:block' />

--- a/apps/dashboard/src/components/flowUI/nodes/McpSuggestNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/McpSuggestNode.tsx
@@ -156,7 +156,11 @@ export const McpSuggestNode: React.FC<{ node: FlowComponent; children?: React.Re
                 </Link>
 
                 {isConnected ? (
-                  <span className='shrink-0 rounded-lg px-2 py-1 text-xs font-medium leading-5 text-muted-foreground'>
+                  <span className='flex shrink-0 items-center gap-1.5 rounded-lg px-2 py-1 text-xs font-medium leading-5 text-status-success'>
+                    <span
+                      className='size-[6px] shrink-0 rounded-full bg-status-success'
+                      aria-hidden
+                    />
                     Connected
                   </span>
                 ) : (

--- a/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
+++ b/apps/dashboard/src/components/flowUI/nodes/NodeRegistry.ts
@@ -24,6 +24,7 @@ import { ChartNode } from './ChartNode';
 import { AgentNode } from './AgentNode';
 import { AgentSummaryNode } from './AgentSummaryNode';
 import { McpSuggestNode } from './McpSuggestNode';
+import { ProviderSuggestNode } from './ProviderSuggestNode';
 import { McpConfigureNode } from './McpConfigureNode';
 import { SlashCommandArtifactNode } from '../../Chat/SlashCommandArtifacts';
 // PrApprovalNode is intentionally NOT imported/registered for now — the component
@@ -82,6 +83,7 @@ NodeRegistry.register('chart', ChartNode);
 NodeRegistry.register('agent', AgentNode);
 NodeRegistry.register('agent_summary', AgentSummaryNode);
 NodeRegistry.register('mcp_suggest', McpSuggestNode);
+NodeRegistry.register('provider_suggest', ProviderSuggestNode);
 NodeRegistry.register('mcpConfigure', McpConfigureNode);
 NodeRegistry.register('slash_command_artifact', SlashCommandArtifactNode);
 

--- a/apps/dashboard/src/components/flowUI/nodes/ProviderSuggestNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/ProviderSuggestNode.tsx
@@ -1,0 +1,178 @@
+import React, { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { cn } from '../../../utils/classNames';
+import type { FlowComponent } from '@xyne/shared';
+import { useAuth } from '../../../hooks/useAuth';
+import { Button, buttonVariants } from '../../ui/Button/Button';
+import { listProviderCredentials } from '../../../services/claw/clawSettingsService';
+import { AgentKeysDialog } from '../../../routes/AIScreen/library/agents/detail/persona/credentials/AgentKeysDialog';
+import { userCredentialScope } from '../../../routes/AIScreen/library/agents/detail/persona/credentials/credentialScope';
+import { CardShell } from './cardPrimitives';
+
+/**
+ * AI provider suggestions inside a conversation.
+ *
+ * Mirrors McpSuggestNode, with one difference that matters: providers are a
+ * fixed list in code rather than DB rows, so the display text posted with the
+ * card is authoritative. Only the connected state is re-read live, so a card
+ * sitting in an old thread does not claim you are disconnected after you have
+ * since connected.
+ */
+interface ProviderSuggestItem {
+  provider: string;
+  name: string;
+  description?: string;
+  connected?: boolean;
+  sharedName?: string;
+  connectMethod?: 'oauth' | 'device' | 'api_key' | 'none';
+}
+
+interface ProviderSuggestProps {
+  title?: string;
+  reason?: string;
+  providers?: ProviderSuggestItem[];
+  browseAll?: boolean;
+  totalCount?: number;
+}
+
+const LINK_BUTTON = '!text-foreground !no-underline hover:!text-foreground';
+
+export const ProviderSuggestNode: React.FC<{ node: FlowComponent; children?: React.ReactNode }> = ({
+  node,
+}) => {
+  const props = node.props as ProviderSuggestProps | undefined;
+  const { user } = useAuth();
+  const [connectFor, setConnectFor] = useState<string | null>(null);
+
+  const { data: credentials, refetch } = useQuery({
+    queryKey: ['claw-user-provider-credentials', user?.id],
+    queryFn: () => listProviderCredentials(user?.id as string),
+    enabled: Boolean(user?.id),
+    staleTime: 30_000,
+  });
+
+  const connectedProviders = useMemo(
+    () => new Set((credentials ?? []).map(c => c.provider)),
+    [credentials],
+  );
+
+  const providers = props?.providers ?? [];
+  if (providers.length === 0) return null;
+
+  return (
+    <CardShell style={node.style}>
+      <div className='flex flex-col gap-4 rounded-b-[11px] border-b border-border bg-card/80 px-3 pb-4 pt-3'>
+        <div className='flex h-6 items-center gap-2 pl-1'>
+          <span className='min-w-0 truncate text-sm font-medium leading-5 tracking-[-0.5px] text-muted-foreground'>
+            {props?.title ?? 'AI providers you can connect'}
+          </span>
+          {props?.browseAll && (
+            <span
+              title='Shows providers you have connected yourself. Your organization may already provide others.'
+              className='shrink-0 rounded-full border border-border px-2 py-0.5 text-[11px] font-medium leading-4 text-muted-foreground'
+            >
+              Personal
+            </span>
+          )}
+        </div>
+
+        {props?.reason && (
+          <span className='pl-1 text-xs leading-5 text-muted-foreground'>{props.reason}</span>
+        )}
+
+        <div className='flex flex-col'>
+          {providers.map(item => {
+            const isConnected = connectedProviders.has(item.provider) || (item.connected ?? false);
+            const connectable = item.connectMethod !== 'none';
+
+            return (
+              <div
+                key={item.provider}
+                className='-mx-1 flex items-center gap-3 rounded-xl px-2 py-2.5 hover:bg-foreground/[0.04]'
+              >
+                <div className='flex min-w-0 flex-1 flex-col'>
+                  <span className='truncate text-sm font-medium leading-5 text-foreground'>
+                    {item.name}
+                  </span>
+                  {item.description && (
+                    <span className='truncate text-xs leading-5 text-muted-foreground'>
+                      {item.description}
+                    </span>
+                  )}
+                  {item.sharedName && (
+                    <span className='truncate text-xs leading-5 text-muted-foreground'>
+                      {item.sharedName}
+                    </span>
+                  )}
+                </div>
+
+                {!connectable ? (
+                  <span className='shrink-0 rounded-lg px-2 py-1 text-xs font-medium leading-5 text-muted-foreground'>
+                    Always available
+                  </span>
+                ) : isConnected ? (
+                  <span className='flex shrink-0 items-center gap-1.5 rounded-lg px-2 py-1 text-xs font-medium leading-5 text-status-success'>
+                    <span
+                      className='size-[6px] shrink-0 rounded-full bg-status-success'
+                      aria-hidden
+                    />
+                    Connected
+                  </span>
+                ) : (
+                  <Button
+                    size='sm'
+                    variant='outline'
+                    className='h-7 shrink-0 rounded-lg px-2.5 text-sm font-medium'
+                    onClick={(): void => setConnectFor(item.provider)}
+                    data-track-category='Claw Provider'
+                    data-track-name='ConnectSuggestedProvider'
+                  >
+                    Connect
+                  </Button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {props?.browseAll && (
+        <div className='flex items-center justify-between gap-3 px-4 py-3'>
+          <span className='min-w-0 truncate text-xs leading-5 text-muted-foreground'>
+            {props.totalCount !== undefined
+              ? `${props.totalCount} providers available`
+              : 'All providers'}
+          </span>
+          <Link
+            to='/ai/settings'
+            className={cn(
+              buttonVariants({ variant: 'ghost', size: 'sm' }),
+              'h-7 shrink-0 rounded-[10px] px-2.5 text-sm font-medium',
+              LINK_BUTTON,
+            )}
+            data-track-category='Claw Provider'
+            data-track-name='OpenProviderSettings'
+          >
+            Open settings
+          </Link>
+        </div>
+      )}
+
+      {connectFor && user?.id && (
+        <AgentKeysDialog
+          open
+          onOpenChange={(next: boolean): void => {
+            if (!next) {
+              setConnectFor(null);
+              void refetch();
+            }
+          }}
+          scope={userCredentialScope(user.id)}
+          canManage
+          initialProvider={connectFor}
+        />
+      )}
+    </CardShell>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/agent/DraftAgentCard.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/agent/DraftAgentCard.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { MaximizeTwoArrow, Spinner } from '@xyne/icons';
 import type { AgentDraftProps, FlowComponent } from '@xyne/shared';
 import { useFlow } from '../../FlowContext';
@@ -145,34 +146,19 @@ export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftPr
   // Decline / Edit / Create Agent — shared by the compact footer AND the
   // expanded preview footer (submit() closes the preview on a decision).
   const actionControls = (
-    <div className='flex w-full items-center justify-between gap-3'>
-      <button
-        type='button'
-        onClick={() => void submit('agent-draft-decline')}
-        disabled={locked}
-        className={cn(ghostButton, 'px-2.5')}
-        data-track-category='AGENT_ARTIFACT'
-        data-track-name='CLICK_DECLINE'
-        data-ph-capture-attribute-track-id='agent_draft_decline'
-      >
-        {pending === 'reject' && <Spinner size={14} className='animate-spin' />}
-        {pending === 'reject' ? 'Declining…' : 'Decline'}
-      </button>
-
+    <div className='flex w-full items-center justify-end gap-3'>
       <div className='flex shrink-0 items-center gap-2'>
-        {/* Placeholder from the frame — no edit flow exists yet. Rendered so the
-            layout matches the design; wire it up when the behaviour is decided. */}
         <button
           type='button'
-          onClick={() => {
-            /* TODO: no edit flow yet — see the Agent Create frame. */
-          }}
+          onClick={() => void submit('agent-draft-decline')}
           disabled={locked}
           className={cn(ghostButton, 'px-2.5')}
           data-track-category='AGENT_ARTIFACT'
-          data-track-name='CLICK_EDIT'
+          data-track-name='CLICK_DECLINE'
+          data-ph-capture-attribute-track-id='agent_draft_decline'
         >
-          Edit
+          {pending === 'reject' && <Spinner size={14} className='animate-spin' />}
+          {pending === 'reject' ? 'Declining…' : 'Decline'}
         </button>
         <button
           type='button'
@@ -209,18 +195,31 @@ export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftPr
             </span>
             {statePill}
           </div>
-          {!insidePreview && (
-            <button
-              type='button'
-              onClick={(): void => setExpanded(true)}
-              aria-label='Expand agent'
-              className='shrink-0 rounded-[10px] p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
-              data-track-category='AGENT_ARTIFACT'
-              data-track-name='EXPAND_ARTIFACT'
-            >
-              <MaximizeTwoArrow size={16} className='shrink-0' />
-            </button>
-          )}
+          {!insidePreview &&
+            (props.phase === 'created' ? (
+              // The agent exists now, so its detail page shows everything the
+              // preview dialog only summarises. While still a draft there is no
+              // page to open, so the dialog stays the way to see the spec.
+              <Link
+                to={`/ai/library/agent/${encodeURIComponent(props.agent.slug)}?tab=persona`}
+                className='shrink-0 rounded-[10px] px-2 py-1 text-sm font-medium leading-5 !text-muted-foreground !no-underline transition-colors hover:bg-accent hover:!text-foreground'
+                data-track-category='AGENT_ARTIFACT'
+                data-track-name='VIEW_AGENT_FROM_DRAFT_CARD'
+              >
+                View
+              </Link>
+            ) : (
+              <button
+                type='button'
+                onClick={(): void => setExpanded(true)}
+                aria-label='Expand agent'
+                className='shrink-0 rounded-[10px] p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+                data-track-category='AGENT_ARTIFACT'
+                data-track-name='EXPAND_ARTIFACT'
+              >
+                <MaximizeTwoArrow size={16} className='shrink-0' />
+              </button>
+            ))}
         </div>
 
         <div className='flex flex-col gap-3'>

--- a/apps/dashboard/src/components/flowUI/nodes/agent/ProfileAgentCard.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/agent/ProfileAgentCard.tsx
@@ -1,11 +1,10 @@
-import React, { useContext, useState } from 'react';
-import { MaximizeTwoArrow } from '@xyne/icons';
+import React, { useContext } from 'react';
+import { Link } from 'react-router-dom';
 import type { AgentProfileProps, FlowComponent } from '@xyne/shared';
-import { useFlow } from '../../FlowContext';
 import { AuditLine, CardShell, Mention, StatusChip } from '../cardPrimitives';
 import Avatar from '../../../ui/Avatar/Avatar';
 import { ChatWithAgentButton } from './ChatWithAgentButton';
-import { AgentPreview, InsideAgentPreviewContext } from './AgentPreview';
+import { InsideAgentPreviewContext } from './AgentPreview';
 
 /**
  * The `agent` artifact's PROFILE variant — a live agent described back to the
@@ -13,18 +12,19 @@ import { AgentPreview, InsideAgentPreviewContext } from './AgentPreview';
  * capability selection and no decision controls.
  *
  * Presentation is a deliberate mirror of DraftAgentCard's created phase — same
- * inset panel, same chin, same expanded preview — so a listed agent and one the
+ * inset panel and chin — so a listed agent and one the
  * user just created are visibly the same object. The two stay separate
  * components because the draft card is stateful and actionable (flow-state,
  * approve/decline) while this one is not; only the chrome is shared.
+ *
+ * View opens the agent's detail page rather than a preview dialog: the page
+ * shows persona, tools and keys in full, which the dialog only summarised.
  */
 export const ProfileAgentCard: React.FC<{ node: FlowComponent; props: AgentProfileProps }> = ({
   node,
   props,
 }) => {
-  const { conversationId, messageId } = useFlow();
   const insidePreview = useContext(InsideAgentPreviewContext);
-  const [expanded, setExpanded] = useState(false);
 
   const statePill = <StatusChip label='Created' />;
 
@@ -66,16 +66,16 @@ export const ProfileAgentCard: React.FC<{ node: FlowComponent; props: AgentProfi
             {statePill}
           </div>
           {!insidePreview && (
-            <button
-              type='button'
-              onClick={(): void => setExpanded(true)}
-              aria-label='Expand agent'
-              className='shrink-0 rounded-[10px] p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+            // The agent exists, so its detail page carries everything the
+            // preview dialog only summarises.
+            <Link
+              to={`/ai/library/agent/${encodeURIComponent(props.agent.slug)}?tab=persona`}
+              className='shrink-0 rounded-[10px] px-2 py-1 text-sm font-medium leading-5 !text-muted-foreground !no-underline transition-colors hover:bg-accent hover:!text-foreground'
               data-track-category='AGENT_ARTIFACT'
-              data-track-name='EXPAND_ARTIFACT'
+              data-track-name='VIEW_AGENT_FROM_CARD'
             >
-              <MaximizeTwoArrow size={16} className='shrink-0' />
-            </button>
+              View
+            </Link>
           )}
         </div>
 
@@ -105,17 +105,6 @@ export const ProfileAgentCard: React.FC<{ node: FlowComponent; props: AgentProfi
       <div className='flex min-h-[44px] items-center justify-between gap-3 px-3 py-2'>
         {footerNode}
       </div>
-
-      <AgentPreview
-        open={expanded}
-        onOpenChange={setExpanded}
-        messageId={messageId ?? ''}
-        agent={props.agent}
-        note={props.note}
-        statePill={statePill}
-        footer={footerNode}
-        conversationId={conversationId ?? undefined}
-      />
     </CardShell>
   );
 };

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/AgentKeysDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/AgentKeysDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react';
+import { useEffect, useState, type ReactElement } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { MultipleCrossCancelDefault, PencilEditLine, PlusDefault } from '@xyne/icons';
 import { Loader2 } from 'lucide-react';
@@ -8,6 +8,7 @@ import { Pill } from '../../../../shared/primitives/Pill';
 import { V2Dialog } from '../../../../shared/primitives/V2Dialog';
 import type { AgentProviderCredentialStatus } from './agentCredentialsService';
 import { CredentialFormFields } from './CredentialFormFields';
+import type { CredentialScope } from './credentialScope';
 import {
   CREDENTIAL_PROVIDERS,
   CREDENTIAL_PROVIDER_LABELS,
@@ -32,8 +33,11 @@ const SECTION_LABEL = 'text-sm font-medium leading-[1.2] tracking-[-0.1px] text-
 interface AgentKeysDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  slug: string;
+  /** Whose credentials this manages — an agent's, or the signed-in user's. */
+  scope: CredentialScope;
   canManage: boolean;
+  /** Preselected when opened from a card that already named a provider. */
+  initialProvider?: string;
 }
 
 const label = (provider: string): string => CREDENTIAL_PROVIDER_LABELS[provider] ?? provider;
@@ -47,21 +51,43 @@ function summarise(entry: AgentProviderCredentialStatus): string {
 export function AgentKeysDialog({
   open,
   onOpenChange,
-  slug,
+  scope,
   canManage,
+  initialProvider,
 }: AgentKeysDialogProps): ReactElement {
   const queryClient = useQueryClient();
-  const { data: credentials, isLoading } = useAgentCredentials(slug, open);
-  const { save, remove, saving, removing } = useAgentCredentialMutations(slug);
+  const isUserScope = scope.kind === 'user';
+  const { data: credentials, isLoading } = useAgentCredentials(scope, open);
+  const { save, remove, saving, removing } = useAgentCredentialMutations(scope);
 
   const [form, setForm] = useState<CredentialForm | null>(null);
   const [editingProvider, setEditingProvider] = useState<string | null>(null);
+
+  // Opened from a card that already named a provider: land straight on its
+  // form instead of the list, so the user does not pick it twice.
+  useEffect(() => {
+    if (!open || !initialProvider) return;
+    setForm({
+      ...EMPTY_CREDENTIAL_FORM,
+      provider: initialProvider as CredentialForm['provider'],
+      authType: supportsOauth(initialProvider) ? 'oauth_token' : 'api_key',
+    });
+    setEditingProvider(null);
+  }, [open, initialProvider]);
 
   const configured = (credentials ?? []).filter(entry => entry.configured);
   const configuredKeys = new Set(configured.map(entry => entry.provider));
   const available = CREDENTIAL_PROVIDERS.filter(provider => !configuredKeys.has(provider));
 
+  // Opened for one named provider, so there is no list behind the form —
+  // cancelling or finishing closes rather than revealing one.
+  const singleProvider = Boolean(initialProvider);
+
   const reset = (): void => {
+    if (singleProvider) {
+      onOpenChange(false);
+      return;
+    }
     setForm(null);
     setEditingProvider(null);
   };
@@ -96,9 +122,21 @@ export function AgentKeysDialog({
         onOpenChange(next);
         if (!next) reset();
       }}
-      title='Agent keys'
-      description='Provider keys this agent runs with.'
-      testId='agent-keys-dialog'
+      title={
+        form === null
+          ? 'Agent keys'
+          : editing
+            ? `Edit ${label(form.provider)}`
+            : `Connect ${label(form.provider)}`
+      }
+      description={
+        form !== null
+          ? `Use a ${label(form.provider)} account for this agent.`
+          : isUserScope
+            ? 'Your own provider keys, used when you talk to an agent.'
+            : 'Provider keys this agent runs with.'
+      }
+      testId={isUserScope ? 'provider-keys-dialog' : 'agent-keys-dialog'}
       footer={
         form === null ? (
           <Button
@@ -136,73 +174,79 @@ export function AgentKeysDialog({
         )
       }
     >
-      <p className='text-sm font-normal leading-5 text-muted-foreground'>
-        Without a key here, everyone falls through to their own provider, or to Spaces.
-      </p>
+      {form === null && (
+        <p className='text-sm font-normal leading-5 text-muted-foreground'>
+          Without a key here, everyone falls through to their own provider, or to Spaces.
+        </p>
+      )}
 
-      <section className='flex w-full flex-col gap-3'>
-        <span className={SECTION_LABEL}>Configured</span>
+      {form === null && (
+        <section className='flex w-full flex-col gap-3'>
+          <span className={SECTION_LABEL}>Configured</span>
 
-        {isLoading ? (
-          <div className='flex flex-col gap-2'>
-            <Skeleton className='h-11 w-full rounded-[10px]' />
-            <Skeleton className='h-11 w-full rounded-[10px]' />
-          </div>
-        ) : configured.length === 0 ? (
-          <p className='text-sm font-normal leading-5 text-muted-foreground'>No agent keys yet.</p>
-        ) : (
-          <div className='flex w-full flex-col gap-2'>
-            {configured.map(entry => (
-              <div
-                key={entry.provider}
-                className='flex min-h-11 w-full items-center gap-2 rounded-[10px] border-[0.8px] border-border bg-muted px-3 py-2'
-              >
-                <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
-                  <span className='truncate text-sm font-medium leading-5 text-foreground'>
-                    {label(entry.provider)}
-                  </span>
-                  <span className='truncate text-xs font-normal leading-4 tracking-[-0.24px] text-muted-foreground'>
-                    {summarise(entry)}
-                  </span>
+          {isLoading ? (
+            <div className='flex flex-col gap-2'>
+              <Skeleton className='h-11 w-full rounded-[10px]' />
+              <Skeleton className='h-11 w-full rounded-[10px]' />
+            </div>
+          ) : configured.length === 0 ? (
+            <p className='text-sm font-normal leading-5 text-muted-foreground'>
+              {isUserScope ? 'No provider keys yet.' : 'No agent keys yet.'}
+            </p>
+          ) : (
+            <div className='flex w-full flex-col gap-2'>
+              {configured.map(entry => (
+                <div
+                  key={entry.provider}
+                  className='flex min-h-11 w-full items-center gap-2 rounded-[10px] border-[0.8px] border-border bg-muted px-3 py-2'
+                >
+                  <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
+                    <span className='truncate text-sm font-medium leading-5 text-foreground'>
+                      {label(entry.provider)}
+                    </span>
+                    <span className='truncate text-xs font-normal leading-4 tracking-[-0.24px] text-muted-foreground'>
+                      {summarise(entry)}
+                    </span>
+                  </div>
+                  <Pill tone='success'>Configured</Pill>
+                  {canManage && (
+                    <>
+                      <button
+                        type='button'
+                        onClick={() => {
+                          setEditingProvider(entry.provider);
+                          setForm(formFromCredential(entry));
+                        }}
+                        aria-label={`Edit ${label(entry.provider)} credential`}
+                        data-track-category='Claw Agents'
+                        data-track-name='Agent detail v2: edit agent key'
+                        className={ICON_BUTTON}
+                      >
+                        <PencilEditLine className='size-4' aria-hidden />
+                      </button>
+                      <button
+                        type='button'
+                        onClick={() => void remove(entry.provider)}
+                        disabled={removing}
+                        aria-label={`Remove ${label(entry.provider)} credential`}
+                        data-track-category='Claw Agents'
+                        data-track-name='Agent detail v2: remove agent key'
+                        className={ICON_BUTTON}
+                      >
+                        {removing ? (
+                          <Loader2 className='size-4 animate-spin' aria-hidden />
+                        ) : (
+                          <MultipleCrossCancelDefault className='size-4' aria-hidden />
+                        )}
+                      </button>
+                    </>
+                  )}
                 </div>
-                <Pill tone='success'>Configured</Pill>
-                {canManage && (
-                  <>
-                    <button
-                      type='button'
-                      onClick={() => {
-                        setEditingProvider(entry.provider);
-                        setForm(formFromCredential(entry));
-                      }}
-                      aria-label={`Edit ${label(entry.provider)} credential`}
-                      data-track-category='Claw Agents'
-                      data-track-name='Agent detail v2: edit agent key'
-                      className={ICON_BUTTON}
-                    >
-                      <PencilEditLine className='size-4' aria-hidden />
-                    </button>
-                    <button
-                      type='button'
-                      onClick={() => void remove(entry.provider)}
-                      disabled={removing}
-                      aria-label={`Remove ${label(entry.provider)} credential`}
-                      data-track-category='Claw Agents'
-                      data-track-name='Agent detail v2: remove agent key'
-                      className={ICON_BUTTON}
-                    >
-                      {removing ? (
-                        <Loader2 className='size-4 animate-spin' aria-hidden />
-                      ) : (
-                        <MultipleCrossCancelDefault className='size-4' aria-hidden />
-                      )}
-                    </button>
-                  </>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
-      </section>
+              ))}
+            </div>
+          )}
+        </section>
+      )}
 
       {canManage && form === null && available.length > 0 && (
         <section className='flex w-full flex-col gap-3'>
@@ -232,16 +276,17 @@ export function AgentKeysDialog({
 
       {form !== null && (
         <section className='flex w-full flex-col gap-3'>
-          <span className={SECTION_LABEL}>
-            {editing ? `Edit ${label(form.provider)}` : `New ${label(form.provider)} key`}
-          </span>
           <CredentialFormFields
             form={form}
             onChange={setForm}
             editing={editing}
-            slug={slug}
+            scope={scope}
             onOauthConnected={() => {
-              void queryClient.invalidateQueries({ queryKey: agentCredentialsKey(slug) });
+              void queryClient.invalidateQueries({ queryKey: agentCredentialsKey(scope) });
+              if (singleProvider) {
+                onOpenChange(false);
+                return;
+              }
               // The exchange already stored the bundle. Stay open in edit mode so
               // a model/base URL can follow — the backend allows that update
               // without an apiKey precisely because OAuth saved the credential.

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/CredentialFormFields.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/CredentialFormFields.tsx
@@ -16,9 +16,10 @@ import {
   type CredentialForm,
 } from './credentialForm';
 import { CredentialOauthFlow } from './CredentialOauthFlow';
+import type { CredentialScope } from './credentialScope';
 
 const FIELD =
-  'h-11 w-full rounded-2xl border border-border bg-card px-4 text-sm leading-5 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring';
+  'h-11 w-full rounded-lg border border-border bg-card px-4 text-sm leading-5 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring';
 
 const Field = ({
   label,
@@ -42,7 +43,7 @@ interface CredentialFormFieldsProps {
   form: CredentialForm;
   onChange: (next: CredentialForm) => void;
   editing: boolean;
-  slug: string;
+  scope: CredentialScope;
   onOauthConnected: () => void;
 }
 
@@ -50,7 +51,7 @@ export function CredentialFormFields({
   form,
   onChange,
   editing,
-  slug,
+  scope,
   onOauthConnected,
 }: CredentialFormFieldsProps): ReactElement {
   const set = <K extends keyof CredentialForm>(key: K, value: CredentialForm[K]): void =>
@@ -74,7 +75,7 @@ export function CredentialFormFields({
               aria-label='Auth type'
               data-track-category='Claw Agents'
               data-track-name='Agent detail v2: credential auth type'
-              className='h-11 w-full rounded-2xl'
+              className='h-11 w-full rounded-lg'
             >
               <SelectValue />
             </SelectTrigger>
@@ -90,7 +91,11 @@ export function CredentialFormFields({
       )}
 
       {oauthProvider ? (
-        <CredentialOauthFlow slug={slug} provider={oauthProvider} onConnected={onOauthConnected} />
+        <CredentialOauthFlow
+          scope={scope}
+          provider={oauthProvider}
+          onConnected={onOauthConnected}
+        />
       ) : (
         <Field label='API key' optional={editing}>
           <input
@@ -145,7 +150,7 @@ export function CredentialFormFields({
               aria-label='Reasoning effort'
               data-track-category='Claw Agents'
               data-track-name='Agent detail v2: credential reasoning effort'
-              className='h-11 w-full rounded-2xl'
+              className='h-11 w-full rounded-lg'
             >
               <SelectValue />
             </SelectTrigger>

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/CredentialOauthFlow.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/CredentialOauthFlow.tsx
@@ -3,14 +3,8 @@ import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/Button/index';
 import { Textarea } from '@/components/ui/Textarea';
 import { clawErrorText } from '@/services/claw/clawRequest';
-import {
-  exchangeAgentOauth,
-  pollAgentCopilotLogin,
-  startAgentCopilotLogin,
-  startAgentOauth,
-  type AgentCopilotDeviceCode,
-  type AgentOauthFlow,
-} from './agentCredentialsService';
+import { type AgentCopilotDeviceCode, type AgentOauthFlow } from './agentCredentialsService';
+import type { CredentialScope } from './credentialScope';
 
 type OauthProvider = 'codex' | 'claude' | 'copilot';
 
@@ -40,11 +34,11 @@ const COPY: Record<OauthProvider, { button: string; blurb: string; alternative: 
  * we don't own, so the browser can't hand the code back to us directly.
  */
 export function CredentialOauthFlow({
-  slug,
+  scope,
   provider,
   onConnected,
 }: {
-  slug: string;
+  scope: CredentialScope;
   provider: OauthProvider;
   onConnected: () => void;
 }): ReactElement {
@@ -68,7 +62,7 @@ export function CredentialOauthFlow({
 
     const tick = async (): Promise<void> => {
       try {
-        const result = await pollAgentCopilotLogin(slug);
+        const result = await scope.pollCopilot();
         if (cancelled) return;
         if (result.status === 'approved') {
           setDevice(null);
@@ -89,19 +83,19 @@ export function CredentialOauthFlow({
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [device, slug]);
+  }, [device, scope]);
 
   const start = async (): Promise<void> => {
     setBusy(true);
     setError(null);
     try {
       if (isDeviceFlow) {
-        const next = await startAgentCopilotLogin(slug);
+        const next = await scope.startCopilot();
         setDevice(next);
         window.open(next.verificationUri, '_blank', 'noopener,noreferrer');
         return;
       }
-      const next = await startAgentOauth(slug, provider);
+      const next = await scope.startOauth(provider);
       setFlow(next);
       window.open(next.url, '_blank', 'noopener,noreferrer');
     } catch (err) {
@@ -116,7 +110,7 @@ export function CredentialOauthFlow({
     setBusy(true);
     setError(null);
     try {
-      await exchangeAgentOauth(slug, provider, { code: code.trim(), state: flow.state });
+      await scope.exchangeOauth(provider, { code: code.trim(), state: flow.state });
       setFlow(null);
       setCode('');
       onConnected();

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/CredentialsCard.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/CredentialsCard.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react';
+import { useMemo, useState, type ReactElement } from 'react';
 import { ChevronBigDown } from '@xyne/icons';
 import { Pill } from '../../../../shared/primitives/Pill';
 import {
@@ -10,6 +10,7 @@ import {
   ReadOnlyBadge,
 } from '../../../../shared/primitives/DetailPrimitives';
 import { AgentKeysDialog } from './AgentKeysDialog';
+import { agentCredentialScope } from './credentialScope';
 import { useAgentCredentials } from './useAgentCredentials';
 
 interface CredentialsCardProps {
@@ -20,7 +21,8 @@ interface CredentialsCardProps {
 
 export function CredentialsCard({ slug, canRead, canManage }: CredentialsCardProps): ReactElement {
   const [keysOpen, setKeysOpen] = useState(false);
-  const { data: credentials } = useAgentCredentials(slug, canRead);
+  const scope = useMemo(() => agentCredentialScope(slug), [slug]);
+  const { data: credentials } = useAgentCredentials(scope, canRead);
 
   const configured = (credentials ?? []).filter(entry => entry.configured).length;
 
@@ -66,7 +68,7 @@ export function CredentialsCard({ slug, canRead, canManage }: CredentialsCardPro
       <AgentKeysDialog
         open={keysOpen}
         onOpenChange={setKeysOpen}
-        slug={slug}
+        scope={scope}
         canManage={canManage}
       />
     </DetailSection>

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/credentialScope.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/credentialScope.ts
@@ -1,0 +1,92 @@
+import {
+  deleteAgentProviderCredential,
+  exchangeAgentOauth,
+  listAgentProviderCredentials,
+  pollAgentCopilotLogin,
+  setAgentProviderCredential,
+  startAgentCopilotLogin,
+  startAgentOauth,
+  type AgentCopilotDeviceCode,
+  type AgentOauthFlow,
+  type AgentProviderCredentialStatus,
+  type SetAgentCredentialPayload,
+} from './agentCredentialsService';
+import {
+  deleteProviderCredential,
+  exchangeClaudeOauth,
+  exchangeCodexOauth,
+  initiateCopilotGitHubLogin,
+  listProviderCredentials,
+  pollCopilotGitHubLogin,
+  startClaudeOauth,
+  startCodexOauth,
+  upsertProviderCredential,
+} from '@/services/claw/clawSettingsService';
+
+export type OauthCredentialProvider = 'codex' | 'claude';
+
+export interface CredentialScope {
+  kind: 'agent' | 'user';
+  /** Stable per-scope key so react-query caches do not collide. */
+  id: string;
+  list: () => Promise<AgentProviderCredentialStatus[]>;
+  set: (payload: SetAgentCredentialPayload) => Promise<unknown>;
+  remove: (provider: string) => Promise<unknown>;
+  startOauth: (provider: OauthCredentialProvider) => Promise<AgentOauthFlow>;
+  exchangeOauth: (
+    provider: OauthCredentialProvider,
+    input: { code: string; state: string },
+  ) => Promise<unknown>;
+  startCopilot: () => Promise<AgentCopilotDeviceCode>;
+  pollCopilot: () => Promise<{ status: string }>;
+}
+
+export function agentCredentialScope(slug: string): CredentialScope {
+  return {
+    kind: 'agent',
+    id: slug,
+    list: () => listAgentProviderCredentials(slug),
+    set: payload => setAgentProviderCredential(slug, payload),
+    remove: provider => deleteAgentProviderCredential(slug, provider),
+    startOauth: provider => startAgentOauth(slug, provider),
+    exchangeOauth: (provider, input) => exchangeAgentOauth(slug, provider, input),
+    startCopilot: () => startAgentCopilotLogin(slug),
+    pollCopilot: () => pollAgentCopilotLogin(slug),
+  };
+}
+
+/**
+ * The same dialog against the signed-in user's own credentials — what
+ * /ai/settings manages. Every endpoint already existed in clawSettingsService;
+ * this only adapts the shapes so one dialog serves both scopes rather than a
+ * second copy drifting from the first.
+ */
+export function userCredentialScope(userId: string): CredentialScope {
+  return {
+    kind: 'user',
+    id: userId,
+    list: async () => {
+      const rows = await listProviderCredentials(userId);
+      return rows as unknown as AgentProviderCredentialStatus[];
+    },
+    set: payload => upsertProviderCredential(userId, payload.provider, payload),
+    remove: provider => deleteProviderCredential(userId, provider),
+    startOauth: async provider => {
+      const flow =
+        provider === 'codex' ? await startCodexOauth(userId) : await startClaudeOauth(userId);
+      return { url: flow.url, state: flow.state, expiresIn: flow.expiresIn ?? 0 };
+    },
+    exchangeOauth: (provider, input) =>
+      provider === 'codex' ? exchangeCodexOauth(userId, input) : exchangeClaudeOauth(userId, input),
+    startCopilot: async () => {
+      const device = await initiateCopilotGitHubLogin(userId);
+      return {
+        userCode: device.userCode,
+        verificationUri: device.verificationUri,
+        expiresIn: device.expiresIn ?? 0,
+        interval: device.interval ?? 5,
+      };
+    },
+    pollCopilot: () => pollCopilotGitHubLogin(userId),
+  };
+}

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/useAgentCredentials.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/useAgentCredentials.ts
@@ -2,26 +2,28 @@ import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tan
 import { toast } from 'sonner';
 import { clawErrorText } from '@/services/claw/clawRequest';
 import {
-  deleteAgentProviderCredential,
-  listAgentProviderCredentials,
-  setAgentProviderCredential,
   type AgentProviderCredentialStatus,
   type SetAgentCredentialPayload,
 } from './agentCredentialsService';
+import type { CredentialScope } from './credentialScope';
 
-export const agentCredentialsKey = (slug: string | undefined): [string, string | undefined] => [
-  'claw-agent-provider-credentials',
-  slug,
+/** Keyed by scope kind + id so agent and user caches never collide. */
+export const agentCredentialsKey = (
+  scope: CredentialScope | undefined,
+): [string, string | undefined, string | undefined] => [
+  'claw-provider-credentials',
+  scope?.kind,
+  scope?.id,
 ];
 
 export function useAgentCredentials(
-  slug: string | undefined,
+  scope: CredentialScope | undefined,
   enabled = true,
 ): UseQueryResult<AgentProviderCredentialStatus[], Error> {
   return useQuery({
-    queryKey: agentCredentialsKey(slug),
-    queryFn: () => listAgentProviderCredentials(slug as string),
-    enabled: Boolean(slug) && enabled,
+    queryKey: agentCredentialsKey(scope),
+    queryFn: () => (scope as CredentialScope).list(),
+    enabled: Boolean(scope) && enabled,
     staleTime: 60 * 1000,
   });
 }
@@ -33,15 +35,16 @@ export interface AgentCredentialMutations {
   removing: boolean;
 }
 
-export function useAgentCredentialMutations(slug: string | undefined): AgentCredentialMutations {
+export function useAgentCredentialMutations(
+  scope: CredentialScope | undefined,
+): AgentCredentialMutations {
   const queryClient = useQueryClient();
   const invalidate = (): void => {
-    void queryClient.invalidateQueries({ queryKey: agentCredentialsKey(slug) });
+    void queryClient.invalidateQueries({ queryKey: agentCredentialsKey(scope) });
   };
 
   const saveMutation = useMutation({
-    mutationFn: (payload: SetAgentCredentialPayload) =>
-      setAgentProviderCredential(slug as string, payload),
+    mutationFn: (payload: SetAgentCredentialPayload) => (scope as CredentialScope).set(payload),
     onSuccess: () => {
       invalidate();
       toast.success('Credential saved');
@@ -50,7 +53,7 @@ export function useAgentCredentialMutations(slug: string | undefined): AgentCred
   });
 
   const removeMutation = useMutation({
-    mutationFn: (provider: string) => deleteAgentProviderCredential(slug as string, provider),
+    mutationFn: (provider: string) => (scope as CredentialScope).remove(provider),
     onSuccess: () => {
       invalidate();
       toast.success('Credential removed');

--- a/apps/xyne-claw-auth/backend/src/lib/provider-hints.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/provider-hints.test.ts
@@ -40,6 +40,17 @@ test("providers we do not offer are named back, never silently dropped", () => {
   expect(unsupportedProvidersFromText("connect claude")).toEqual([]);
 });
 
+test("a question about an agent's config is not a request to connect", () => {
+  // Both posted a card in prod (2026-09-10) and read as noise: the user was
+  // asking about an agent, not about their own accounts.
+  expect(wantsProviderRoster("which AI provider this agent will use check")).toBe(false);
+  expect(wantsProviderRoster("can u check which AI provider the above PR agent will use")).toBe(false);
+  expect(providersUserAskedFor("create a PR agent for me with anthropic as Ai provider")).toEqual([]);
+  expect(wantsProviderRoster("then why in the model->provider it shows spaces platform model")).toBe(
+    false,
+  );
+});
+
 test("an unsupported name does not turn into a roster", () => {
   expect(wantsProviderRoster("i want to connect the gemini model")).toBe(false);
 });

--- a/apps/xyne-claw-auth/backend/src/lib/provider-hints.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/provider-hints.test.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "vitest";
+import {
+  providerTypesFromText,
+  providersUserAskedFor,
+  unsupportedProvidersFromText,
+  wantsProviderRoster,
+} from "./provider-hints.js";
+
+test("roster asks resolve without the model", () => {
+  expect(wantsProviderRoster("list down all the AI providers i have")).toBe(true);
+  expect(wantsProviderRoster("what AI providers do we have")).toBe(true);
+  expect(wantsProviderRoster("how many models do i have")).toBe(true);
+  expect(wantsProviderRoster("show me the models")).toBe(true);
+  expect(wantsProviderRoster("i want to connect to an AI provider")).toBe(true);
+});
+
+test("naming a provider is a request for that one, not the roster", () => {
+  expect(wantsProviderRoster("help me connect to Anthropic")).toBe(false);
+  expect(wantsProviderRoster("connect me to codex")).toBe(false);
+});
+
+test("ordinary tasks never look like a provider ask", () => {
+  expect(wantsProviderRoster("summarize this doc")).toBe(false);
+  expect(wantsProviderRoster("what is the weather")).toBe(false);
+  expect(providersUserAskedFor("summarize this doc")).toEqual([]);
+});
+
+test("users are matched on the names they actually type", () => {
+  expect(providersUserAskedFor("help me connect to Anthropic")).toEqual(["claude"]);
+  expect(providersUserAskedFor("i want to use openai")).toEqual(["codex"]);
+  expect(providersUserAskedFor("switch to chatgpt")).toEqual(["codex"]);
+  expect(providersUserAskedFor("connect github copilot")).toEqual(["copilot"]);
+  expect(providerTypesFromText("set up litellm")).toEqual(["litellm"]);
+});
+
+test("providers we do not offer are named back, never silently dropped", () => {
+  expect(unsupportedProvidersFromText("connect me to gemini")).toEqual(["Gemini"]);
+  expect(unsupportedProvidersFromText("can i use mistral")).toEqual(["Mistral"]);
+  expect(unsupportedProvidersFromText("add deepseek")).toEqual(["DeepSeek"]);
+  expect(unsupportedProvidersFromText("connect claude")).toEqual([]);
+});
+
+test("an unsupported name does not turn into a roster", () => {
+  expect(wantsProviderRoster("i want to connect the gemini model")).toBe(false);
+});

--- a/apps/xyne-claw-auth/backend/src/lib/provider-hints.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/provider-hints.ts
@@ -1,0 +1,149 @@
+/**
+ * AI provider recognition, read from the user's own words.
+ *
+ * Providers are a fixed list defined in code (there is no `providers` table),
+ * so unlike connectors the server can answer "what do I have?" completely on
+ * its own — no catalog round-trip and no dependence on the model choosing to
+ * call a tool.
+ *
+ * UNSUPPORTED_PROVIDERS exists so "connect me to gemini" is recognised as a
+ * provider request we cannot fulfil, rather than falling through as unrelated
+ * prose. Without it the model is left to improvise an answer, which is how the
+ * figma connector card ended up being described but never rendered.
+ */
+
+export const SUPPORTED_PROVIDERS = [
+  "codex",
+  "claude",
+  "copilot",
+  "openrouter",
+  "litellm",
+  "spaces",
+] as const;
+
+export type SupportedProvider = (typeof SUPPORTED_PROVIDERS)[number];
+
+export const PROVIDER_LABELS: Record<string, string> = {
+  codex: "OpenAI Codex",
+  claude: "Anthropic Claude",
+  copilot: "GitHub Copilot",
+  openrouter: "OpenRouter",
+  litellm: "LiteLLM (own key)",
+  spaces: "Spaces",
+};
+
+export const PROVIDER_DESCRIPTIONS: Record<string, string> = {
+  codex: "Your ChatGPT account, signed in through OpenAI.",
+  claude: "Your Anthropic account, signed in through Claude.",
+  copilot: "Your GitHub Copilot seat.",
+  openrouter: "One key, many models across providers.",
+  litellm: "Point at your own LiteLLM gateway.",
+  spaces: "The built-in default. Always available, nothing to connect.",
+};
+
+/** How the card connects each one — anything else is not a valid action. */
+export const PROVIDER_CONNECT_METHOD: Record<string, "oauth" | "device" | "api_key" | "none"> = {
+  codex: "oauth",
+  claude: "oauth",
+  copilot: "device",
+  openrouter: "api_key",
+  litellm: "api_key",
+  spaces: "none",
+};
+
+interface ProviderHint {
+  provider: SupportedProvider;
+  keywords: readonly string[];
+}
+
+/**
+ * Nobody types our internal keys. "anthropic" and "chatgpt" are what users
+ * actually say, so the aliases matter more than the canonical name.
+ */
+const PROVIDER_HINTS: readonly ProviderHint[] = [
+  { provider: "claude", keywords: ["claude", "anthropic", "sonnet", "opus", "haiku"] },
+  { provider: "codex", keywords: ["codex", "openai", "open ai", "chatgpt", "gpt"] },
+  { provider: "copilot", keywords: ["copilot", "github copilot"] },
+  { provider: "openrouter", keywords: ["openrouter", "open router"] },
+  { provider: "litellm", keywords: ["litellm", "lite llm"] },
+  { provider: "spaces", keywords: ["spaces default", "xyne default"] },
+];
+
+/**
+ * Named often enough to be worth answering precisely. Anything here gets a
+ * truthful "not supported" instead of silence or an invented card.
+ */
+const UNSUPPORTED_PROVIDERS: Record<string, readonly string[]> = {
+  Gemini: ["gemini", "bard", "google ai"],
+  Mistral: ["mistral"],
+  Llama: ["llama", "meta ai"],
+  Perplexity: ["perplexity"],
+  Grok: ["grok"],
+  Cohere: ["cohere"],
+  DeepSeek: ["deepseek", "deep seek"],
+};
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function mentions(text: string, keyword: string): number {
+  return text.search(new RegExp(`\\b${escapeRegExp(keyword)}\\b`, "i"));
+}
+
+/** Providers the text names, in the order they first appear. */
+export function providerTypesFromText(text: string): SupportedProvider[] {
+  if (!text.trim()) return [];
+  const hits: { provider: SupportedProvider; at: number }[] = [];
+  for (const hint of PROVIDER_HINTS) {
+    let earliest = -1;
+    for (const keyword of hint.keywords) {
+      const at = mentions(text, keyword);
+      if (at >= 0 && (earliest === -1 || at < earliest)) earliest = at;
+    }
+    if (earliest >= 0) hits.push({ provider: hint.provider, at: earliest });
+  }
+  return hits.sort((a, b) => a.at - b.at).map((h) => h.provider);
+}
+
+/** Display names of providers the text names that Xyne does not offer. */
+export function unsupportedProvidersFromText(text: string): string[] {
+  if (!text.trim()) return [];
+  const found: string[] = [];
+  for (const [label, keywords] of Object.entries(UNSUPPORTED_PROVIDERS)) {
+    if (keywords.some((k) => mentions(text, k) >= 0)) found.push(label);
+  }
+  return found;
+}
+
+const PROVIDER_NOUN = /\b(ai provider|ai providers|provider|providers|model|models|llm|llms)\b/i;
+
+const ROSTER_INTENT =
+  /\b(show|see|view|open|display|list|find|browse|bring up|pull up|what|which|how many|any)\b/i;
+
+const CONNECT_INTENT =
+  /\b(re)?connect(ed|ing|ion|ions)?\b|\bauthori[sz]e\b|\badd\b|\bset ?up\b|\bsign in\b|\blog in\b|\bconfigure\b|\benable\b|\bhook up\b|\bswitch to\b|\buse\b/i;
+
+/**
+ * "What providers do I have?" — a roster ask, provided no specific provider was
+ * named. Naming one is a request for that provider, not for the whole list.
+ */
+export function wantsProviderRoster(text: string): boolean {
+  if (!text.trim()) return false;
+  if (!PROVIDER_NOUN.test(text)) return false;
+  // "I want to connect a provider" without naming one is also a roster ask —
+  // they cannot name what they have not been shown yet.
+  if (!ROSTER_INTENT.test(text) && !CONNECT_INTENT.test(text)) return false;
+  return providerTypesFromText(text).length === 0 && unsupportedProvidersFromText(text).length === 0;
+}
+
+/**
+ * Providers the user explicitly asked to connect or switch to. Read from their
+ * own message — the model does not get a vote, for the same reason it does not
+ * for connectors: it has an incentive to claim intent so its card is shown.
+ */
+export function providersUserAskedFor(text: string): SupportedProvider[] {
+  if (!text.trim()) return [];
+  if (!CONNECT_INTENT.test(text) && !PROVIDER_NOUN.test(text)) return [];
+  return providerTypesFromText(text);
+}

--- a/apps/xyne-claw-auth/backend/src/lib/provider-hints.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/provider-hints.ts
@@ -118,6 +118,16 @@ export function unsupportedProvidersFromText(text: string): string[] {
 
 const PROVIDER_NOUN = /\b(ai provider|ai providers|provider|providers|model|models|llm|llms)\b/i;
 
+/**
+ * The message is about an AGENT's configuration, not the user's own accounts.
+ *
+ * "which provider will this agent use" and "create a PR agent with anthropic"
+ * both name a provider, but neither is a request to connect one — the card was
+ * posted on both and read as noise. An agent's provider lives in its own Keys
+ * dialog, so a user-level connect card is the wrong answer here regardless.
+ */
+const AGENT_CONTEXT = /\bagents?\b|\bsubagents?\b|@[a-z0-9-]+/i;
+
 const ROSTER_INTENT =
   /\b(show|see|view|open|display|list|find|browse|bring up|pull up|what|which|how many|any)\b/i;
 
@@ -130,6 +140,7 @@ const CONNECT_INTENT =
  */
 export function wantsProviderRoster(text: string): boolean {
   if (!text.trim()) return false;
+  if (AGENT_CONTEXT.test(text)) return false;
   if (!PROVIDER_NOUN.test(text)) return false;
   // "I want to connect a provider" without naming one is also a roster ask —
   // they cannot name what they have not been shown yet.
@@ -144,6 +155,7 @@ export function wantsProviderRoster(text: string): boolean {
  */
 export function providersUserAskedFor(text: string): SupportedProvider[] {
   if (!text.trim()) return [];
+  if (AGENT_CONTEXT.test(text)) return [];
   if (!CONNECT_INTENT.test(text) && !PROVIDER_NOUN.test(text)) return [];
   return providerTypesFromText(text);
 }

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -119,6 +119,7 @@ import JSZip from "jszip";
 import {
   buildTicketProposalFlow,
   buildMcpSuggestFlow,
+  buildProviderSuggestFlow,
   buildCodeFlow,
   buildDiffFlow,
   buildChartFlow,
@@ -131,6 +132,15 @@ import { isAgentInvocableBy } from "xyne-claw-shared";
 import type { Todo } from "xyne-claw-shared";
 import { tools as xyneSpacesTools } from "../mcp/servers/xyne-spaces-tools.js";
 import { connectorTypesFromText, connectorTypesUserAskedFor, wantsConnectorRoster } from "../lib/connector-hints.js";
+import {
+  SUPPORTED_PROVIDERS,
+  PROVIDER_LABELS,
+  PROVIDER_DESCRIPTIONS,
+  PROVIDER_CONNECT_METHOD,
+  providersUserAskedFor,
+  unsupportedProvidersFromText,
+  wantsProviderRoster,
+} from "../lib/provider-hints.js";
 import { availabilityForServerIds } from "../lib/connector-availability.js";
 
 const clog = createLogger("webhook");
@@ -6250,6 +6260,74 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
       }
     } catch (err) {
       log.warn("Failed to post connector suggestions (non-fatal)", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // AI provider suggestions. Unlike connectors the roster is a fixed list in
+  // code, so intent is read from the user's own message and the card is built
+  // without the model participating at all. A provider we do not offer is
+  // named back as unsupported rather than dropped, so the reply cannot promise
+  // a card that will never render.
+  if (agentCardDeliverable) {
+    try {
+      const askText = ctx.rootTask ?? ctx.task ?? "";
+      const namedProviders = providersUserAskedFor(askText);
+      const unsupported = unsupportedProvidersFromText(askText);
+      const providerRoster = wantsProviderRoster(askText);
+
+      if (namedProviders.length > 0 || providerRoster) {
+        const creds = await userProviderCredentialsRepository
+          .listByUser(ctx.senderId)
+          .catch(() => []);
+        const connectedByProvider = new Map(creds.map((c) => [c.provider, c] as const));
+
+        const shown = providerRoster ? [...SUPPORTED_PROVIDERS] : namedProviders;
+        const providers = shown.map((provider) => {
+          const cred = connectedByProvider.get(provider);
+          return {
+            provider,
+            name: PROVIDER_LABELS[provider] ?? provider,
+            ...(PROVIDER_DESCRIPTIONS[provider]
+              ? { description: PROVIDER_DESCRIPTIONS[provider] as string }
+              : {}),
+            connected: provider === "spaces" ? true : !!cred,
+            ...(cred?.sharedCredentialId ? { sharedName: "Shared with your org" } : {}),
+            ...(PROVIDER_CONNECT_METHOD[provider]
+              ? { connectMethod: PROVIDER_CONNECT_METHOD[provider] as "oauth" | "device" | "api_key" | "none" }
+              : {}),
+          };
+        });
+
+        const flow = withSpacesAppId(
+          buildProviderSuggestFlow({
+            providers,
+            title: providerRoster ? "AI providers you can connect" : "Connect this provider",
+            ...(providerRoster ? { browseAll: true, totalCount: SUPPORTED_PROVIDERS.length } : {}),
+            ...(unsupported.length > 0
+              ? { reason: `${unsupported.join(", ")} ${unsupported.length === 1 ? "is" : "are"} not available on Xyne.` }
+              : {}),
+            screenKey: `${ctx.senderId}-${shown.join("-")}`,
+            ...(ctx.agentSlug ? { agentSlug: ctx.agentSlug } : {}),
+            userId: ctx.senderId,
+            conversationId: ctx.conversationId,
+            channelId: ctx.channelId,
+          }),
+          ctx.spacesAppId,
+        );
+        await spacesAppFetch("/chat/postMessage", {
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          flow,
+          userId: ctx.spacesAppUserId,
+        }, ctx.appToken);
+        log.info(`[provider-suggest] posted ${providers.length} provider cards conv=${ctx.conversationId}`);
+      } else if (unsupported.length > 0) {
+        log.info(`[provider-suggest] unsupported only: ${unsupported.join(", ")} — no card`);
+      }
+    } catch (err) {
+      log.warn("Failed to post provider suggestions (non-fatal)", {
         error: err instanceof Error ? err.message : String(err),
       });
     }

--- a/packages/shared/src/types/flowUI.ts
+++ b/packages/shared/src/types/flowUI.ts
@@ -37,6 +37,7 @@ export type FlowComponentType =
   | 'slash_command_artifact'
   | 'agent_summary'
   | 'mcp_suggest'
+  | 'provider_suggest'
 
 
 export interface FlowComponent {

--- a/packages/shared/src/validation/flowSchema.ts
+++ b/packages/shared/src/validation/flowSchema.ts
@@ -952,6 +952,39 @@ export const mcpSuggestComponentSchema = baseComponentSchema.extend({
 export type McpSuggestItem = z.infer<typeof mcpSuggestItemSchema>;
 export type McpSuggestProps = z.infer<typeof mcpSuggestPropsSchema>;
 
+export const providerSuggestItemSchema = z
+  .object({
+    provider: z.string().min(1),
+    name: z.string().min(1),
+    description: z.string().optional(),
+    /** The user's own credential — never the agent's or an org-shared one. */
+    connected: z.boolean().optional(),
+    /** Available through a credential an admin shared, so it works unconfigured. */
+    sharedName: z.string().optional(),
+    /** How the card connects it: nothing else is a valid action. */
+    connectMethod: z.enum(['oauth', 'device', 'api_key', 'none']).optional(),
+  })
+  .strict();
+
+export const providerSuggestPropsSchema = z
+  .object({
+    title: z.string().optional(),
+    reason: z.string().optional(),
+    providers: z.array(providerSuggestItemSchema).min(1),
+    /** Roster mode: the user asked what exists, so offer a link to settings. */
+    browseAll: z.boolean().optional(),
+    totalCount: z.number().int().nonnegative().optional(),
+  })
+  .strict();
+
+export const providerSuggestComponentSchema = baseComponentSchema.extend({
+  type: z.literal('provider_suggest'),
+  props: providerSuggestPropsSchema,
+});
+
+export type ProviderSuggestItem = z.infer<typeof providerSuggestItemSchema>;
+export type ProviderSuggestProps = z.infer<typeof providerSuggestPropsSchema>;
+
 export const mcpConfigureComponentSchema = baseComponentSchema.extend({
   type: z.literal('mcpConfigure'),
   props: mcpConfigurePropsSchema,
@@ -989,6 +1022,7 @@ export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
     agentComponentSchema,
     mcpConfigureComponentSchema,
     mcpSuggestComponentSchema,
+    providerSuggestComponentSchema,
     slashCommandArtifactComponentSchema,
     // Container types — inline here so they can reference flowComponentSchema
     baseComponentSchema.extend({
@@ -1026,7 +1060,7 @@ export const flowComponentSchema: z.ZodType<any> = z.lazy(() =>
 const KNOWN_COMPONENT_TYPES = new Set([
   'text', 'heading', 'input', 'textarea', 'dropdown', 'select', 'multiselect',
   'date', 'button', 'divider', 'image', 'link', 'table', 'plan', 'pr',
-  'pr_approval', 'call_schedule', 'agent', 'agent_summary', 'mcpConfigure', 'mcp_suggest', 'row', 'column', 'card',
+  'pr_approval', 'call_schedule', 'agent', 'agent_summary', 'mcpConfigure', 'mcp_suggest', 'provider_suggest', 'row', 'column', 'card',
 ]);
 
 const unknownComponentSchema = baseComponentSchema

--- a/packages/xyne-claw-shared/src/flow/builder.ts
+++ b/packages/xyne-claw-shared/src/flow/builder.ts
@@ -32,6 +32,7 @@ type FlowComponentType =
   | 'agent'
   | 'agent_summary'
   | 'mcp_suggest'
+  | 'provider_suggest'
   | 'mcpConfigure'
   | 'pr'
   | 'user_question'
@@ -1228,6 +1229,61 @@ export function buildChartFlow(chart: ChartArtifact): FlowDefinition {
       fallbackText: chart.caption?.trim()
         ? chart.caption.trim()
         : `${chart.type} chart · ${pointCount} point${pointCount === 1 ? '' : 's'}`,
+    })
+    .build();
+}
+
+export interface ProviderSuggestItem {
+  provider: string;
+  name: string;
+  description?: string;
+  connected?: boolean;
+  sharedName?: string;
+  connectMethod?: "oauth" | "device" | "api_key" | "none";
+}
+
+/**
+ * AI provider suggestions posted into a conversation. Same shape as the
+ * connector card, but the provider list is a fixed six defined in code rather
+ * than DB rows, so the server can answer "what do I have?" without the model.
+ */
+export function buildProviderSuggestFlow(context: {
+  providers: ProviderSuggestItem[];
+  title?: string;
+  reason?: string;
+  browseAll?: boolean;
+  totalCount?: number;
+  screenKey: string;
+  agentSlug?: string;
+  userId: string;
+  conversationId?: string;
+  channelId?: string;
+}): FlowDefinition {
+  return new FlowBuilder(`provider-suggest-${context.screenKey}`)
+    .addComponent({
+      id: "provider-suggest",
+      type: "provider_suggest",
+      props: {
+        ...(context.title ? { title: context.title } : {}),
+        ...(context.reason ? { reason: context.reason } : {}),
+        ...(context.browseAll ? { browseAll: true } : {}),
+        ...(context.totalCount !== undefined ? { totalCount: context.totalCount } : {}),
+        providers: context.providers.map((p) => ({
+          provider: p.provider,
+          name: p.name,
+          ...(p.description ? { description: p.description } : {}),
+          ...(p.connected !== undefined ? { connected: p.connected } : {}),
+          ...(p.sharedName ? { sharedName: p.sharedName } : {}),
+          ...(p.connectMethod ? { connectMethod: p.connectMethod } : {}),
+        })),
+      },
+    })
+    .setData({
+      actionType: "provider-suggest",
+      ...(context.agentSlug ? { agentSlug: context.agentSlug } : {}),
+      userId: context.userId,
+      ...(context.conversationId ? { conversationId: context.conversationId } : {}),
+      ...(context.channelId ? { channelId: context.channelId } : {}),
     })
     .build();
 }

--- a/packages/xyne-claw-shared/src/index.ts
+++ b/packages/xyne-claw-shared/src/index.ts
@@ -55,7 +55,7 @@ export {
 } from "./skill-diff/index.js";
 export type { SkillDiff, SkillForAuthz, ApproverResolution, SkillApprovalAuthz, SkillFileUpdateAuthz } from "./skill-diff/index.js";
 export { createSkillTool, updateSkillTool } from "./tools/skill-management/index.js";
-export { FlowBuilder, mdToMrkdwn, buildWriteApprovalFlow, buildWriteResultFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildCapacityRetryFlow, buildGoalSuggestionFlow, buildAgentCallProposalFlow, buildCloneApprovalFlow, buildSkillUpdateApprovalFlow, buildMcpConfigureFlow, buildMcpSuggestFlow, type McpSuggestConnector, buildCodeFlow, buildDiffFlow, buildTicketFlow, buildTicketProposalFlow, buildChartFlow } from "./flow/builder.js";
+export { FlowBuilder, mdToMrkdwn, buildWriteApprovalFlow, buildWriteResultFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildCapacityRetryFlow, buildGoalSuggestionFlow, buildAgentCallProposalFlow, buildCloneApprovalFlow, buildSkillUpdateApprovalFlow, buildMcpConfigureFlow, buildMcpSuggestFlow, type McpSuggestConnector, buildProviderSuggestFlow, type ProviderSuggestItem, buildCodeFlow, buildDiffFlow, buildTicketFlow, buildTicketProposalFlow, buildChartFlow } from "./flow/builder.js";
 export type { FlowDefinition, FlowComponent, FlowAction, SelectOption, TicketArtifact, ChartArtifact } from "./flow/builder.js";
 export { buildPlanFlow, PLAN_COMPONENT_ID } from "./flow/plan-flow.js";
 export { isFlowJsonContent, parseFlowJsonComponents, extractTextFromFlowJson, extractCleanTextFromFlowJson } from "./flow/flow-text.js";


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
