### PR TITLE
fix: XYNE-63385 MCP connect dialog collects no credentials for code-defined connectors

### DIFF
--- a/apps/dashboard/src/routes/AIScreen/library/mcp/detail/McpConnectDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/mcp/detail/McpConnectDialog.tsx
@@ -1,18 +1,23 @@
 import { type ReactElement, useEffect, useState } from 'react';
 import { Button } from '@/components/ui/Button/Button';
-import { createMcpConnection, mcpCredentialFields } from '@/services/claw/clawMcpService';
+import { createMcpConnection } from '@/services/claw/clawMcpService';
 import type { McpServer } from '@/services/claw/clawMcpTypes';
 import { V2Dialog } from '../../shared/primitives/V2Dialog';
 import { McpLogo } from '../../shared/pickers/mcp/McpLogo';
+import { useMcpCredentialFields } from '../../shared/pickers/mcp/useMcpCredentialFields';
 
 /**
  * Collects a connector's own credentials (url, token, api key, …) and creates
  * the connection.
  *
- * Which inputs to show comes from the connector itself — its saved
- * `credentialForm`, else derived from its JSON `credentialSchema` — so a new
- * connector needs no change here to be connectable. Values are posted straight
- * to claw-auth and never stored client-side.
+ * Which inputs to show comes from the /servers/credential-fields registry
+ * first, falling back to the connector's own `credentialForm` /
+ * `credentialSchema` columns. Reading the columns alone is what broke prod:
+ * they are nullable and unset for connectors whose fields live only in code
+ * (amplitude, asana, bigquery, bitbucket…), so the dialog said "no details
+ * needed" and Connect posted an empty bag the backend then rejected.
+ *
+ * Values are posted straight to claw-auth and never stored client-side.
  */
 interface McpConnectDialogProps {
   server: McpServer;
@@ -35,7 +40,8 @@ export const McpConnectDialog = ({
   onOpenChange,
   onConnected,
 }: McpConnectDialogProps): ReactElement => {
-  const fields = mcpCredentialFields(server);
+  const { fieldsFor, loading: fieldsLoading } = useMcpCredentialFields();
+  const fields = fieldsFor(server);
   const [values, setValues] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -54,7 +60,7 @@ export const McpConnectDialog = ({
   );
 
   const handleSubmit = async (): Promise<void> => {
-    if (submitting || missingRequired) return;
+    if (submitting || fieldsLoading || missingRequired) return;
     setError(null);
     setSubmitting(true);
     try {
@@ -87,7 +93,7 @@ export const McpConnectDialog = ({
           </Button>
           <Button
             onClick={(): void => void handleSubmit()}
-            disabled={submitting || missingRequired}
+            disabled={submitting || fieldsLoading || missingRequired}
             data-track-category='Claw MCP'
             data-track-name='SubmitConnectMcp'
           >
@@ -110,7 +116,9 @@ export const McpConnectDialog = ({
 
       {fields.length === 0 ? (
         <p className='text-sm text-muted-foreground'>
-          This connector needs no details — confirm to connect.
+          {fieldsLoading
+            ? 'Checking what this connector needs…'
+            : 'This connector needs no details — confirm to connect.'}
         </p>
       ) : (
         fields.map(field => (


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->

XYNE-63385. Connecting Amplitude, Asana, BigQuery or Bitbucket from Spaces
failed with `amplitude requires 'apiKey'`. The dialog said **"This connector
needs no details — confirm to connect"** and posted an empty credential bag.

A connector's required fields exist in two places: the adapter in code, and the
`mcp_servers.credentialForm` / `credentialSchema` columns. Those columns are
nullable and **unset in pre-prod and prod** for connectors whose fields live
only in code. The dialog read the columns directly, saw nothing, and collected
nothing.

The *gate* that decides whether to open the dialog was already fixed to resolve
from `/servers/credential-fields`. The dialog that renders the inputs was not —
so the bug only surfaced once the dialog correctly started appearing.

This switches the dialog to the existing `useMcpCredentialFields` hook, which
asks that endpoint and falls back to the columns only when it cannot answer.
Worth noting the endpoint is itself DB-first where it should be — an http
connector with a launch config resolves from its own row; stdio resolves from
code because its launch command is code-reviewed. So this defers to the
server's precedence rather than second-guessing it, and matches what claw v1
and v3 already do.

Also disables Connect while the lookup is in flight: `fieldsFor` returns the
column fallback until it resolves, so a fast click could otherwise still have
posted an empty bag.


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->

The bug cannot reproduce on a default local DB — local rows have
`credentialForm` populated. So I reproduced pre-prod by nulling the column for
the four affected connectors, and confirmed the registry still resolves them:

```
amplitude  -> [apiKey]
asana      -> [accessToken]
bigquery   -> [projectId, keyFile, location]
bitbucket  -> [username, token, baseUrl]
```

- Amplitude -> Connect now shows the API Key field instead of "needs no details"
- BigQuery -> shows all three fields
- Grafana (column still set) -> unchanged, so the DB path still works
- Verified no other caller reads the columns directly: `mcpCredentialFields` has
  no remaining callers outside the service and the hook


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- no runner configured for apps/dashboard; this is a one-line source swap in a presentational dialog -->

### Manual

**Users**
- [x] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [x] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [x] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [x] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [x] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbkst9h49jK2WvvwywM1ZR
