### PR TITLE
fix: XYNE-63485 resolve DM/group-DM channel names in mention notifications

### DIFF
--- a/apps/backend/src/controllers/canvasController.ts
+++ b/apps/backend/src/controllers/canvasController.ts
@@ -858,15 +858,6 @@ export class CanvasController {
       });
       const canvasChannelId = canvasRecord?.channelId;
 
-      // Fetch channel name if canvas is linked to a channel
-      const channel = canvasChannelId
-        ? await db.channel.findUnique({
-            where: { id: canvasChannelId },
-            select: { name: true },
-          })
-        : null;
-      const channelName = channel?.name;
-
       // Resolve mentioned users
       const mentionedUsers: { userId: string; mentionSource: 'direct' | 'group' }[] = [];
 
@@ -962,7 +953,6 @@ export class CanvasController {
           userId,
           senderName,
           req.user?.workspaceId ?? '',
-          channelName,
           blockId,
           commentThreadId,
           canvasChannelId ?? undefined,

--- a/apps/backend/src/services/notificationService.ts
+++ b/apps/backend/src/services/notificationService.ts
@@ -25,6 +25,7 @@ import { buildInitialMessageMd,
   NotificationDeliveryMethod,
   NotificationType, MessageType, NotificationStatus, UserStatus, ActivityClassification, TicketStatusV2 } from '@xyne/shared';
 import { activityService } from '@/services/activity/activityService';
+import { isDMScope, parseDMParticipantIds, formatMentionLocation } from '@/utils/channelDisplayName';
 
 const prisma = DatabaseClient.getInstance();
 
@@ -1112,9 +1113,15 @@ class NotificationService {
     prefetchedData?: PrefetchedFilterData,
     isGroupDM: boolean = false,
   ): Promise<{ deliveredUserIds: string[] }> {
+    // Resolve the location fragment once. Regular channels keep the zero-cost
+    // `#name` path; only DM / GROUP_DM channels (whose `channelName` is the raw
+    // participant-id CSV) go through the resolver, which returns real names.
+    const channelLocation = isDMChannel
+      ? ((await this.resolveChannelNotificationLabel(channelId, senderId)) ?? 'a direct message')
+      : `#${channelName}`;
     const title = mentionType
-      ? `${mentionType} in #${channelName}`
-      : `You were mentioned in #${channelName}`;
+      ? `${mentionType} in ${channelLocation}`
+      : `You were mentioned in ${channelLocation}`;
 
     const recipientIds = userIds.filter(id => id !== senderId);
 
@@ -1306,6 +1313,52 @@ class NotificationService {
   }
 
   /**
+   * Turn a channelId into a safe notification location fragment:
+   * `#name` for a regular channel, or the DM participants' names for a
+   * DM / GROUP_DM. Never returns the raw participant-id CSV that lives in
+   * `channel.name` for direct-message channels. `viewerId` (the sender or the
+   * recipient) is excluded from DM labels.
+   *
+   * Single backend home for channel-name resolution — every mention title
+   * routes through here instead of interpolating `channel.name` on its own.
+   */
+  private async resolveChannelNotificationLabel(
+    channelId: string,
+    viewerId?: string | null,
+  ): Promise<string | null> {
+    const channel = await prisma.channel.findUnique({
+      where: { id: channelId },
+      select: { name: true, scopeType: true },
+    });
+    if (!channel) return null;
+
+    // Prisma types `scopeType` as a plain string; it carries the same values as
+    // the shared ChannelScopeType enum.
+    const scopeType = channel.scopeType as ChannelScopeType;
+
+    let participantNames = new Map<string, string>();
+    if (isDMScope(scopeType)) {
+      const ids = parseDMParticipantIds(channel.name, scopeType);
+      if (ids.length > 0) {
+        const users = await prisma.user.findMany({
+          where: { id: { in: ids } },
+          select: { id: true, name: true, displayName: true },
+        });
+        participantNames = new Map(
+          users.map(u => [u.id, u.displayName || u.name || '']),
+        );
+      }
+    }
+
+    return formatMentionLocation({
+      scopeType,
+      name: channel.name,
+      participantNames,
+      viewerId,
+    });
+  }
+
+  /**
    * Send mention notifications for canvas mentions.
    * Mirrors message mention flow: when canvas is in a channel, use "You were mentioned in #channelName".
    * Respects global pause and channel notification level (NONE = silenced).
@@ -1317,7 +1370,6 @@ class NotificationService {
     senderId: string,
     senderName: string,
     workspaceId: string,
-    channelName?: string,
     blockId?: string,
     commentThreadId?: string,
     channelId?: string | null,
@@ -1328,6 +1380,14 @@ class NotificationService {
       logger.info(`[NOTIFICATION-SERVICE] No recipients after filtering, skipping notification creation`);
       return { deliveredUserIds: [] };
     }
+
+    // Resolve the channel into a safe location label. The raw `channel.name` is
+    // the participant-id CSV for DM / GROUP_DM channels, so it must never be
+    // interpolated into a title directly — resolveChannelNotificationLabel
+    // returns real participant names for those (viewer = the canvas author).
+    const channelLocation = channelId
+      ? await this.resolveChannelNotificationLabel(channelId, senderId)
+      : null;
 
     // Apply pause and channel-level filtering.
     // If the canvas is in a channel, use channel-level settings; otherwise fall back to global pause only.
@@ -1348,13 +1408,13 @@ class NotificationService {
     const isCommentMention = mentionContext === 'comment';
     const title = isCommentMention
       ? `You were mentioned in a comment on ${canvasTitle}`
-      : channelName
-        ? `You were mentioned in #${channelName}`
+      : channelLocation
+        ? `You were mentioned in ${channelLocation}`
         : `You were mentioned in ${canvasTitle}`;
     const message = isCommentMention
       ? ''
-      : channelName
-        ? `${senderName} mentioned you in #${channelName}`
+      : channelLocation
+        ? `${senderName} mentioned you in ${channelLocation}`
         : `${senderName} mentioned you in a canvas`;
 
     const notificationData = {

--- a/apps/backend/src/utils/channelDisplayName.test.ts
+++ b/apps/backend/src/utils/channelDisplayName.test.ts
@@ -1,0 +1,129 @@
+import { ChannelScopeType } from '@xyne/shared';
+import {
+  isDMScope,
+  parseDMParticipantIds,
+  resolveChannelMentionLabel,
+  formatMentionLocation,
+} from './channelDisplayName';
+
+const names = new Map<string, string>([
+  ['u1', 'Alice'],
+  ['u2', 'Bob'],
+  ['u3', 'Carol'],
+  ['u4', 'Dave'],
+  ['u5', 'Erin'],
+]);
+
+describe('channelDisplayName', () => {
+  describe('isDMScope', () => {
+    it('is true for DM and GROUP_DM only', () => {
+      expect(isDMScope(ChannelScopeType.DM)).toBe(true);
+      expect(isDMScope(ChannelScopeType.GROUP_DM)).toBe(true);
+      expect(isDMScope(ChannelScopeType.DEFAULT)).toBe(false);
+      expect(isDMScope(null)).toBe(false);
+      expect(isDMScope(undefined)).toBe(false);
+    });
+  });
+
+  describe('parseDMParticipantIds', () => {
+    it('splits the id CSV for DM channels', () => {
+      expect(parseDMParticipantIds('u1,u2,u3', ChannelScopeType.GROUP_DM)).toEqual(['u1', 'u2', 'u3']);
+    });
+    it('returns [] for a non-DM channel', () => {
+      expect(parseDMParticipantIds('engineering', ChannelScopeType.DEFAULT)).toEqual([]);
+    });
+    it('tolerates spaces and empty segments', () => {
+      expect(parseDMParticipantIds(' u1 , ,u2 ', ChannelScopeType.DM)).toEqual(['u1', 'u2']);
+    });
+  });
+
+  describe('resolveChannelMentionLabel', () => {
+    it('returns the raw name for a regular channel (caller prefixes #)', () => {
+      expect(
+        resolveChannelMentionLabel({
+          scopeType: ChannelScopeType.DEFAULT,
+          name: 'engineering',
+          participantNames: names,
+        }),
+      ).toEqual({ label: 'engineering', isDm: false });
+    });
+
+    it('names a 1:1 DM after the other participant, not the id CSV', () => {
+      expect(
+        resolveChannelMentionLabel({
+          scopeType: ChannelScopeType.DM,
+          name: 'u1,u2',
+          participantNames: names,
+          viewerId: 'u1',
+        }),
+      ).toEqual({ label: 'Bob', isDm: true });
+    });
+
+    it('lists group-DM participant names excluding the viewer', () => {
+      expect(
+        resolveChannelMentionLabel({
+          scopeType: ChannelScopeType.GROUP_DM,
+          name: 'u1,u2,u3',
+          participantNames: names,
+          viewerId: 'u1',
+        }),
+      ).toEqual({ label: 'Bob, Carol', isDm: true });
+    });
+
+    it('summarises large group DMs as "and N others"', () => {
+      expect(
+        resolveChannelMentionLabel({
+          scopeType: ChannelScopeType.GROUP_DM,
+          name: 'u1,u2,u3,u4,u5',
+          participantNames: names,
+          viewerId: 'u1',
+        }),
+      ).toEqual({ label: 'Bob, Carol, Dave and 1 other', isDm: true });
+    });
+
+    it('falls back to a neutral phrase when names are unresolved — never a cuid', () => {
+      const label = resolveChannelMentionLabel({
+        scopeType: ChannelScopeType.GROUP_DM,
+        name: 'ck1,ck2,ck3',
+        participantNames: new Map(),
+        viewerId: 'ck1',
+      });
+      expect(label.isDm).toBe(true);
+      expect(label.label).toBe('a direct message');
+      expect(label.label).not.toContain('ck2');
+    });
+
+    it('handles a self-DM', () => {
+      expect(
+        resolveChannelMentionLabel({
+          scopeType: ChannelScopeType.DM,
+          name: 'u1',
+          participantNames: names,
+          viewerId: 'u1',
+        }),
+      ).toEqual({ label: 'Alice (you)', isDm: true });
+    });
+  });
+
+  describe('formatMentionLocation', () => {
+    it('prefixes # for regular channels', () => {
+      expect(
+        formatMentionLocation({
+          scopeType: ChannelScopeType.DEFAULT,
+          name: 'engineering',
+          participantNames: names,
+        }),
+      ).toBe('#engineering');
+    });
+    it('does NOT prefix # for DMs', () => {
+      expect(
+        formatMentionLocation({
+          scopeType: ChannelScopeType.GROUP_DM,
+          name: 'u1,u2,u3',
+          participantNames: names,
+          viewerId: 'u1',
+        }),
+      ).toBe('Bob, Carol');
+    });
+  });
+});

--- a/apps/backend/src/utils/channelDisplayName.ts
+++ b/apps/backend/src/utils/channelDisplayName.ts
@@ -1,0 +1,118 @@
+import { ChannelScopeType } from '@xyne/shared';
+
+/**
+ * Backend channel-name resolution — the single source of truth for turning a
+ * channel row into a human label in server-generated text (notifications,
+ * activity, Slack mirrors).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `channel.name` is a complected column: for DEFAULT channels it is a human
+ * display name, but for DM / GROUP_DM channels it holds the participant user
+ * ids comma-joined (e.g. `"cuidA,cuidB,cuidC"`, sorted). Interpolating it raw
+ * into a title (`#${channel.name}`) prints cuids to the user — the exact
+ * canvas / call-summary "hashes in the notification" defect.
+ *
+ * The frontend already isolates this in `useChannelDisplayName` /
+ * `ChatDirectory.utils.resolveChannelLabel`. The backend had no equivalent, so
+ * every notification builder re-derived (or forgot) the DM branch on its own.
+ * This module is the backend counterpart: resolve names in ONE place so the raw
+ * id-CSV is never representable in a title again.
+ */
+
+export const isDMScope = (scopeType?: ChannelScopeType | null): boolean =>
+  scopeType === ChannelScopeType.DM || scopeType === ChannelScopeType.GROUP_DM;
+
+/**
+ * DM / GROUP_DM channels store their participant ids comma-joined in `name`.
+ * Returns [] for non-DM channels (their `name` is a real display name, not ids).
+ */
+export const parseDMParticipantIds = (
+  name: string | null | undefined,
+  scopeType?: ChannelScopeType | null,
+): string[] => {
+  if (scopeType != null && !isDMScope(scopeType)) return [];
+  return (name ?? '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+};
+
+export interface ChannelMentionLabelInput {
+  scopeType?: ChannelScopeType | null;
+  /** The raw `channel.name` column. */
+  name: string | null | undefined;
+  /** id -> display label (`displayName || name`) for the DM participants. */
+  participantNames: Map<string, string>;
+  /**
+   * The perspective the label is built for. For a notification this is the
+   * viewer/recipient (or the sender) and is excluded from a DM label so we
+   * don't name a conversation after the person reading it.
+   */
+  viewerId?: string | null;
+}
+
+export interface ChannelMentionLabel {
+  /** Safe, human label. Never a raw id-CSV. */
+  label: string;
+  /** True for DM / GROUP_DM — callers must NOT prefix a '#'. */
+  isDm: boolean;
+}
+
+/**
+ * Resolve a channel into `{ label, isDm }` for use in a notification title.
+ *
+ * - DEFAULT / named channels -> `{ label: name, isDm: false }`. Caller prefixes '#'.
+ * - DM / GROUP_DM -> the OTHER participants' names (viewer excluded), matching
+ *   the frontend's "Alice, Bob and 2 others" convention. Never the id-CSV.
+ *
+ * Pure and synchronous — the caller is responsible for loading `participantNames`.
+ */
+export function resolveChannelMentionLabel(
+  input: ChannelMentionLabelInput,
+): ChannelMentionLabel {
+  const { scopeType, name, participantNames, viewerId } = input;
+
+  if (!isDMScope(scopeType)) {
+    return { label: name ?? 'a channel', isDm: false };
+  }
+
+  const ids = parseDMParticipantIds(name, scopeType);
+  const otherIds = ids.filter(id => id !== viewerId);
+
+  // Self-DM: the viewer is the only participant.
+  if (otherIds.length === 0) {
+    const self = viewerId ? participantNames.get(viewerId) : undefined;
+    return { label: self ? `${self} (you)` : 'yourself', isDm: true };
+  }
+
+  const names = otherIds
+    .map(id => participantNames.get(id))
+    .filter((n): n is string => Boolean(n));
+
+  // Participants not resolvable (not loaded / deleted) — a neutral phrase still
+  // beats a cuid.
+  if (names.length === 0) {
+    return { label: 'a direct message', isDm: true };
+  }
+
+  if (otherIds.length <= 3) {
+    return { label: names.join(', '), isDm: true };
+  }
+
+  const visible = names.slice(0, 3);
+  const remaining = otherIds.length - visible.length;
+  return {
+    label: `${visible.join(', ')} and ${remaining} other${remaining > 1 ? 's' : ''}`,
+    isDm: true,
+  };
+}
+
+/**
+ * Convenience: the "in <location>" fragment used by mention titles.
+ * DEFAULT -> `#name`; DM -> the participant names (no '#').
+ */
+export function formatMentionLocation(input: ChannelMentionLabelInput): string {
+  const { label, isDm } = resolveChannelMentionLabel(input);
+  return isDm ? label : `#${label}`;
+}

--- a/apps/backend/src/zero/side-effects/tables/canvas-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/canvas-handler.ts
@@ -82,16 +82,6 @@ export class CanvasSideEffectHandler extends BaseSideEffectHandler {
       const bot = await repositories.users.findById(createdByUserId);
       const senderName = bot?.name || 'Xyne Automatic';
 
-      // Get channel name if canvas is in a channel
-      let channelName: string | undefined;
-      if (canvas.channelId) {
-        const channel = await db.channel.findUnique({
-          where: { id: canvas.channelId },
-          select: { name: true },
-        });
-        channelName = channel?.name || undefined;
-      }
-
       // Create activity entries for activity tab
       const activities = recipientIds.map(userId => ({
         userId,
@@ -121,7 +111,6 @@ export class CanvasSideEffectHandler extends BaseSideEffectHandler {
           createdByUserId,
           senderName,
           this.ctx.workspaceId,
-          channelName,
           undefined, // no specific blockId for AI-generated content
           undefined, // no comment thread for AI-generated content
           canvas.channelId ?? undefined,


### PR DESCRIPTION
## Problem

`channel.name` is a **complected** column (a Hickey violation): for regular channels it holds a human display name, but for `DM` / `GROUP_DM` channels it holds the participant user-ids comma-joined (`"cuidA,cuidB,..."`). Every backend notification builder interpolated it raw into titles as `` `#${channel.name}` ``, so **DM / group-DM mention notifications rendered cuids/hashes instead of participant names** — this is the reported "hashes in canvas call-summary notification" defect.

The naming logic was also **fragmented** (a Löwy violation): the frontend isolates it in `useChannelDisplayName` / `resolveChannelLabel`, but the backend had no equivalent, so each notification surface re-derived (or, for the canvas path, entirely forgot) the DM branch. `createCanvasMentionNotifications` didn't even receive the channel's scope type.

## Fix (refactor first, bug fixed as a side-effect)

1. **New single backend resolver** — `apps/backend/src/utils/channelDisplayName.ts`. Pure helpers (`isDMScope`, `parseDMParticipantIds`, `resolveChannelMentionLabel`, `formatMentionLocation`) mirroring the frontend convention: regular channel → `#name`; DM/GROUP_DM → the other participants' names ("Alice, Bob and 2 others"), viewer excluded; never the raw id-CSV. This is the isolated boundary the Löwy violation was missing.
2. **Canvas mention path routed through it (Hickey fix).** Dropped the `channelName?: string` parameter from `createCanvasMentionNotifications` so the raw name is no longer *representable* in a canvas title; the service now resolves the label internally from `channelId`. Both callers (`canvas-handler.ts`, `canvasController.ts`) stop fetching/passing raw `channel.name`. The reported bug disappears as a side-effect.
3. **Message-mention title routed through it too.** `createMentionNotifications` builds the same `#${channelName}` title and had the identical latent defect; it now uses the resolver. Guarded so **regular channels keep the zero-cost `#name` path** (no extra query) — only DM/GROUP_DM channels do the participant lookup.

## Scope boundary

The DM/group-DM *message* builder (`createDMNotification`), thread-reply, and keyword builders share the same raw-name pattern but live on the hottest notification path. Migrating them is deferred to a follow-up to keep this PR's blast radius contained — the new resolver is the sanctioned home for that migration.

## Tests

- New unit tests `apps/backend/src/utils/channelDisplayName.test.ts` (regular / 1:1 DM / group DM / large group / unresolved-fallback / self-DM / `#`-prefix). Logic verified green via tsx.
- `tsc --noEmit` shows no new type errors from the changed files (pre-existing stale-`@xyne/shared`-dist errors are unrelated).