### PR TITLE
fix: XYNE-63395: CodeQL hardening for claw-auth and claw-shared

### DIFF
--- a/apps/xyne-claw-auth/backend/src/http/routes.ts
+++ b/apps/xyne-claw-auth/backend/src/http/routes.ts
@@ -71,6 +71,7 @@ import { slackRouter } from "../surfaces/slack/routes/index.js";
 import { mcpGatewayRouter } from "../mcpgateway/index.js";
 import { requireAuth, requireNoAccessToken, allowReadAccessToken, requireStrictS2S, requireInternalS2S, requireUserAuth, optionalAuth, s2sKeyMatches } from "../middleware/require-auth.js";
 import { requireClawAdmin, requireSearchEvalAccess } from "../middleware/agent-acl.js";
+import { apiLimiter } from "../middleware/rate-limiters.js";
 
 const BASE = "/claw/api/v1";
 
@@ -105,6 +106,8 @@ function mountRequestContext(app: Express): void {
   app.get("/claw/health", (_req: Request, res: Response) => {
     res.json({ status: "ok", service: "xyne-claw-auth", uptime: process.uptime() });
   });
+
+  app.use(BASE, apiLimiter);
 }
 
 function mountCoreApi(app: Express): void {

--- a/apps/xyne-claw-auth/backend/src/lib/agent-widget-binding.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-widget-binding.ts
@@ -32,12 +32,12 @@ export type WidgetKind = "pr" | "plan";
  * "PROJECT/repo" while the webhook exposes project.key + repo.slug separately).
  */
 export function normalizePrUrl(url: string): string {
-  return url
-    .trim()
-    .toLowerCase()
-    .replace(/^https?:\/\//, "")
-    .replace(/[?#].*$/, "")
-    .replace(/\/+$/, "");
+  const withoutScheme = url.trim().toLowerCase().replace(/^https?:\/\//, "");
+  const cut = withoutScheme.search(/[?#]/);
+  const path = cut === -1 ? withoutScheme : withoutScheme.slice(0, cut);
+  let end = path.length;
+  while (end > 0 && path.charCodeAt(end - 1) === 47) end -= 1;
+  return path.slice(0, end);
 }
 
 export interface WidgetBindingInput {

--- a/apps/xyne-claw-auth/backend/src/lib/citations.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/citations.ts
@@ -50,7 +50,7 @@ export function hydrateCitationIcons<T>(invocations: T): T {
 export function collectCitationIconUrls(
   invocations: unknown,
 ): Record<string, string> {
-  const out: Record<string, string> = {};
+  const out: Record<string, string> = Object.create(null);
   if (!Array.isArray(invocations)) return out;
   for (const inv of invocations) {
     if (!inv || typeof inv !== "object") continue;

--- a/apps/xyne-claw-auth/backend/src/lib/log-safe.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/log-safe.ts
@@ -1,0 +1,6 @@
+const CONTROL_CHARS_RE = /[\u0000-\u001f\u007f-\u009f]/g;
+
+export function logSafe(value: unknown): string {
+  const text = typeof value === "string" ? value : String(value ?? "");
+  return text.replace(CONTROL_CHARS_RE, " ");
+}

--- a/apps/xyne-claw-auth/backend/src/lib/safe-keys.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/safe-keys.ts
@@ -1,0 +1,5 @@
+const FORBIDDEN_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+export function isSafeObjectKey(key: unknown): key is string {
+  return typeof key === "string" && key.length > 0 && !FORBIDDEN_KEYS.has(key);
+}

--- a/apps/xyne-claw-auth/backend/src/lib/session-tokens.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/session-tokens.ts
@@ -15,7 +15,7 @@ export interface SessionTokenPayload {
 
 function b64url(input: Buffer | string): string {
   const buf = typeof input === "string" ? Buffer.from(input, "utf8") : input;
-  return buf.toString("base64").replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+  return buf.toString("base64url");
 }
 
 function fromB64url(input: string): Buffer {

--- a/apps/xyne-claw-auth/backend/src/lib/start-run.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/start-run.ts
@@ -57,6 +57,7 @@ import { isScheduledOrAutomationEvent } from "./run-bridge.js";
 import { dispatchRun } from "./dispatch-run.js";
 import { createLogger } from "../logger.js";
 import type { SessionContext } from "../routes/webhook.js";
+import { isSafeObjectKey } from "./safe-keys.js";
 
 const log = createLogger("run");
 
@@ -1076,11 +1077,15 @@ export async function prepareRun(
         const cfg = effectiveProviderConfigs?.[runOverride.provider];
         if (cfg) {
           effectiveProvider = runOverride.provider;
-          if (runOverride.model?.trim()) {
-            effectiveProviderConfigs = {
-              ...effectiveProviderConfigs,
-              [runOverride.provider]: { ...cfg, model: runOverride.model.trim() },
-            };
+          if (runOverride.model?.trim() && isSafeObjectKey(runOverride.provider)) {
+            const nextConfigs = { ...effectiveProviderConfigs };
+            Object.defineProperty(nextConfigs, runOverride.provider, {
+              value: { ...cfg, model: runOverride.model.trim() },
+              enumerable: true,
+              writable: true,
+              configurable: true,
+            });
+            effectiveProviderConfigs = nextConfigs;
           }
           effectiveProviderOrder = [];
         } else if (runOverride.provider === "litellm" && runOverride.model?.trim()) {

--- a/apps/xyne-claw-auth/backend/src/lib/url-path.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/url-path.ts
@@ -1,0 +1,31 @@
+const SEGMENT_RE = /^[A-Za-z0-9._~-]+$/;
+
+export function pathSegment(label: string, value: unknown): string {
+  const raw = typeof value === "string" ? value.trim() : typeof value === "number" ? String(value) : "";
+  if (!raw || !SEGMENT_RE.test(raw) || raw === "." || raw === "..") {
+    throw new Error(`${label}: invalid value — expected a single path segment matching [A-Za-z0-9._~-]+`);
+  }
+  return encodeURIComponent(raw);
+}
+
+export function safePathSegment(value: unknown): string | null {
+  const raw = typeof value === "string" ? value.trim() : typeof value === "number" ? String(value) : "";
+  if (!raw || !SEGMENT_RE.test(raw) || raw === "." || raw === "..") return null;
+  return encodeURIComponent(raw);
+}
+
+export function repoFilePath(label: string, value: unknown): string {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (!raw) throw new Error(`${label}: a relative repository path is required`);
+  if (/^[\\/]/.test(raw)) throw new Error(`${label}: path must be relative`);
+  return raw
+    .split("/")
+    .map((segment) => pathSegment(label, segment))
+    .join("/");
+}
+
+export function countTrailingBase64Padding(value: string): number {
+  let n = 0;
+  while (n < value.length && value.charCodeAt(value.length - 1 - n) === 61) n += 1;
+  return n;
+}

--- a/apps/xyne-claw-auth/backend/src/lib/webhook-commands/fast-mode.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/webhook-commands/fast-mode.ts
@@ -35,7 +35,7 @@ export async function handleFastModeToggle(ctx: WebhookCommandCtx, enabled: bool
 // typos were already handled (ack-only) by the parseSlashCommand branch
 // above, so only the with-task shape reaches this regex. `/fast off <task>`
 // disables fast mode and still runs the task.
-const FAST_TASK_RE = /^\s*\/fast\s+([\s\S]+?)\s*$/i;
+const FAST_TASK_RE = /^\/fast\s([\s\S]+)$/i;
 
 export async function applyFastTaskCommand(
   ctx: WebhookCommandCtx,
@@ -43,7 +43,7 @@ export async function applyFastTaskCommand(
   task: string,
 ): Promise<string> {
   const { agent, payload, log } = ctx;
-  const fastTaskMatch = FAST_TASK_RE.exec(taskWithoutMentions);
+  const fastTaskMatch = FAST_TASK_RE.exec(taskWithoutMentions.trim());
   if (!fastTaskMatch) return task;
   let rest = fastTaskMatch[1]!.trim();
   let fastEnable = true;

--- a/apps/xyne-claw-auth/backend/src/mcp/adapters/bitbucket.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/adapters/bitbucket.ts
@@ -1,6 +1,7 @@
 import type { StdioMcpAdapter, McpToolInfo } from "../types.js";
 import type { Citation } from "xyne-claw-shared";
 import { prefixChunk } from "./grafana.js";
+import { pathSegment, repoFilePath } from "../../lib/url-path.js";
 
 export const bitbucketAdapter: StdioMcpAdapter = {
   transport: "stdio",
@@ -249,7 +250,10 @@ export async function handleUploadPrScreenshot(
   const authHeader = "Basic " + Buffer.from(`${username}:${token}`).toString("base64");
 
   // Upload as repo attachment — Bitbucket Server returns attachment metadata with links
-  const uploadUrl = `${baseUrl}/rest/api/1.0/projects/${projectKey}/repos/${repoSlug}/attachments`;
+  const safeProject = pathSegment("upload-pr-screenshot: projectKey", projectKey);
+  const safeRepo = pathSegment("upload-pr-screenshot: repoSlug", repoSlug);
+  const safePrId = pathSegment("upload-pr-screenshot: prId", prId);
+  const uploadUrl = `${baseUrl}/rest/api/1.0/projects/${safeProject}/repos/${safeRepo}/attachments`;
 
   const boundary = "----XyneUpload" + Date.now();
   const bodyParts = [
@@ -292,7 +296,7 @@ export async function handleUploadPrScreenshot(
   const fullUrl = attachmentUrl.startsWith("http") ? attachmentUrl : `${baseUrl}${attachmentUrl}`;
 
   // Add a PR comment with the embedded image
-  const commentUrl = `${baseUrl}/rest/api/1.0/projects/${projectKey}/repos/${repoSlug}/pull-requests/${prId}/comments`;
+  const commentUrl = `${baseUrl}/rest/api/1.0/projects/${safeProject}/repos/${safeRepo}/pull-requests/${safePrId}/comments`;
   const commentBody = `![${caption}](${fullUrl})\n\n**${caption}**`;
 
   const commentRes = await fetch(commentUrl, {
@@ -455,6 +459,9 @@ export async function handleGetPrComments(
     throw new Error("get-pr-comments: projectKey, repoSlug, and prId are required");
   }
 
+  const safeProject = pathSegment("get-pr-comments: projectKey", projectKey);
+  const safeRepo = pathSegment("get-pr-comments: repoSlug", repoSlug);
+  const safePrId = pathSegment("get-pr-comments: prId", prId);
   const authHeader = "Basic " + Buffer.from(`${username}:${token}`).toString("base64");
   const pageSize = 100;
   const out: FlatComment[] = [];
@@ -464,8 +471,8 @@ export async function handleGetPrComments(
 
   while (out.length < maxComments && pagesWalked < maxPages) {
     const url =
-      `${baseUrl}/rest/api/1.0/projects/${projectKey}/repos/${repoSlug}` +
-      `/pull-requests/${prId}/activities?start=${start}&limit=${pageSize}`;
+      `${baseUrl}/rest/api/1.0/projects/${safeProject}/repos/${safeRepo}` +
+      `/pull-requests/${safePrId}/activities?start=${start}&limit=${pageSize}`;
 
     const res = await fetch(url, {
       method: "GET",
@@ -558,14 +565,16 @@ export async function handleGetPrTemplate(
     throw new Error("get-pr-template: path must be a relative repo path with no '..' or empty segments");
   }
 
+  const safeProject = pathSegment("get-pr-template: projectKey", projectKey);
+  const safeRepo = pathSegment("get-pr-template: repoSlug", repoSlug);
   const authHeader = "Basic " + Buffer.from(`${username}:${token}`).toString("base64");
   const candidates = explicitPath ? [explicitPath] : DEFAULT_PR_TEMPLATE_PATHS;
   const tried: string[] = [];
 
   for (const path of candidates) {
     // Encode each path segment to prevent traversal / stray query chars leaking into the URL.
-    const encodedPath = path.split("/").map(encodeURIComponent).join("/");
-    let url = `${baseUrl}/rest/api/1.0/projects/${projectKey}/repos/${repoSlug}/raw/${encodedPath}`;
+    const encodedPath = repoFilePath("get-pr-template: path", path);
+    let url = `${baseUrl}/rest/api/1.0/projects/${safeProject}/repos/${safeRepo}/raw/${encodedPath}`;
     if (at) url += `?at=${encodeURIComponent(at)}`;
 
     tried.push(path);
@@ -624,7 +633,12 @@ interface BbPrPage {
 
 /** `vpa-beta` and `refs/heads/vpa-beta` are the same branch; callers pass either. */
 function normalizeBranchRef(branch: string): { ref: string; displayId: string } {
-  const trimmed = branch.trim().replace(/^\/+|\/+$/g, "");
+  const raw = branch.trim();
+  let begin = 0;
+  let end = raw.length;
+  while (begin < end && raw.charCodeAt(begin) === 47) begin += 1;
+  while (end > begin && raw.charCodeAt(end - 1) === 47) end -= 1;
+  const trimmed = raw.slice(begin, end);
   const displayId = trimmed.replace(/^refs\/heads\//, "");
   return { ref: `refs/heads/${displayId}`, displayId };
 }
@@ -665,6 +679,8 @@ export async function handleListPullRequests(
   const targetBranchRaw = typeof params["targetBranch"] === "string" ? (params["targetBranch"] as string).trim() : "";
   const target = targetBranchRaw ? normalizeBranchRef(targetBranchRaw) : null;
 
+  const safeProject = pathSegment("list-pull-requests: projectKey", projectKey);
+  const safeRepo = pathSegment("list-pull-requests: repoSlug", repoSlug);
   const authHeader = "Basic " + Buffer.from(`${username}:${token}`).toString("base64");
   const pageSize = 100;
   const collected: BbPullRequest[] = [];
@@ -689,7 +705,7 @@ export async function handleListPullRequests(
       qs.set("direction", "INCOMING");
     }
 
-    const url = `${baseUrl}/rest/api/1.0/projects/${projectKey}/repos/${repoSlug}/pull-requests?${qs.toString()}`;
+    const url = `${baseUrl}/rest/api/1.0/projects/${safeProject}/repos/${safeRepo}/pull-requests?${qs.toString()}`;
     const res = await fetch(url, {
       method: "GET",
       headers: { Authorization: authHeader, Accept: "application/json" },

--- a/apps/xyne-claw-auth/backend/src/mcp/adapters/github.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/adapters/github.ts
@@ -1,6 +1,7 @@
 import type { StdioMcpAdapter, McpToolInfo } from "../types.js";
 import type { Citation } from "xyne-claw-shared";
 import { prefixChunk } from "./grafana.js";
+import { pathSegment } from "../../lib/url-path.js";
 
 export const githubAdapter: StdioMcpAdapter = {
   transport: "stdio",
@@ -146,6 +147,8 @@ export async function handleUploadPrAttachment(
   if (!/^[A-Za-z0-9_.-]{1,100}$/.test(owner) || !/^[A-Za-z0-9_.-]{1,100}$/.test(repo)) {
     throw new Error("upload-pr-attachment: owner/repo contain unsupported characters");
   }
+  const safeOwner = pathSegment("upload-pr-attachment: owner", owner);
+  const safeRepo = pathSegment("upload-pr-attachment: repo", repo);
   if (!fileData || typeof fileData !== "string") {
     throw new Error("upload-pr-attachment: fileData (base64) is required");
   }
@@ -182,7 +185,7 @@ export async function handleUploadPrAttachment(
   };
 
   // The upload endpoint keys off the numeric repository id, not owner/name.
-  const lookupRes = await fetch(`https://api.github.com/repos/${owner}/${repo}`, {
+  const lookupRes = await fetch(`https://api.github.com/repos/${safeOwner}/${safeRepo}`, {
     headers: { ...auth, Accept: "application/vnd.github+json" },
     signal: AbortSignal.timeout(20_000),
   });
@@ -248,7 +251,7 @@ export async function handleUploadPrAttachment(
 
   // PR/issue comments share the issues endpoint on GitHub.
   const commentRes = await fetch(
-    `https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/comments`,
+    `https://api.github.com/repos/${safeOwner}/${safeRepo}/issues/${prNumber}/comments`,
     {
       method: "POST",
       headers: { ...auth, Accept: "application/vnd.github+json", "Content-Type": "application/json" },

--- a/apps/xyne-claw-auth/backend/src/mcp/bitbucket-throttle.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/bitbucket-throttle.ts
@@ -20,6 +20,7 @@
 import { callTool } from "./runner.js";
 import { errMsg } from "../lib/errors.js";
 import type { McpCallResult } from "./types.js";
+import { pathSegment } from "../lib/url-path.js";
 
 const MAX_CONCURRENT_PER_USER = Number(process.env["BITBUCKET_MAX_CONCURRENCY"] ?? 2);
 const MIN_INTERVAL_MS = Number(process.env["BITBUCKET_MIN_INTERVAL_MS"] ?? 300);
@@ -80,7 +81,10 @@ async function probeBitbucketStatus(
   const token = credentials["token"] as string | undefined;
   if (!username || !token) return null;
   const baseUrl = ((credentials["baseUrl"] as string) || "https://bitbucket.juspay.net").replace(/\/+$/, "");
-  const url = `${baseUrl}/rest/api/1.0/projects/${project}/repos/${repo}/pull-requests/${prId}`;
+  const url =
+    `${baseUrl}/rest/api/1.0/projects/${pathSegment("bitbucket probe: project", project)}` +
+    `/repos/${pathSegment("bitbucket probe: repo", repo)}` +
+    `/pull-requests/${pathSegment("bitbucket probe: prId", prId)}`;
   try {
     const res = await fetch(url, {
       method: "GET",

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-client.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-client.ts
@@ -12,6 +12,7 @@
  */
 
 import { errMsg } from "../../lib/errors.js";
+import { logSafe } from "../../lib/log-safe.js";
 
 export interface SpacesAuthContext {
   token?: string;
@@ -178,7 +179,7 @@ export async function spacesFetch(path: string, init?: RequestInit, auth?: Space
       res.status === 504)
   ) {
     console.warn(
-      `[spaces-client] /claw route unavailable (${res.status ?? "network"}) for ${path} — falling back to ${clawless}`,
+      `[spaces-client] /claw route unavailable (${res.status ?? "network"}) for ${logSafe(path)} — falling back to ${logSafe(clawless)}`,
     );
     res = await attempt(clawless);
   }

--- a/apps/xyne-claw-auth/backend/src/mcpgateway/services/execution.ts
+++ b/apps/xyne-claw-auth/backend/src/mcpgateway/services/execution.ts
@@ -8,6 +8,7 @@ import * as registryDb from "../db/registry.js";
 import * as tokenCache from "../cache/token-cache.js";
 import { signGatewayJwt } from "../crypto/jwt.js";
 import { httpRequest, HttpRequestError } from "./http-client.js";
+import { logSafe } from "../../lib/log-safe.js";
 import type {
   Service,
   Tool,
@@ -129,7 +130,7 @@ export async function executeTool(
 ): Promise<ExecuteToolResult> {
   const startTime = Date.now();
   const { serviceName, toolName, arguments: toolArgs, backendId } = request;
-  console.log(`[execute] START service=${serviceName} tool=${toolName} backend=${backendId ?? "auto"}`);
+  console.log(`[execute] START service=${logSafe(serviceName)} tool=${logSafe(toolName)} backend=${logSafe(backendId ?? "auto")}`);
 
   if (!isGatewayEnabled) {
     return {
@@ -229,10 +230,10 @@ export async function executeTool(
     });
 
     const fullUrl = `${selectedBackend.backendUrl}${pathWithParams}`;
-    console.log(`[execute] Calling service=${serviceName} tool=${toolName} method=${tool.method || "POST"}`);
+    console.log(`[execute] Calling service=${logSafe(serviceName)} tool=${logSafe(toolName)} method=${logSafe(tool.method || "POST")}`);
 
     // Strip path params from body
-    const requestArgs: Record<string, unknown> = {};
+    const requestArgs: Record<string, unknown> = Object.create(null);
     for (const [key, value] of Object.entries(toolArgs)) {
       if (!pathParamNames.has(key)) {
         requestArgs[key] = value;
@@ -247,7 +248,7 @@ export async function executeTool(
       "Content-Type": "application/json",
       [xAuthHeaderName]: authToken,
     };
-    console.log(`[execute] Forward request prepared service=${serviceName} tool=${toolName} method=${httpMethod}`);
+    console.log(`[execute] Forward request prepared service=${logSafe(serviceName)} tool=${logSafe(toolName)} method=${logSafe(httpMethod)}`);
 
     // Execute request
     let backendResponse: { status: number; data: unknown };
@@ -303,7 +304,7 @@ export async function executeTool(
     }
 
     const duration = Date.now() - startTime;
-    console.log(`[execute] SUCCESS service=${serviceName} tool=${toolName} backend=${selectedBackend.backendId} status=${backendResponse.status} duration=${duration}ms`);
+    console.log(`[execute] SUCCESS service=${logSafe(serviceName)} tool=${logSafe(toolName)} backend=${logSafe(selectedBackend.backendId)} status=${backendResponse.status} duration=${duration}ms`);
 
     return {
       success: true,
@@ -315,7 +316,7 @@ export async function executeTool(
     };
   } catch (error) {
     const duration = Date.now() - startTime;
-    console.log(`[execute] FAILED service=${serviceName} tool=${toolName} duration=${duration}ms error=${error instanceof Error ? error.message : "unknown"}`);
+    console.log(`[execute] FAILED service=${logSafe(serviceName)} tool=${logSafe(toolName)} duration=${duration}ms error=${logSafe(error instanceof Error ? error.message : "unknown")}`);
 
     if (error instanceof HttpRequestError) {
       if (error.code === "http") {

--- a/apps/xyne-claw-auth/backend/src/middleware/rate-limiters.test.ts
+++ b/apps/xyne-claw-auth/backend/src/middleware/rate-limiters.test.ts
@@ -1,0 +1,103 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import express from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+process.env["ENCRYPTION_KEY"] = "00".repeat(32);
+
+const state = vi.hoisted(() => ({
+  config: {
+    xyneClawS2sKey: "s2s-secret",
+    spacesInternalUrl: "http://spaces.local",
+    encryptionKey: Buffer.from("00".repeat(32), "hex"),
+  },
+}));
+
+vi.mock("../config.js", () => ({ CONFIG: state.config }));
+
+vi.mock("../db.js", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    orgMember: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("../lib/cli-tokens.js", () => ({ verify: vi.fn(async () => null) }));
+vi.mock("../lib/users-jit.js", () => ({ ensureUserExists: vi.fn(async () => undefined) }));
+vi.mock("../logger.js", () => ({
+  createLogger: () => ({ debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+}));
+
+let server: Server;
+let baseUrl: string;
+
+async function startApp(max: number): Promise<void> {
+  const { createRequesterLimiter } = await import("./rate-limiters.js");
+  const app = express();
+  app.use(createRequesterLimiter({ windowMs: 60_000, max }));
+  app.get("/ping", (_req, res) => {
+    res.json({ ok: true });
+  });
+  server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(async () => {
+  if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe("createRequesterLimiter", () => {
+  it("returns 429 once one IP bursts past the limit", async () => {
+    await startApp(3);
+    const statuses: number[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      const res = await fetch(`${baseUrl}/ping`);
+      statuses.push(res.status);
+    }
+    expect(statuses.slice(0, 3)).toEqual([200, 200, 200]);
+    expect(statuses.slice(3)).toEqual([429, 429]);
+  });
+
+  it("never limits a caller presenting a valid x-s2s-key", async () => {
+    await startApp(3);
+    const statuses: number[] = [];
+    for (let i = 0; i < 20; i += 1) {
+      const res = await fetch(`${baseUrl}/ping`, { headers: { "x-s2s-key": "s2s-secret" } });
+      statuses.push(res.status);
+    }
+    expect(statuses.every((s) => s === 200)).toBe(true);
+  });
+
+  it("still limits a caller presenting a wrong x-s2s-key", async () => {
+    await startApp(2);
+    const statuses: number[] = [];
+    for (let i = 0; i < 4; i += 1) {
+      const res = await fetch(`${baseUrl}/ping`, { headers: { "x-s2s-key": "not-the-key" } });
+      statuses.push(res.status);
+    }
+    expect(statuses).toEqual([200, 200, 429, 429]);
+  });
+
+  it("keys separately per user id so one user cannot exhaust another", async () => {
+    await startApp(2);
+    for (let i = 0; i < 3; i += 1) {
+      await fetch(`${baseUrl}/ping`, { headers: { "x-user-id": "user-a" } });
+    }
+    const other = await fetch(`${baseUrl}/ping`, { headers: { "x-user-id": "user-b" } });
+    expect(other.status).toBe(200);
+    const exhausted = await fetch(`${baseUrl}/ping`, { headers: { "x-user-id": "user-a" } });
+    expect(exhausted.status).toBe(429);
+  });
+
+  it("emits standard RateLimit headers and no legacy X-RateLimit headers", async () => {
+    await startApp(5);
+    const res = await fetch(`${baseUrl}/ping`);
+    expect(res.headers.get("ratelimit-limit")).toBe("5");
+    expect(res.headers.get("x-ratelimit-limit")).toBeNull();
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/middleware/rate-limiters.ts
+++ b/apps/xyne-claw-auth/backend/src/middleware/rate-limiters.ts
@@ -1,10 +1,38 @@
 import rateLimit, { ipKeyGenerator, type RateLimitRequestHandler } from "express-rate-limit";
-import type { Request } from "express";
+import type { Request, Response } from "express";
+import { s2sKeyMatches } from "./require-auth.js";
 
 function requesterKey(req: Request): string {
-  const userId = req.header("x-user-id");
-  return userId && userId.trim() ? `user:${userId.trim()}` : ipKeyGenerator(req.ip ?? "unknown");
+  const header = req.headers?.["x-user-id"];
+  const userId = Array.isArray(header) ? header[0] : header;
+  if (userId && userId.trim()) return `user:${userId.trim()}`;
+  const sessionUserId = (req as Request & { session?: { userId?: string } }).session?.userId;
+  if (sessionUserId && sessionUserId.trim()) return `user:${sessionUserId.trim()}`;
+  return ipKeyGenerator(req.ip ?? "unknown");
 }
+
+function isInternalCaller(req: Request, _res: Response): boolean {
+  return s2sKeyMatches(req.headers?.["x-s2s-key"]);
+}
+
+export function createRequesterLimiter(options: { windowMs: number; max: number }): RateLimitRequestHandler {
+  return rateLimit({
+    windowMs: options.windowMs,
+    max: options.max,
+    keyGenerator: requesterKey,
+    skip: isInternalCaller,
+    message: {
+      success: false,
+      error: "Too many requests. Please slow down and try again shortly.",
+    },
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+}
+
+export const apiLimiter: RateLimitRequestHandler = createRequesterLimiter({ windowMs: 60 * 1000, max: 600 });
+
+export const publicShareLimiter: RateLimitRequestHandler = createRequesterLimiter({ windowMs: 60 * 1000, max: 60 });
 
 export const oauthLimiter: RateLimitRequestHandler = rateLimit({
   windowMs: 60 * 1000,

--- a/apps/xyne-claw-auth/backend/src/repositories/agentRunRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/agentRunRepository.ts
@@ -13,7 +13,7 @@ function stripNulDeep(value: unknown): unknown {
   if (typeof value === "string") return value.replace(/\u0000/g, "");
   if (Array.isArray(value)) return value.map(stripNulDeep);
   if (value && typeof value === "object") {
-    const out: Record<string, unknown> = {};
+    const out: Record<string, unknown> = Object.create(null);
     for (const [k, v] of Object.entries(value)) out[k] = stripNulDeep(v);
     return out;
   }

--- a/apps/xyne-claw-auth/backend/src/routes/artifact-app-storage.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/artifact-app-storage.ts
@@ -72,8 +72,8 @@ export const artifactAppStorageRouter: Router = Router();
  */
 export function storageBearerAuthBridge(req: Request, _res: Response, next: NextFunction): void {
   if (!req.headers.cookie) {
-    const match = /^Bearer\s+(.+)$/i.exec(req.headers.authorization ?? "");
-    const token = match?.[1]?.trim();
+    const match = /^Bearer[ \t]+(\S+)$/i.exec((req.headers.authorization ?? "").trim());
+    const token = match?.[1];
     const workspaceId = token ? workspaceIdFromJwt(token) : undefined;
     if (token && workspaceId) {
       req.headers.cookie = `xyne_last_workspace=${workspaceId}; xyne_ws_${workspaceId}_token=${token}`;

--- a/apps/xyne-claw-auth/backend/src/routes/connections.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/connections.ts
@@ -266,7 +266,8 @@ router.post("/:userId/connections/auto-connect-spaces", asyncHandler(async (req:
   // pending-auth window it holds a JSON blob.
   const cookie = req.headers.cookie ?? "";
   const readCookie = (name: string): string | undefined => {
-    const m = cookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const m = cookie.match(new RegExp(`(?:^|;[ \t]*)${escaped}=([^;]*)`));
     return m?.[1] ? decodeURIComponent(m[1]) : undefined;
   };
   const lastWorkspace = readCookie("xyne_last_workspace");

--- a/apps/xyne-claw-auth/backend/src/routes/design-shares.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/design-shares.ts
@@ -7,6 +7,7 @@ import { getOrgId, getRequesterId } from "../middleware/agent-acl.js";
 import { isOrgMember } from "./organizations.js";
 import { gcsService } from "../services/storageService.js";
 import { createLogger } from "../logger.js";
+import { publicShareLimiter } from "../middleware/rate-limiters.js";
 
 const log = createLogger("design-shares");
 const MAX_HTML_BYTES = 10 * 1024 * 1024;
@@ -388,7 +389,7 @@ function denyPublicShare(res: Response, reason: "not_found" | "auth_required", s
   res.status(404).json({ success: false, error: "Shared design not found or no longer available" });
 }
 
-publicDesignSharesRouter.get("/metadata", async (req: Request, res: Response): Promise<void> => {
+publicDesignSharesRouter.get("/metadata", publicShareLimiter, async (req: Request, res: Response): Promise<void> => {
   try {
     const access = await authorizePublicShare(req);
     if (!access.ok) {
@@ -411,7 +412,7 @@ publicDesignSharesRouter.get("/metadata", async (req: Request, res: Response): P
   }
 });
 
-publicDesignSharesRouter.get("/content", async (req: Request, res: Response): Promise<void> => {
+publicDesignSharesRouter.get("/content", publicShareLimiter, async (req: Request, res: Response): Promise<void> => {
   try {
     const access = await authorizePublicShare(req);
     if (!access.ok) {

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -152,6 +152,8 @@ import type { Todo } from "xyne-claw-shared";
 import { tools as xyneSpacesTools } from "../mcp/servers/xyne-spaces-tools.js";
 import { connectorTypesFromText, connectorTypesUserAskedFor, wantsConnectorRoster } from "../lib/connector-hints.js";
 import { availabilityForServerIds } from "../lib/connector-availability.js";
+import { countTrailingBase64Padding, safePathSegment } from "../lib/url-path.js";
+import { assertSafeOutboundUrl } from "../mcpgateway/services/http-client.js";
 
 const clog = createLogger("webhook");
 const SDLC_AGENT_TOOL_PROFILE = sdlcAgentToolProfile(
@@ -1804,14 +1806,15 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
           `Attachment ${att.attachmentId}: fileUrl=${att.fileUrl ? `"${att.fileUrl.slice(0, 120)}"` : "(empty)"} hasUserToken=${!!userSpacesToken} hasSessionId=${!!userSpacesSessionId}`,
         );
 
-        const sources: Array<{ label: string; url: string; headers?: Record<string, string> }> = [];
+        const safeAttachmentId = safePathSegment(att.attachmentId);
+        const sources: Array<{ label: string; url: string; headers?: Record<string, string>; external?: boolean }> = [];
         if (att.fileUrl && /^https?:\/\//i.test(att.fileUrl)) {
-          sources.push({ label: "fileUrl", url: att.fileUrl });
+          sources.push({ label: "fileUrl", url: att.fileUrl, external: true });
         }
-        if (userSpacesToken) {
+        if (userSpacesToken && safeAttachmentId) {
           sources.push({
             label: "user-token",
-            url: `${CONFIG.spacesInternalUrl}/api/attachments/${att.attachmentId}/download`,
+            url: `${CONFIG.spacesInternalUrl}/api/attachments/${safeAttachmentId}/download`,
             headers: {
               Authorization: `Bearer ${userSpacesToken}`,
               ...(userSpacesWorkspaceId ? { "x-workspace-id": userSpacesWorkspaceId } : {}),
@@ -1819,21 +1822,24 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
             },
           });
         }
-        sources.push({
-          label: "apps-route",
-          url: `${CONFIG.spacesInternalUrl}/api/apps/attachments/${att.attachmentId}/download`,
-          headers: { Authorization: `Bearer ${agent.appToken}` },
-        });
-        sources.push({
-          label: "user-route",
-          url: `${CONFIG.spacesInternalUrl}/api/attachments/${att.attachmentId}/download`,
-          headers: { Authorization: `Bearer ${agent.appToken}` },
-        });
+        if (safeAttachmentId) {
+          sources.push({
+            label: "apps-route",
+            url: `${CONFIG.spacesInternalUrl}/api/apps/attachments/${safeAttachmentId}/download`,
+            headers: { Authorization: `Bearer ${agent.appToken}` },
+          });
+          sources.push({
+            label: "user-route",
+            url: `${CONFIG.spacesInternalUrl}/api/attachments/${safeAttachmentId}/download`,
+            headers: { Authorization: `Bearer ${agent.appToken}` },
+          });
+        }
 
         const failures: string[] = [];
         let downloaded = false;
         for (const src of sources) {
           try {
+            if (src.external) await assertSafeOutboundUrl(src.url);
             const dlRes = await fetch(src.url, {
               signal: AbortSignal.timeout(CONFIG.attachmentDownloadTimeoutMs),
               ...(src.headers ? { headers: src.headers } : {}),
@@ -6036,7 +6042,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
             mimeType: a.mimeType,
             sizeBytes: typeof a.data === "string"
               // base64 → bytes: ceil(len * 3/4), minus padding "="s
-              ? Math.max(0, Math.floor(a.data.length * 3 / 4) - (a.data.match(/=+$/)?.[0]?.length ?? 0))
+              ? Math.max(0, Math.floor(a.data.length * 3 / 4) - countTrailingBase64Padding(a.data))
               : 0,
           }));
           const decision = await recordTurnAndDecide({

--- a/apps/xyne-claw-auth/backend/src/services/agentChatContextService.ts
+++ b/apps/xyne-claw-auth/backend/src/services/agentChatContextService.ts
@@ -128,15 +128,15 @@ export function normalizeAttachedContext(input: unknown): { items: AttachedConte
 
   const items: AttachedContextRef[] = [];
   const seen = new Set<string>();
-  const perTypeCounts: Record<Exclude<ContextType, "activity">, number> = {
-    channel: 0,
-    ticket: 0,
-    canvas: 0,
-    call: 0,
-    collection: 0,
-    file: 0,
-    folder: 0,
-  };
+  const perTypeCounts = new Map<Exclude<ContextType, "activity">, number>([
+    ["channel", 0],
+    ["ticket", 0],
+    ["canvas", 0],
+    ["call", 0],
+    ["collection", 0],
+    ["file", 0],
+    ["folder", 0],
+  ]);
 
   for (const raw of input) {
     if (!raw || typeof raw !== "object") return { items: [], error: "attachedContext contains invalid entries" };
@@ -153,7 +153,7 @@ export function normalizeAttachedContext(input: unknown): { items: AttachedConte
     }
 
     // Only apply per-type limit for non-activity types
-    if (type !== "activity" && perTypeCounts[type] >= PER_TYPE_LIMIT) {
+    if (type !== "activity" && (perTypeCounts.get(type) ?? 0) >= PER_TYPE_LIMIT) {
       return { items: [], error: `attachedContext exceeds ${PER_TYPE_LIMIT} items for type ${type}` };
     }
 
@@ -161,7 +161,7 @@ export function normalizeAttachedContext(input: unknown): { items: AttachedConte
     if (seen.has(key)) continue;
     seen.add(key);
     if (type !== "activity") {
-      perTypeCounts[type] += 1;
+      perTypeCounts.set(type, (perTypeCounts.get(type) ?? 0) + 1);
     }
     
     // Build item with all activity-specific fields if applicable

--- a/packages/xyne-claw-shared/src/tools/platform-config-keys.ts
+++ b/packages/xyne-claw-shared/src/tools/platform-config-keys.ts
@@ -50,7 +50,7 @@ export function stripPlatformConfigKeys(
   config: Record<string, unknown> | undefined | null,
 ): Record<string, unknown> {
   if (!config) return {};
-  const out: Record<string, unknown> = {};
+  const out: Record<string, unknown> = Object.create(null);
   for (const [key, value] of Object.entries(config)) {
     if (PLATFORM_ONLY_CONFIG_KEYS.has(key)) continue;
     out[key] = value;

--- a/packages/xyne-claw-shared/src/tools/react-artifact/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/react-artifact/tools.ts
@@ -257,7 +257,7 @@ function parseDependencies(raw: unknown): Record<string, string> {
     fail("`dependencies` must be an object mapping package name to version.");
   }
 
-  const deps: Record<string, string> = {};
+  const deps: Record<string, string> = Object.create(null);
   for (const [name, version] of Object.entries(raw as Record<string, unknown>)) {
     if (!NPM_PACKAGE_NAME_RE.test(name)) {
       fail(`"${name}" is not a valid npm package name.`);


### PR DESCRIPTION
Fixes the 59 CodeQL alerts raised on #1823 (the verbatim copy of the claw folders into `main`). The fixes land here, on the deploy branch, because that is the source of truth for those folders.

## What changed, by alert category

### js/missing-rate-limiting — 26 alerts, all fixed
`apps/xyne-claw-auth/backend/src/middleware/rate-limiters.ts` gains a `createRequesterLimiter({ windowMs, max })` factory and two limiters built from it:

- `apiLimiter` — 600 req/min per requester, mounted once in `http/routes.ts` as `app.use(BASE, apiLimiter)` (covers the 24 route mounts flagged at `routes.ts:124-184`).
- `publicShareLimiter` — 60 req/min per requester, applied directly to `publicDesignSharesRouter` `GET /metadata` and `GET /content` in `routes/design-shares.ts` (the 2 remaining alerts).

Design:

- **S2S exemption.** `skip` calls the existing constant-time `s2sKeyMatches(req.headers["x-s2s-key"])` from `middleware/require-auth.js`. Any caller holding a valid S2S key — claw pods hitting `/webhook/progress`, `/mcp/tools`, `/mcp/call`, `/internal/*` and `/run` callbacks — is never counted or limited.
- **Key.** `x-user-id` when present, else `req.session?.userId`, else `ipKeyGenerator(req.ip)`. This is the same `requesterKey` the pre-existing `oauthLimiter` uses, so the identity-header firewall in `mountRequestContext` (which strips a forged `x-user-id` from non-S2S callers before any route runs) still governs what a client can assert.
- **Limits.** 600/min per key for the general API — generous enough that the UI and CLI never trip it — and 60/min for the anonymous public share viewer.
- **Headers.** `standardHeaders: true, legacyHeaders: false` on both.
- **Health.** `app.use(BASE, apiLimiter)` is mounted *after* `app.get("/claw/health", …)`, and `/claw/health` sits outside `BASE`, so health/readiness probes are never rate-limited.

New test `src/middleware/rate-limiters.test.ts` (5 cases, all green) proves: a burst past the limit from one IP returns 429; a caller presenting the valid `x-s2s-key` is never limited across 20x the limit; a *wrong* `x-s2s-key` is still limited; per-user keying isolates users from each other; standard headers are emitted and legacy ones are not.

### js/request-forgery — 9 alerts: 8 fixed, 1 recommended for dismissal
New helper `src/lib/url-path.ts`:

- `pathSegment(label, value)` — asserts `^[A-Za-z0-9._~-]+$`, rejects `.`/`..`, applies `encodeURIComponent`, throws a clear error otherwise.
- `safePathSegment(value)` — same check, returns `null` instead of throwing (used where a throw would abort a batch).
- `repoFilePath(label, value)` — rejects absolute paths and validates every `/`-separated segment through `pathSegment`.

Applied at:

- `mcp/adapters/bitbucket.ts` — `projectKey`, `repoSlug`, `prId` validated once per handler and the validated values interpolated into the attachment-upload, PR-comment, activities, raw-file and pull-requests URLs (alerts 135, 137, 138, 139, 141). The template `path` now goes through `repoFilePath`. Hosts still come only from `credentials.baseUrl` / the hardcoded default.
- `mcp/adapters/github.ts:250` — `owner`/`repo` go through `pathSegment` after the existing character check; both `api.github.com` URLs use the validated values (alert 136).
- `mcp/bitbucket-throttle.ts:85` — each probe URL segment validated (alert 142).
- `routes/webhook.ts:1837` — `att.attachmentId` goes through `safePathSegment` before it is interpolated into the three `spacesInternalUrl` download URLs (internal sources are skipped when it does not validate, rather than aborting the whole attachment loop), and the one genuinely-external source (`att.fileUrl`, an arbitrary URL off the webhook payload) is now passed through `assertSafeOutboundUrl` before the fetch (alert 2152).

### js/remote-property-injection — 7 alerts, all fixed
- `lib/citations.ts:64`, `mcpgateway/services/execution.ts:238`, `repositories/agentRunRepository.ts:17`, `packages/xyne-claw-shared/src/tools/platform-config-keys.ts:56`, `packages/xyne-claw-shared/src/tools/react-artifact/tools.ts:273` — target objects switched to `Object.create(null)`.
- `services/agentChatContextService.ts:164` — `perTypeCounts` switched from an object literal to a `Map`.
- `lib/start-run.ts:1082` — new `lib/safe-keys.ts` `isSafeObjectKey` guard (`__proto__`/`constructor`/`prototype`) before the provider key is written, and the write uses `Object.defineProperty` on a fresh copy.

### js/polynomial-redos (7) + js/redos (1) + js/regex-injection (1) — 8 fixed, 1 recommended for dismissal
- `lib/agent-widget-binding.ts:35` — the `.replace(/[?#].*$/).replace(/\/+$/)` chain replaced with a `search()` + index-based trailing-slash trim (no backtracking).
- `lib/session-tokens.ts:18` — `.toString("base64").replace(/=+$/,"")…` replaced with Node's `toString("base64url")`, which is byte-identical output with no regex.
- `lib/webhook-commands/fast-mode.ts:46` — `/^\s*\/fast\s+([\s\S]+?)\s*$/i` → `/^\/fast\s([\s\S]+)$/i` on a pre-trimmed input; the capture is still `.trim()`ed, so behavior is unchanged and the ambiguity is gone.
- `mcp/adapters/bitbucket.ts:627` (`normalizeBranchRef`) — `/^\/+|\/+$/g` replaced with index-based trimming.
- `routes/artifact-app-storage.ts:75` — `/^Bearer\s+(.+)$/i` → `/^Bearer[ \t]+(\S+)$/i` on a trimmed header.
- `routes/webhook.ts:6039` — `a.data.match(/=+$/)` replaced with `countTrailingBase64Padding()`, a small loop in `lib/url-path.ts`.
- `routes/connections.ts:269` (js/regex-injection) — the cookie name is now escaped with `replace(/[.*+?^${}()|[\]\\]/g, "\\$&")` before `new RegExp`, and `\s*` in the pattern narrowed to `[ \t]*`.

### js/log-injection — 6 alerts, all fixed
New `src/lib/log-safe.ts` exports `logSafe(value)`, which strips C0/C1 control characters (CR, LF included) to spaces. Applied to the user-derived interpolations in `mcpgateway/services/execution.ts` (lines 132, 232, 250, 306, 318 — `serviceName`, `toolName`, `backendId`, `httpMethod`, `error.message`) and `mcp/servers/xyne-spaces-client.ts:181` (`path`, `clawless`).

## Alerts recommended for DISMISSAL (3) — not dismissed by this PR

| # | Rule | Location | Recommended reason | Justification |
|---|---|---|---|---|
| 1884 | js/request-forgery | `mcp/adapters/webfetch.ts:185` | Won't fix — intended behavior, guarded | Fetching a user-supplied URL is the whole purpose of the `webfetch` tool. The SSRF guard is `assertSafeOutboundUrl` (`mcpgateway/services/http-client.ts:282` → `validatePublicDestination`), and it is called at `webfetch.ts:183`, *inside* the redirect loop, with `redirect: "manual"` — so every hop, not just the first, is re-validated against the private-range / loopback / metadata policy before the fetch. Verified during this change; the code is left as-is. |
| 2077 | js/redos | `lib/chain-workflow.test.ts:133` | Used in tests | The test deliberately feeds `(a+)+$` to assert the workflow validator *rejects* a catastrophic pattern. Changing it would delete the assertion. |
| 697 | js/user-controlled-bypass | `routes/run.ts:90` | False positive | `requireRunCaller` uses `body.triggerSource === "api"` only to choose *which* auth middleware runs (`requireAuth` vs `requireUserAuth`). Every branch authenticates; there is no unauthenticated path, so the user-controlled value selects a credential scheme, it does not bypass a check. |
| 2299 | js/user-controlled-bypass | `routes/flow-action.ts:1153` | False positive | `actionType === "schedule-approval"` is an action dispatch, not an authorization decision. The authorization for that branch is the very next check (lines 1159–1170): the schedule may only be armed when `callerUserId === creatorUserId`, and `callerUserId` is derived from the re-verified Spaces signature, not from the body. It fails closed on a missing caller identity. |

That is 4 rows for 3 categories — 4 alert numbers total recommended for dismissal (1884, 2077, 697, 2299), so **55 alerts fixed in code, 4 recommended for dismissal**.

## Verification

**Typecheck**

- `packages/xyne-claw-shared`: `npx tsc --noEmit` → 0 errors.
- `apps/xyne-claw-auth/backend`: `npx tsc --noEmit`, diffed against the same command on the unmodified branch. The only new lines are the same pre-existing `express-rate-limit` ↔ `express` type-version mismatch that already affects `oauthLimiter` and every route that uses it (`classic-oauth-provider.ts:129`, `egnyte-oauth.ts`, `docusign-oauth.ts`, …): `TS2769 No overload matches this call` at the three new limiter mount sites and `TS2322 … ValueDeterminingMiddleware<boolean>` for the new `skip` callback. No new errors of any other kind. (The pre-existing `@prisma/client has no exported member` wall clears after `npx prisma generate`; both baseline and post-change runs were taken the same way.)

**Tests**

- `apps/xyne-claw-auth/backend`, `npx vitest run src/lib src/queue src/routes src/middleware`: **26 failed | 472 passed (498)**. Baseline on the unmodified branch, same command, same environment: **26 failed | 467 passed (493)**. Identical failing-file set (`mention-transform`, `run-attachment-store`, `require-auth`, `verify-spaces-signature`, `run-recovery-experiment`, `mcp-automation-app-mode`, `organizations.service-tokens`, `run.cli-bearer`, `skills.skill-update`) — all pre-existing. The +5 passes are the new rate-limiter tests. Zero regressions.
- `apps/xyne-claw-auth/backend`, `npx vitest run src/mcp src/services src/mcpgateway src/repositories` (covers `bitbucket-list-prs.test.ts`, `github.test.ts`, `validators.test.ts`): **1 failed | 152 passed**. The single failure, `xyne-spaces-tools-list.test.ts > spaces-tickets > lists tickets`, was confirmed failing on the unmodified branch too.
- `packages/xyne-claw-shared`, `npx vitest run`: **3 failed | 325 passed** — exactly the known pre-existing `react-artifact/tools.test.ts` trio.

Note: `src/middleware/require-auth.test.ts`'s mount-policy case fails on the unmodified branch as well (three `artifact-apps*` mounts legitimately lack `requireNoAccessToken`); it is unrelated to this change and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014msUsE5XaWEfhM6FTpo4Kj
