### PR TITLE
refactor(shared): convert WorkspaceJoinPolicy back to TypeScript enum

### DIFF
--- a/packages/shared/src/zero/types.ts
+++ b/packages/shared/src/zero/types.ts
@@ -223,13 +223,12 @@ export const WorkspaceType = {
 
 export type WorkspaceType = typeof WorkspaceType[keyof typeof WorkspaceType];
 
-export const WorkspaceJoinPolicy = {
-  INVITE_ONLY: 'INVITE_ONLY',
-  OPEN: 'OPEN',
-  REQUEST_TO_JOIN: 'REQUEST_TO_JOIN',
-} as const;
-
-export type WorkspaceJoinPolicy = typeof WorkspaceJoinPolicy[keyof typeof WorkspaceJoinPolicy];
+// @ts-ignore TS1294
+export enum WorkspaceJoinPolicy {
+  INVITE_ONLY = 'INVITE_ONLY',
+  OPEN = 'OPEN',
+  REQUEST_TO_JOIN = 'REQUEST_TO_JOIN',
+}
 
 export const CommunityJoinResultStatus = {
   JOINED: 'JOINED',


### PR DESCRIPTION
Restores `WorkspaceJoinPolicy` to a proper TypeScript enum in `packages/shared/src/zero/types.ts` while keeping the surrounding workspace join-related const objects (`WorkspaceType`, `CommunityJoinResultStatus`, `WorkspaceJoinRequestStatus`, `WorkspaceJoinRequestAction`) unchanged.

This makes `WorkspaceJoinPolicy` consistent with the other shared enums and avoids the const-object workaround.