### PR TITLE
Fix/automation grafana metrics

### DIFF
--- a/apps/backend/src/automations/engine/automation-executor.ts
+++ b/apps/backend/src/automations/engine/automation-executor.ts
@@ -32,10 +32,7 @@ import {
 } from '../types/workflow-adapter';
 import { triggerRegistry } from '../triggers/trigger-registry';
 import { logger } from '@/utils/logger';
-import {
-  recordAutomationRunMetric,
-  type AutomationMetricLabels,
-} from '@/services/otel/automationMetrics';
+import { recordAutomationRunMetric } from '@/services/otel/automationMetrics';
 
 type WalkResult =
   | { kind: 'completed' }
@@ -115,14 +112,6 @@ export class AutomationExecutor {
     this.resolver = options.variableResolver ?? new VariableResolver();
   }
 
-  private getMetricLabels(context: AutomationContext): AutomationMetricLabels {
-    return {
-      automationId: context.automation.id,
-      workspaceId: context.automation.workspaceId,
-      triggerType: context.trigger.type,
-    };
-  }
-
   async runExecution(executionId: string): Promise<unknown> {
     const existing = await this.prisma.workflowExecution.findUnique({
       where: { id: executionId },
@@ -144,11 +133,8 @@ export class AutomationExecutor {
         where: { id: executionId },
         data: { status: AutomationRunStatus.CANCELLED },
       });
-      recordAutomationRunMetric('cancelled', {
-        automationId: existing.workflowId,
-        workspaceId: existing.workspaceId,
-        triggerType: 'unknown',
-      });
+      // Workflow row is gone, so the trigger type is unknowable here.
+      recordAutomationRunMetric('cancelled');
       logger.warn(
         `[automations] runExecution: workflow ${existing.workflowId} missing — run ${executionId} CANCELLED`,
       );
@@ -159,11 +145,10 @@ export class AutomationExecutor {
         where: { id: executionId },
         data: { status: AutomationRunStatus.CANCELLED },
       });
-      recordAutomationRunMetric('cancelled', {
-        automationId: workflow.id,
-        workspaceId: workflow.workspaceId,
-        triggerType: parseAutomationConfig(workflow.context).trigger.type,
-      });
+      recordAutomationRunMetric(
+        'cancelled',
+        parseAutomationConfig(workflow.context).trigger.type,
+      );
       logger.info(
         `[automations] runExecution: workflow ${workflow.id} is ${workflow.status} (no longer live) — run ${executionId} CANCELLED`,
       );
@@ -201,7 +186,7 @@ export class AutomationExecutor {
       data: { status: AutomationRunStatus.RUNNING },
     });
     if (prep.label === 'STARTED') {
-      recordAutomationRunMetric('started', this.getMetricLabels(prep.ctx));
+      recordAutomationRunMetric('started', prep.ctx.trigger.type);
     }
     await persistAutomationState(executionId, { context: JSON.stringify(prep.ctx) });
     logger.info(
@@ -239,6 +224,7 @@ export class AutomationExecutor {
         where: { id: executionId },
         data: { status: AutomationRunStatus.FAILED },
       });
+      recordAutomationRunMetric('failed', config.trigger.type);
       return null;
     }
     let initialCtx: AutomationContext;
@@ -257,6 +243,7 @@ export class AutomationExecutor {
         where: { id: executionId },
         data: { status: AutomationRunStatus.FAILED },
       });
+      recordAutomationRunMetric('failed', config.trigger.type);
       return null;
     }
     const chain: readonly string[] = readAutomationMeta(pauseState.context).chain;
@@ -323,11 +310,7 @@ export class AutomationExecutor {
         where: { id: executionId },
         data: { status: AutomationRunStatus.SKIPPED },
       });
-      recordAutomationRunMetric('skipped', {
-        automationId: workflow.id,
-        workspaceId: workflow.workspaceId,
-        triggerType: config.trigger.type,
-      });
+      recordAutomationRunMetric('skipped', config.trigger.type);
       skeleton.__meta = { error: null, chain };
       await persistAutomationState(executionId, { context: JSON.stringify(skeleton) });
       logger.info(
@@ -434,7 +417,7 @@ export class AutomationExecutor {
         where: { id: runId },
         data: { status: AutomationRunStatus.COMPLETED },
       });
-      recordAutomationRunMetric('completed', this.getMetricLabels(context));
+      recordAutomationRunMetric('completed', context.trigger.type);
       context.__meta = { error: null, chain };
       await persistAutomationState(runId, {
         context: JSON.stringify(context),
@@ -448,7 +431,7 @@ export class AutomationExecutor {
         where: { id: runId },
         data: { status: AutomationRunStatus.FAILED },
       });
-      recordAutomationRunMetric('failed', this.getMetricLabels(context));
+      recordAutomationRunMetric('failed', context.trigger.type);
       context.__meta = { error: errMessage, chain };
       await persistAutomationState(runId, {
         context: JSON.stringify(context),
@@ -503,7 +486,7 @@ export class AutomationExecutor {
             where: { id: runId },
             data: { status: EXTERNAL_WAIT_STATUS },
           });
-          recordAutomationRunMetric('paused', this.getMetricLabels(context));
+          recordAutomationRunMetric('paused', context.trigger.type);
           return { kind: 'paused', atIndex: i, externalRef: err.externalRef };
         }
         const errMessage = err instanceof Error ? err.message : String(err);

--- a/apps/backend/src/automations/engine/automation-executor.ts
+++ b/apps/backend/src/automations/engine/automation-executor.ts
@@ -186,7 +186,7 @@ export class AutomationExecutor {
       data: { status: AutomationRunStatus.RUNNING },
     });
     if (prep.label === 'STARTED') {
-      recordAutomationRunMetric('started', prep.ctx.trigger.type);
+      recordAutomationRunMetric('running', prep.ctx.trigger.type);
     }
     await persistAutomationState(executionId, { context: JSON.stringify(prep.ctx) });
     logger.info(
@@ -486,7 +486,7 @@ export class AutomationExecutor {
             where: { id: runId },
             data: { status: EXTERNAL_WAIT_STATUS },
           });
-          recordAutomationRunMetric('paused', context.trigger.type);
+          recordAutomationRunMetric('external_wait', context.trigger.type);
           return { kind: 'paused', atIndex: i, externalRef: err.externalRef };
         }
         const errMessage = err instanceof Error ? err.message : String(err);

--- a/apps/backend/src/automations/engine/automation-executor.ts
+++ b/apps/backend/src/automations/engine/automation-executor.ts
@@ -32,6 +32,10 @@ import {
 } from '../types/workflow-adapter';
 import { triggerRegistry } from '../triggers/trigger-registry';
 import { logger } from '@/utils/logger';
+import {
+  recordAutomationRunMetric,
+  type AutomationMetricLabels,
+} from '@/services/otel/automationMetrics';
 
 type WalkResult =
   | { kind: 'completed' }
@@ -111,6 +115,14 @@ export class AutomationExecutor {
     this.resolver = options.variableResolver ?? new VariableResolver();
   }
 
+  private getMetricLabels(context: AutomationContext): AutomationMetricLabels {
+    return {
+      automationId: context.automation.id,
+      workspaceId: context.automation.workspaceId,
+      triggerType: context.trigger.type,
+    };
+  }
+
   async runExecution(executionId: string): Promise<unknown> {
     const existing = await this.prisma.workflowExecution.findUnique({
       where: { id: executionId },
@@ -132,6 +144,11 @@ export class AutomationExecutor {
         where: { id: executionId },
         data: { status: AutomationRunStatus.CANCELLED },
       });
+      recordAutomationRunMetric('cancelled', {
+        automationId: existing.workflowId,
+        workspaceId: existing.workspaceId,
+        triggerType: 'unknown',
+      });
       logger.warn(
         `[automations] runExecution: workflow ${existing.workflowId} missing — run ${executionId} CANCELLED`,
       );
@@ -141,6 +158,11 @@ export class AutomationExecutor {
       await this.prisma.workflowExecution.update({
         where: { id: executionId },
         data: { status: AutomationRunStatus.CANCELLED },
+      });
+      recordAutomationRunMetric('cancelled', {
+        automationId: workflow.id,
+        workspaceId: workflow.workspaceId,
+        triggerType: parseAutomationConfig(workflow.context).trigger.type,
       });
       logger.info(
         `[automations] runExecution: workflow ${workflow.id} is ${workflow.status} (no longer live) — run ${executionId} CANCELLED`,
@@ -178,6 +200,9 @@ export class AutomationExecutor {
       where: { id: executionId },
       data: { status: AutomationRunStatus.RUNNING },
     });
+    if (prep.label === 'STARTED') {
+      recordAutomationRunMetric('started', this.getMetricLabels(prep.ctx));
+    }
     await persistAutomationState(executionId, { context: JSON.stringify(prep.ctx) });
     logger.info(
       `[automations] run ${prep.label} runId=${executionId} automation=${workflow.id} startIndex=${prep.startIndex} steps=${config.steps.length}`,
@@ -298,6 +323,11 @@ export class AutomationExecutor {
         where: { id: executionId },
         data: { status: AutomationRunStatus.SKIPPED },
       });
+      recordAutomationRunMetric('skipped', {
+        automationId: workflow.id,
+        workspaceId: workflow.workspaceId,
+        triggerType: config.trigger.type,
+      });
       skeleton.__meta = { error: null, chain };
       await persistAutomationState(executionId, { context: JSON.stringify(skeleton) });
       logger.info(
@@ -404,6 +434,7 @@ export class AutomationExecutor {
         where: { id: runId },
         data: { status: AutomationRunStatus.COMPLETED },
       });
+      recordAutomationRunMetric('completed', this.getMetricLabels(context));
       context.__meta = { error: null, chain };
       await persistAutomationState(runId, {
         context: JSON.stringify(context),
@@ -417,6 +448,7 @@ export class AutomationExecutor {
         where: { id: runId },
         data: { status: AutomationRunStatus.FAILED },
       });
+      recordAutomationRunMetric('failed', this.getMetricLabels(context));
       context.__meta = { error: errMessage, chain };
       await persistAutomationState(runId, {
         context: JSON.stringify(context),
@@ -471,6 +503,7 @@ export class AutomationExecutor {
             where: { id: runId },
             data: { status: EXTERNAL_WAIT_STATUS },
           });
+          recordAutomationRunMetric('paused', this.getMetricLabels(context));
           return { kind: 'paused', atIndex: i, externalRef: err.externalRef };
         }
         const errMessage = err instanceof Error ? err.message : String(err);

--- a/apps/backend/src/automations/engine/event-router.ts
+++ b/apps/backend/src/automations/engine/event-router.ts
@@ -13,6 +13,7 @@ import { AutomationStatus, AutomationRunStatus } from '../types/status';
 import { automationQueue } from '../queue/automation.queue';
 import type { AutomationEvent } from '../types/automation-events';
 import { EMAIL_RECEIVED_EVENT } from '../triggers/email-received.trigger';
+import { recordAutomationRunMetric } from '@/services/otel/automationMetrics';
 
 // Wire payload carries only ticketId, so the scope ids come off the ticket row.
 const TICKET_SCOPED_EVENTS: ReadonlySet<string> = new Set([
@@ -155,6 +156,9 @@ class EventRouter {
             }),
         );
 
+        // Counted at creation, before the enqueue: a run that is created but never
+        // delivered to a worker shows up as pending with no matching terminal state.
+        recordAutomationRunMetric('pending', eventType);
         await automationQueue.enqueueRun({ executionId: execution.id });
         enqueued += 1;
       } catch (err) {

--- a/apps/backend/src/automations/queue/automation-schedule.queue.ts
+++ b/apps/backend/src/automations/queue/automation-schedule.queue.ts
@@ -2,6 +2,10 @@ import Bull from 'bull';
 import { logger } from '@/utils/logger';
 import { redisService } from '@/services/redisService';
 import { markAutomationFailed } from '@/database/repositories/workflowExecutionStateUtils';
+import {
+  getAutomationQueueJobsGauge,
+  recordAutomationRunMetricAsync,
+} from '@/services/otel/automationMetrics';
 
 export interface AutomationScheduleJobData {
   executionId: string;
@@ -36,6 +40,7 @@ class AutomationScheduleQueue {
         logger.error(
           `[AUTOMATION-SCHEDULE-QUEUE] job ${job.id} failed — execution ${executionId}: ${message}`,
         );
+        void recordAutomationRunMetricAsync('queue_failed', executionId);
         void markAutomationFailed(executionId, message)
           .then(result => {
             if (result === 'marked') {
@@ -55,6 +60,7 @@ class AutomationScheduleQueue {
         logger.error('[AUTOMATION-SCHEDULE-QUEUE] queue error:', err),
       );
 
+      getAutomationQueueJobsGauge();
       this.isInitialized = true;
       logger.info('[AUTOMATION-SCHEDULE-QUEUE] Initialized');
     } catch (err) {

--- a/apps/backend/src/automations/queue/automation-schedule.queue.ts
+++ b/apps/backend/src/automations/queue/automation-schedule.queue.ts
@@ -2,10 +2,7 @@ import Bull from 'bull';
 import { logger } from '@/utils/logger';
 import { redisService } from '@/services/redisService';
 import { markAutomationFailed } from '@/database/repositories/workflowExecutionStateUtils';
-import {
-  getAutomationQueueJobsGauge,
-  recordAutomationRunMetricAsync,
-} from '@/services/otel/automationMetrics';
+import { recordAutomationRunMetric } from '@/services/otel/automationMetrics';
 
 export interface AutomationScheduleJobData {
   executionId: string;
@@ -40,10 +37,12 @@ class AutomationScheduleQueue {
         logger.error(
           `[AUTOMATION-SCHEDULE-QUEUE] job ${job.id} failed — execution ${executionId}: ${message}`,
         );
-        void recordAutomationRunMetricAsync('queue_failed', executionId);
         void markAutomationFailed(executionId, message)
           .then(result => {
             if (result === 'marked') {
+              // See automation.queue.ts — only count the failures this handler marks,
+              // so executor-failed runs aren't counted twice.
+              recordAutomationRunMetric('failed');
               logger.info(
                 `[AUTOMATION-SCHEDULE-QUEUE] reconciled execution=${executionId} → FAILED`,
               );
@@ -60,7 +59,6 @@ class AutomationScheduleQueue {
         logger.error('[AUTOMATION-SCHEDULE-QUEUE] queue error:', err),
       );
 
-      getAutomationQueueJobsGauge();
       this.isInitialized = true;
       logger.info('[AUTOMATION-SCHEDULE-QUEUE] Initialized');
     } catch (err) {

--- a/apps/backend/src/automations/queue/automation-schedule.worker.ts
+++ b/apps/backend/src/automations/queue/automation-schedule.worker.ts
@@ -8,6 +8,7 @@ import {
   automationScheduleQueue,
   type AutomationScheduleJobData,
 } from './automation-schedule.queue';
+import { registerAutomationQueueMetrics } from '@/services/otel/automationMetrics';
 
 class AutomationScheduleWorker {
   private isInitialized = false;
@@ -30,6 +31,9 @@ class AutomationScheduleWorker {
         return this.processJob(job);
       });
 
+    registerAutomationQueueMetrics('automations-schedule', () =>
+      automationScheduleQueue.getQueue().getJobCounts(),
+    );
     this.isInitialized = true;
     logger.info('[AUTOMATION-SCHEDULE-WORKER] Started');
   }

--- a/apps/backend/src/automations/queue/automation.queue.ts
+++ b/apps/backend/src/automations/queue/automation.queue.ts
@@ -2,6 +2,10 @@ import Bull from 'bull';
 import { logger } from '@/utils/logger';
 import { redisService } from '@/services/redisService';
 import { markAutomationFailed } from '@/database/repositories/workflowExecutionStateUtils';
+import {
+  getAutomationQueueJobsGauge,
+  recordAutomationRunMetricAsync,
+} from '@/services/otel/automationMetrics';
 
 export interface AutomationJobData {
   executionId: string;
@@ -38,6 +42,7 @@ class AutomationQueue {
       });
 
       this.setupEventListeners();
+      getAutomationQueueJobsGauge();
       this.isInitialized = true;
       logger.info('[AUTOMATION-QUEUE] Initialized');
     } catch (error) {
@@ -56,6 +61,7 @@ class AutomationQueue {
       logger.error(
         `[AUTOMATION-QUEUE] Job ${job.id} failed — execution ${executionId}: ${message}`,
       );
+      void recordAutomationRunMetricAsync('queue_failed', executionId);
       void markAutomationFailed(executionId, message)
         .then(result => {
           if (result === 'marked') {
@@ -71,6 +77,7 @@ class AutomationQueue {
     });
     this.queue.on('stalled', (job) => {
       logger.warn(`[AUTOMATION-QUEUE] Job ${job.id} stalled`);
+      void recordAutomationRunMetricAsync('stalled', job.data.executionId);
     });
     this.queue.on('error', (err) => {
       logger.error('[AUTOMATION-QUEUE] Queue error:', err);

--- a/apps/backend/src/automations/queue/automation.queue.ts
+++ b/apps/backend/src/automations/queue/automation.queue.ts
@@ -2,10 +2,7 @@ import Bull from 'bull';
 import { logger } from '@/utils/logger';
 import { redisService } from '@/services/redisService';
 import { markAutomationFailed } from '@/database/repositories/workflowExecutionStateUtils';
-import {
-  getAutomationQueueJobsGauge,
-  recordAutomationRunMetricAsync,
-} from '@/services/otel/automationMetrics';
+import { recordAutomationRunMetric } from '@/services/otel/automationMetrics';
 
 export interface AutomationJobData {
   executionId: string;
@@ -42,7 +39,6 @@ class AutomationQueue {
       });
 
       this.setupEventListeners();
-      getAutomationQueueJobsGauge();
       this.isInitialized = true;
       logger.info('[AUTOMATION-QUEUE] Initialized');
     } catch (error) {
@@ -61,10 +57,13 @@ class AutomationQueue {
       logger.error(
         `[AUTOMATION-QUEUE] Job ${job.id} failed — execution ${executionId}: ${message}`,
       );
-      void recordAutomationRunMetricAsync('queue_failed', executionId);
       void markAutomationFailed(executionId, message)
         .then(result => {
           if (result === 'marked') {
+            // Count only when this handler is the one that marked the run FAILED.
+            // A run the executor failed itself is already terminal ('skipped-terminal')
+            // and was counted there — emitting here too would double-count it.
+            recordAutomationRunMetric('failed');
             logger.info(`[AUTOMATION-QUEUE] reconciled execution=${executionId} → FAILED`);
           }
         })
@@ -77,7 +76,7 @@ class AutomationQueue {
     });
     this.queue.on('stalled', (job) => {
       logger.warn(`[AUTOMATION-QUEUE] Job ${job.id} stalled`);
-      void recordAutomationRunMetricAsync('stalled', job.data.executionId);
+      recordAutomationRunMetric('stalled');
     });
     this.queue.on('error', (err) => {
       logger.error('[AUTOMATION-QUEUE] Queue error:', err);

--- a/apps/backend/src/automations/queue/automation.worker.ts
+++ b/apps/backend/src/automations/queue/automation.worker.ts
@@ -19,9 +19,8 @@ import { computeScheduleRunAt } from '../types/automation-config';
 import { triggerRegistry } from '../triggers/trigger-registry';
 import type { TriggerType } from '../types/trigger-types';
 import {
-  getAutomationQueueJobsGauge,
   recordAutomationRunMetric,
-  type AutomationMetricLabels,
+  registerAutomationQueueMetrics,
 } from '@/services/otel/automationMetrics';
 
 const EXECUTION_FETCH_MAX_RETRIES = 3;
@@ -47,7 +46,9 @@ class AutomationWorker {
       return this.processJob(job);
     });
 
-    getAutomationQueueJobsGauge();
+    registerAutomationQueueMetrics('automations', () =>
+      automationQueue.getQueue().getJobCounts(),
+    );
     this.isInitialized = true;
     logger.info('[AUTOMATION-WORKER] Started');
   }
@@ -102,14 +103,13 @@ class AutomationWorker {
     }
 
     await runAsServiceActor('automation', workspaceId, () =>
-      this.runJob(job, execution, workspaceId),
+      this.runJob(job, execution),
     );
   }
 
   private async runJob(
     job: Bull.Job<AutomationJobData>,
     execution: NonNullable<Awaited<ReturnType<typeof db.workflowExecution.findUnique>>>,
-    workspaceId: string,
   ): Promise<void> {
     if (!this.executor) {
       throw new Error('[AUTOMATION-WORKER] Executor not initialized');
@@ -127,18 +127,13 @@ class AutomationWorker {
       return;
     }
     const config = parseAutomationConfig(workflow.context);
-    const metricLabels = {
-      automationId: workflow.id,
-      workspaceId,
-      triggerType: config.trigger.type,
-    };
 
     if (workflow.status !== AutomationStatus.ACTIVE && !mayDrainInFlight(workflow)) {
       await db.workflowExecution.update({
         where: { id: executionId },
         data: { status: AutomationRunStatus.CANCELLED },
       });
-      recordAutomationRunMetric('cancelled', metricLabels);
+      recordAutomationRunMetric('cancelled', config.trigger.type);
       logger.info(
         `[AUTOMATION-WORKER] workflow ${workflow.id} is ${workflow.status} (no longer live) — execution=${executionId} CANCELLED`,
       );
@@ -152,7 +147,7 @@ class AutomationWorker {
         where: { id: executionId },
         data: { status: AutomationRunStatus.CANCELLED },
       });
-      recordAutomationRunMetric('cancelled', metricLabels);
+      recordAutomationRunMetric('cancelled', config.trigger.type);
       logger.info(
         `[AUTOMATION-WORKER] cycle detected — workflow ${workflow.id} already in chain [${upstreamChain.join(' → ')}], execution=${executionId} CANCELLED`,
       );
@@ -181,7 +176,7 @@ class AutomationWorker {
           where: { id: executionId },
           data: { status: AutomationRunStatus.SKIPPED },
         });
-        recordAutomationRunMetric('skipped', metricLabels);
+        recordAutomationRunMetric('skipped', config.trigger.type);
         logger.info(
           `[AUTOMATION-WORKER] filter mismatched at intake — execution=${executionId} automation=${workflow.id}, skipping`,
         );
@@ -190,7 +185,12 @@ class AutomationWorker {
     }
 
     if (config.schedule && config.schedule.type === 'SCHEDULED') {
-      const handled = await this.tryDefer(executionId, config.schedule, hydratedTriggerData, metricLabels);
+      const handled = await this.tryDefer(
+        executionId,
+        config.schedule,
+        hydratedTriggerData,
+        config.trigger.type,
+      );
       if (handled) return;
     }
 
@@ -230,7 +230,7 @@ class AutomationWorker {
     executionId: string,
     schedule: Extract<ReturnType<typeof parseAutomationConfig>['schedule'], { type: 'SCHEDULED' }>,
     triggerData: Record<string, unknown>,
-    metricLabels: AutomationMetricLabels,
+    triggerType: string,
   ): Promise<boolean> {
     const runAt = computeScheduleRunAt(schedule, triggerData);
     if (runAt === null) {
@@ -252,7 +252,7 @@ class AutomationWorker {
       where: { id: executionId },
       data: { status: AutomationRunStatus.SCHEDULED },
     });
-    recordAutomationRunMetric('scheduled', metricLabels);
+    recordAutomationRunMetric('scheduled', triggerType);
     await automationScheduleQueue.enqueueScheduled({ executionId }, delayMs);
     logger.info(
       `[AUTOMATION-WORKER] execution=${executionId} SCHEDULED runAt=${new Date(runAt).toISOString()} delayMs=${delayMs}`,

--- a/apps/backend/src/automations/queue/automation.worker.ts
+++ b/apps/backend/src/automations/queue/automation.worker.ts
@@ -18,6 +18,11 @@ import { getAutomationPauseState } from '@/database/repositories/workflowExecuti
 import { computeScheduleRunAt } from '../types/automation-config';
 import { triggerRegistry } from '../triggers/trigger-registry';
 import type { TriggerType } from '../types/trigger-types';
+import {
+  getAutomationQueueJobsGauge,
+  recordAutomationRunMetric,
+  type AutomationMetricLabels,
+} from '@/services/otel/automationMetrics';
 
 const EXECUTION_FETCH_MAX_RETRIES = 3;
 const EXECUTION_FETCH_RETRY_BASE_DELAY_MS = 200;
@@ -42,6 +47,7 @@ class AutomationWorker {
       return this.processJob(job);
     });
 
+    getAutomationQueueJobsGauge();
     this.isInitialized = true;
     logger.info('[AUTOMATION-WORKER] Started');
   }
@@ -96,13 +102,14 @@ class AutomationWorker {
     }
 
     await runAsServiceActor('automation', workspaceId, () =>
-      this.runJob(job, execution),
+      this.runJob(job, execution, workspaceId),
     );
   }
 
   private async runJob(
     job: Bull.Job<AutomationJobData>,
     execution: NonNullable<Awaited<ReturnType<typeof db.workflowExecution.findUnique>>>,
+    workspaceId: string,
   ): Promise<void> {
     if (!this.executor) {
       throw new Error('[AUTOMATION-WORKER] Executor not initialized');
@@ -119,11 +126,19 @@ class AutomationWorker {
       logger.warn(`[AUTOMATION-WORKER] workflow ${execution.workflowId} missing — dropping`);
       return;
     }
+    const config = parseAutomationConfig(workflow.context);
+    const metricLabels = {
+      automationId: workflow.id,
+      workspaceId,
+      triggerType: config.trigger.type,
+    };
+
     if (workflow.status !== AutomationStatus.ACTIVE && !mayDrainInFlight(workflow)) {
       await db.workflowExecution.update({
         where: { id: executionId },
         data: { status: AutomationRunStatus.CANCELLED },
       });
+      recordAutomationRunMetric('cancelled', metricLabels);
       logger.info(
         `[AUTOMATION-WORKER] workflow ${workflow.id} is ${workflow.status} (no longer live) — execution=${executionId} CANCELLED`,
       );
@@ -137,13 +152,12 @@ class AutomationWorker {
         where: { id: executionId },
         data: { status: AutomationRunStatus.CANCELLED },
       });
+      recordAutomationRunMetric('cancelled', metricLabels);
       logger.info(
         `[AUTOMATION-WORKER] cycle detected — workflow ${workflow.id} already in chain [${upstreamChain.join(' → ')}], execution=${executionId} CANCELLED`,
       );
       return;
     }
-
-    const config = parseAutomationConfig(workflow.context);
 
     const triggerType = config.trigger.type as TriggerType;
     const triggerImpl = triggerRegistry.has(triggerType)
@@ -167,6 +181,7 @@ class AutomationWorker {
           where: { id: executionId },
           data: { status: AutomationRunStatus.SKIPPED },
         });
+        recordAutomationRunMetric('skipped', metricLabels);
         logger.info(
           `[AUTOMATION-WORKER] filter mismatched at intake — execution=${executionId} automation=${workflow.id}, skipping`,
         );
@@ -175,7 +190,7 @@ class AutomationWorker {
     }
 
     if (config.schedule && config.schedule.type === 'SCHEDULED') {
-      const handled = await this.tryDefer(executionId, config.schedule, hydratedTriggerData);
+      const handled = await this.tryDefer(executionId, config.schedule, hydratedTriggerData, metricLabels);
       if (handled) return;
     }
 
@@ -215,6 +230,7 @@ class AutomationWorker {
     executionId: string,
     schedule: Extract<ReturnType<typeof parseAutomationConfig>['schedule'], { type: 'SCHEDULED' }>,
     triggerData: Record<string, unknown>,
+    metricLabels: AutomationMetricLabels,
   ): Promise<boolean> {
     const runAt = computeScheduleRunAt(schedule, triggerData);
     if (runAt === null) {
@@ -236,6 +252,7 @@ class AutomationWorker {
       where: { id: executionId },
       data: { status: AutomationRunStatus.SCHEDULED },
     });
+    recordAutomationRunMetric('scheduled', metricLabels);
     await automationScheduleQueue.enqueueScheduled({ executionId }, delayMs);
     logger.info(
       `[AUTOMATION-WORKER] execution=${executionId} SCHEDULED runAt=${new Date(runAt).toISOString()} delayMs=${delayMs}`,

--- a/apps/backend/src/automations/routes/webhook-trigger.handler.ts
+++ b/apps/backend/src/automations/routes/webhook-trigger.handler.ts
@@ -14,6 +14,7 @@ import {
   parseAutomationMetadata,
 } from '../types/workflow-adapter';
 import { WEBHOOK_EVENT } from '../triggers/webhook.trigger';
+import { recordAutomationRunMetric } from '@/services/otel/automationMetrics';
 
 const router = Router();
 
@@ -120,6 +121,7 @@ router.post(
         }),
     );
 
+    recordAutomationRunMetric('pending', WEBHOOK_EVENT);
     await automationQueue.enqueueRun({ executionId: execution.id });
     logger.info(
       `[webhook-trigger] automation=${workflow.id} execution=${execution.id} accepted`,

--- a/apps/backend/src/services/otel/automationMetrics.ts
+++ b/apps/backend/src/services/otel/automationMetrics.ts
@@ -18,14 +18,18 @@ export function getAutomationRunsTotal(): Counter {
   return _automationRuns;
 }
 
+// Mirrors the AutomationRunStatus values the UI filters on (RunHistory.tsx), so a
+// Grafana status filter maps 1:1 onto the run-history filter. 'stalled' is the one
+// addition: a Bull-level event with no DB status of its own.
 export type AutomationRunMetricStatus =
-  | 'started'
+  | 'pending'
+  | 'scheduled'
+  | 'running'
+  | 'external_wait'
   | 'completed'
   | 'failed'
-  | 'skipped'
   | 'cancelled'
-  | 'paused'
-  | 'scheduled'
+  | 'skipped'
   | 'stalled';
 
 /** Single entry point so every emission carries the same label set — a partial

--- a/apps/backend/src/services/otel/automationMetrics.ts
+++ b/apps/backend/src/services/otel/automationMetrics.ts
@@ -1,21 +1,17 @@
 import { metrics } from '@opentelemetry/api';
-import type { Counter, ObservableGauge, Meter } from '@opentelemetry/api';
+import type { Counter, Meter } from '@opentelemetry/api';
 import { config } from '@/config/env';
-import { db } from '@/database/client';
-import { parseAutomationConfig } from '@/automations/types/workflow-adapter';
-import { automationQueue } from '@/automations/queue/automation.queue';
-import { automationScheduleQueue } from '@/automations/queue/automation-schedule.queue';
 
 function getMeter(): Meter {
   return metrics.getMeter(config.otel.serviceName);
 }
 
-// Automation run state-transition counter.
+// Automation run state-transition counter — labels: status, trigger_type
 let _automationRuns: Counter | null = null;
-function getAutomationRunsCounter(): Counter {
+export function getAutomationRunsTotal(): Counter {
   if (!_automationRuns) {
-    _automationRuns = getMeter().createCounter('automations_runs_total', {
-      description: 'Total automation runs by state, workspace, automation and trigger type',
+    _automationRuns = getMeter().createCounter('automation_runs_total', {
+      description: 'Total automation runs by state and trigger type',
       unit: '1',
     });
   }
@@ -30,125 +26,56 @@ export type AutomationRunMetricStatus =
   | 'cancelled'
   | 'paused'
   | 'scheduled'
-  | 'queue_failed'
   | 'stalled';
 
-export interface AutomationMetricLabels {
-  automationId?: string | null;
-  workspaceId?: string | null;
-  triggerType?: string | null;
-}
-
+/** Single entry point so every emission carries the same label set — a partial
+ *  label set would silently drop runs out of any trigger_type-filtered panel. */
 export function recordAutomationRunMetric(
   status: AutomationRunMetricStatus,
-  labels: AutomationMetricLabels = {},
+  triggerType?: string | null,
 ): void {
-  getAutomationRunsCounter().add(1, {
+  getAutomationRunsTotal().add(1, {
     status,
-    automation_id: labels.automationId ?? 'unknown',
-    workspace_id: labels.workspaceId ?? 'unknown',
-    trigger_type: labels.triggerType ?? 'unknown',
+    trigger_type: triggerType || 'unknown',
   });
 }
 
-/** Best-effort metric emission that looks up an execution's labels by id.
- *  Used from queue event listeners where only the execution id is available. */
-export async function recordAutomationRunMetricAsync(
-  status: AutomationRunMetricStatus,
-  executionId: string,
-): Promise<void> {
-  try {
-    const execution = await db.workflowExecution.findUnique({
-      where: { id: executionId },
-      select: { workflowId: true, workspaceId: true },
-    });
-    const workflow = execution?.workflowId
-      ? await db.workflow.findUnique({
-          where: { id: execution.workflowId },
-          select: { context: true, workspaceId: true },
-        })
-      : null;
-    const cfg = workflow?.context ? parseAutomationConfig(workflow.context) : null;
-    recordAutomationRunMetric(status, {
-      automationId: execution?.workflowId,
-      workspaceId: workflow?.workspaceId ?? execution?.workspaceId,
-      triggerType: cfg?.trigger.type,
-    });
-  } catch {
-    // Best-effort: emit without labels if lookups fail.
-    recordAutomationRunMetric(status);
-  }
+/** Bull's getJobCounts() shape, narrowed to the states worth graphing. */
+interface AutomationQueueCounts {
+  waiting: number;
+  active: number;
+  delayed: number;
 }
 
-// Observable gauge exposing Bull job counts for each automation queue.
-let _automationQueueJobs: ObservableGauge | null = null;
-export function getAutomationQueueJobsGauge(): ObservableGauge {
-  if (!_automationQueueJobs) {
-    _automationQueueJobs = getMeter().createObservableGauge('automations_queue_jobs', {
-      description: 'Current number of automation queue jobs by queue name and state',
+// Observable gauge exposing Bull job depth per automation queue.
+//
+// Register from the queue's WORKER, never from initialize(): the API process also
+// calls initializeAutomations(), so registering at queue init would make every API
+// replica report the same Redis depth.
+//
+// Depth is a property of Redis, not of the reporting process, so N worker replicas
+// emit N identical series — aggregate with max/avg by (queue), never sum.
+const _registeredQueues = new Set<string>();
+export function registerAutomationQueueMetrics(
+  queueName: string,
+  getCounts: () => Promise<AutomationQueueCounts>,
+): void {
+  if (_registeredQueues.has(queueName)) return;
+  _registeredQueues.add(queueName);
+
+  getMeter()
+    .createObservableGauge('automation_queue_jobs', {
+      description: 'Current number of automation queue jobs by queue and state',
       unit: '1',
-    });
-
-    _automationQueueJobs.addCallback(async observableResult => {
-      if (automationQueue.isReady) {
-        try {
-          const counts = await automationQueue.getQueue().getJobCounts();
-          observableResult.observe(counts.waiting ?? 0, {
-            queue_name: 'automations',
-            state: 'waiting',
-          });
-          observableResult.observe(counts.active ?? 0, {
-            queue_name: 'automations',
-            state: 'active',
-          });
-          observableResult.observe(counts.completed ?? 0, {
-            queue_name: 'automations',
-            state: 'completed',
-          });
-          observableResult.observe(counts.failed ?? 0, {
-            queue_name: 'automations',
-            state: 'failed',
-          });
-          observableResult.observe(counts.delayed ?? 0, {
-            queue_name: 'automations',
-            state: 'delayed',
-          });
-        } catch {
-          // Ignore transient queue read errors.
-        }
-      }
-
-      if (automationScheduleQueue.isReady) {
-        try {
-          const counts = await automationScheduleQueue.getQueue().getJobCounts();
-          observableResult.observe(counts.waiting ?? 0, {
-            queue_name: 'automations-schedule',
-            state: 'waiting',
-          });
-          observableResult.observe(counts.active ?? 0, {
-            queue_name: 'automations-schedule',
-            state: 'active',
-          });
-          observableResult.observe(counts.completed ?? 0, {
-            queue_name: 'automations-schedule',
-            state: 'completed',
-          });
-          observableResult.observe(counts.failed ?? 0, {
-            queue_name: 'automations-schedule',
-            state: 'failed',
-          });
-          observableResult.observe(counts.delayed ?? 0, {
-            queue_name: 'automations-schedule',
-            state: 'delayed',
-          });
-        } catch {
-          // Ignore transient queue read errors.
-        }
+    })
+    .addCallback(async result => {
+      try {
+        const counts = await getCounts();
+        result.observe(counts.waiting ?? 0, { queue: queueName, state: 'waiting' });
+        result.observe(counts.active ?? 0, { queue: queueName, state: 'active' });
+        result.observe(counts.delayed ?? 0, { queue: queueName, state: 'delayed' });
+      } catch {
+        // Transient Redis read failure — skip this collection cycle.
       }
     });
-  }
-  return _automationQueueJobs;
 }
-
-// Register the gauge callback eagerly so collectors see the metric as soon as OTEL starts.
-void getAutomationQueueJobsGauge();

--- a/apps/backend/src/services/otel/automationMetrics.ts
+++ b/apps/backend/src/services/otel/automationMetrics.ts
@@ -1,0 +1,154 @@
+import { metrics } from '@opentelemetry/api';
+import type { Counter, ObservableGauge, Meter } from '@opentelemetry/api';
+import { config } from '@/config/env';
+import { db } from '@/database/client';
+import { parseAutomationConfig } from '@/automations/types/workflow-adapter';
+import { automationQueue } from '@/automations/queue/automation.queue';
+import { automationScheduleQueue } from '@/automations/queue/automation-schedule.queue';
+
+function getMeter(): Meter {
+  return metrics.getMeter(config.otel.serviceName);
+}
+
+// Automation run state-transition counter.
+let _automationRuns: Counter | null = null;
+function getAutomationRunsCounter(): Counter {
+  if (!_automationRuns) {
+    _automationRuns = getMeter().createCounter('automations_runs_total', {
+      description: 'Total automation runs by state, workspace, automation and trigger type',
+      unit: '1',
+    });
+  }
+  return _automationRuns;
+}
+
+export type AutomationRunMetricStatus =
+  | 'started'
+  | 'completed'
+  | 'failed'
+  | 'skipped'
+  | 'cancelled'
+  | 'paused'
+  | 'scheduled'
+  | 'queue_failed'
+  | 'stalled';
+
+export interface AutomationMetricLabels {
+  automationId?: string | null;
+  workspaceId?: string | null;
+  triggerType?: string | null;
+}
+
+export function recordAutomationRunMetric(
+  status: AutomationRunMetricStatus,
+  labels: AutomationMetricLabels = {},
+): void {
+  getAutomationRunsCounter().add(1, {
+    status,
+    automation_id: labels.automationId ?? 'unknown',
+    workspace_id: labels.workspaceId ?? 'unknown',
+    trigger_type: labels.triggerType ?? 'unknown',
+  });
+}
+
+/** Best-effort metric emission that looks up an execution's labels by id.
+ *  Used from queue event listeners where only the execution id is available. */
+export async function recordAutomationRunMetricAsync(
+  status: AutomationRunMetricStatus,
+  executionId: string,
+): Promise<void> {
+  try {
+    const execution = await db.workflowExecution.findUnique({
+      where: { id: executionId },
+      select: { workflowId: true, workspaceId: true },
+    });
+    const workflow = execution?.workflowId
+      ? await db.workflow.findUnique({
+          where: { id: execution.workflowId },
+          select: { context: true, workspaceId: true },
+        })
+      : null;
+    const cfg = workflow?.context ? parseAutomationConfig(workflow.context) : null;
+    recordAutomationRunMetric(status, {
+      automationId: execution?.workflowId,
+      workspaceId: workflow?.workspaceId ?? execution?.workspaceId,
+      triggerType: cfg?.trigger.type,
+    });
+  } catch {
+    // Best-effort: emit without labels if lookups fail.
+    recordAutomationRunMetric(status);
+  }
+}
+
+// Observable gauge exposing Bull job counts for each automation queue.
+let _automationQueueJobs: ObservableGauge | null = null;
+export function getAutomationQueueJobsGauge(): ObservableGauge {
+  if (!_automationQueueJobs) {
+    _automationQueueJobs = getMeter().createObservableGauge('automations_queue_jobs', {
+      description: 'Current number of automation queue jobs by queue name and state',
+      unit: '1',
+    });
+
+    _automationQueueJobs.addCallback(async observableResult => {
+      if (automationQueue.isReady) {
+        try {
+          const counts = await automationQueue.getQueue().getJobCounts();
+          observableResult.observe(counts.waiting ?? 0, {
+            queue_name: 'automations',
+            state: 'waiting',
+          });
+          observableResult.observe(counts.active ?? 0, {
+            queue_name: 'automations',
+            state: 'active',
+          });
+          observableResult.observe(counts.completed ?? 0, {
+            queue_name: 'automations',
+            state: 'completed',
+          });
+          observableResult.observe(counts.failed ?? 0, {
+            queue_name: 'automations',
+            state: 'failed',
+          });
+          observableResult.observe(counts.delayed ?? 0, {
+            queue_name: 'automations',
+            state: 'delayed',
+          });
+        } catch {
+          // Ignore transient queue read errors.
+        }
+      }
+
+      if (automationScheduleQueue.isReady) {
+        try {
+          const counts = await automationScheduleQueue.getQueue().getJobCounts();
+          observableResult.observe(counts.waiting ?? 0, {
+            queue_name: 'automations-schedule',
+            state: 'waiting',
+          });
+          observableResult.observe(counts.active ?? 0, {
+            queue_name: 'automations-schedule',
+            state: 'active',
+          });
+          observableResult.observe(counts.completed ?? 0, {
+            queue_name: 'automations-schedule',
+            state: 'completed',
+          });
+          observableResult.observe(counts.failed ?? 0, {
+            queue_name: 'automations-schedule',
+            state: 'failed',
+          });
+          observableResult.observe(counts.delayed ?? 0, {
+            queue_name: 'automations-schedule',
+            state: 'delayed',
+          });
+        } catch {
+          // Ignore transient queue read errors.
+        }
+      }
+    });
+  }
+  return _automationQueueJobs;
+}
+
+// Register the gauge callback eagerly so collectors see the metric as soon as OTEL starts.
+void getAutomationQueueJobsGauge();

--- a/apps/backend/src/services/otel/index.ts
+++ b/apps/backend/src/services/otel/index.ts
@@ -6,3 +6,4 @@ export * from './dbMetrics';
 export * from './notificationMetrics';
 export * from './aiMetrics';
 export * from './nudgeMetrics';
+export * from './automationMetrics';


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
