### PR TITLE
Fix/cmdk rows rebase 1258

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -1917,39 +1917,133 @@ const ChannelCommandMenu = ({
     ];
   }, [mentionSearchType, mentionSearchQuery]);
 
+  // ── Mention typeahead: ONE flat, ordered list of the rows selectable right now. The render,
+  // Enter/Tab accept (acceptHighlightedMention) and the ghost label all read this, so what's
+  // highlighted, what Enter picks and what the ghost previews can never disagree. Plain const,
+  // not useMemo: the inputs change on nearly every keystroke, so a memo would only ever miss.
+  // Order MUST match the render (esp. `in:` = channels then DMs) — it's the flat highlight index.
+  const activeMentionCandidates: Array<{
+    section: string;
+    name: string;
+    accept: () => void;
+    channel?: Channel;
+    user?: { id: string; name: string; status?: string; email?: string };
+    value?: { id: string; name: string };
+    target?: { id: string; name: string; type: ChipType };
+  }> = [];
+  const addChannelMentionRows = (
+    list: Array<{ channel: Channel; displayName: string }>,
+    section: string,
+  ) =>
+    list.forEach(({ channel, displayName }) =>
+      activeMentionCandidates.push({
+        section,
+        name: displayName,
+        channel,
+        accept: () =>
+          void handleMentionSelect({ id: channel.id, name: displayName, type: ChipType.CHANNEL }),
+      }),
+    );
+  if (mentionSearchType) {
+    if (channelTrigger === 'in:') {
+      addChannelMentionRows(availableRegularChannels, 'Channels');
+      addChannelMentionRows(availableDMs, 'DMs');
+    } else if (channelTrigger === 'in:#') {
+      addChannelMentionRows(availableRegularChannels, 'Channels');
+    } else if (channelTrigger === 'in:@') {
+      addChannelMentionRows(availableDMs, 'DMs');
+    } else if (channelTrigger === '#') {
+      addChannelMentionRows(availableChannels, 'Channels');
+    } else if (mentionSearchType === ChipType.USER) {
+      availableUsers.forEach(user =>
+        activeMentionCandidates.push({
+          section: 'Users',
+          name: getUserDisplayName(user),
+          user,
+          accept: () =>
+            void handleMentionSelect({
+              id: user.id,
+              name: getUserDisplayName(user),
+              type: ChipType.USER,
+              ...(user.email ? { email: user.email } : {}),
+            }),
+        }),
+      );
+    } else if (mentionSearchType === ChipType.BOARD) {
+      availableBoards.forEach(board =>
+        activeMentionCandidates.push({
+          section: 'Board',
+          name: board.name,
+          value: board,
+          accept: () =>
+            void handleMentionSelect({ id: board.id, name: board.name, type: ChipType.BOARD }),
+        }),
+      );
+    } else if (mentionSearchType === ChipType.PRIORITY) {
+      availablePriorities.forEach(priority =>
+        activeMentionCandidates.push({
+          section: 'Priority',
+          name: priority.name,
+          value: priority,
+          accept: () =>
+            void handleMentionSelect({
+              id: priority.id,
+              name: priority.name,
+              type: ChipType.PRIORITY,
+            }),
+        }),
+      );
+    } else if (mentionSearchType === ChipType.DATE) {
+      availableDates.forEach(option =>
+        activeMentionCandidates.push({
+          section: 'Date',
+          name: option.name,
+          value: option,
+          accept: () => selectDate(option),
+        }),
+      );
+    } else if (mentionSearchType === ChipType.MENTIONS) {
+      availableMentionTargets.forEach(target =>
+        activeMentionCandidates.push({
+          section: target.type === ChipType.USER ? 'People' : 'Channels',
+          name: target.name,
+          target,
+          accept: () =>
+            void handleMentionSelect({ id: target.id, name: target.name, type: target.type }),
+        }),
+      );
+    }
+  }
+
   // The highlighted candidate in the open mention popup — the exact row Enter/click selects.
-  // Reads the same arrays the Enter handler indexes, so the ghost never disagrees with Enter.
-  const mentionActiveLabel = useMemo<string | null>(() => {
-    if (mentionSearchType === ChipType.USER) {
-      const user = availableUsers[selectedMentionIndex];
-      return user ? getUserDisplayName(user) : null;
-    }
-    if (mentionSearchType === ChipType.CHANNEL) {
-      return availableChannels[selectedMentionIndex]?.displayName ?? null;
-    }
-    if (mentionSearchType === ChipType.DATE) {
-      return availableDates[selectedMentionIndex]?.name ?? null;
-    }
-    if (mentionSearchType === ChipType.BOARD) {
-      return availableBoards[selectedMentionIndex]?.name ?? null;
-    }
-    if (mentionSearchType === ChipType.PRIORITY) {
-      return availablePriorities[selectedMentionIndex]?.name ?? null;
-    }
-    if (mentionSearchType === ChipType.MENTIONS) {
-      return availableMentionTargets[selectedMentionIndex]?.name ?? null;
-    }
-    return null;
-  }, [
-    mentionSearchType,
-    availableUsers,
-    availableChannels,
-    availablePriorities,
-    availableDates,
-    availableBoards,
-    availableMentionTargets,
-    selectedMentionIndex,
-  ]);
+  const mentionActiveLabel = activeMentionCandidates[selectedMentionIndex]?.name ?? null;
+
+  // CHANNEL/USER render from these candidates, grouped by consecutive section (`startIndex` is the
+  // flat highlight index of a group's first row). BOARD/DATE/PRIORITY/MENTIONS keep their own
+  // bespoke render below — their candidates above feed only accept + the ghost label, not this.
+  const mentionSectionGroups: Array<{
+    section: string;
+    startIndex: number;
+    rows: typeof activeMentionCandidates;
+  }> = [];
+  activeMentionCandidates.forEach((candidate, index) => {
+    const current = mentionSectionGroups[mentionSectionGroups.length - 1];
+    if (current && current.section === candidate.section) current.rows.push(candidate);
+    else
+      mentionSectionGroups.push({
+        section: candidate.section,
+        startIndex: index,
+        rows: [candidate],
+      });
+  });
+  const mentionEmptyText =
+    channelTrigger === 'in:@'
+      ? 'No DMs found'
+      : channelTrigger === 'in:#' || channelTrigger === '#'
+        ? 'No channels found'
+        : mentionSearchType === ChipType.USER
+          ? 'No users found'
+          : 'No results found';
 
   // Ghost suffix for an OPEN filter typeahead: previews the highlighted candidate + the action
   // Enter triggers - " - Select" for the filter prefixes (from/to/with/assignee/in/priority),
@@ -3270,122 +3364,9 @@ const ChannelCommandMenu = ({
   // and by Tab/ArrowRight so `from:ar` + Tab completes the mention the same way Enter would,
   // instead of falling through to tab-cycling or the ticket-preview shortcut.
   const acceptHighlightedMention = (): void => {
-    // Handle 'in:' trigger - Channels + DMs (NO Users)
-    if (channelTrigger === 'in:') {
-      const regularChannelCount = availableRegularChannels.length;
-
-      if (selectedMentionIndex < regularChannelCount) {
-        // Selecting a regular channel
-        const channelIndex = selectedMentionIndex;
-        if (availableRegularChannels[channelIndex]) {
-          const { channel, displayName } = availableRegularChannels[channelIndex];
-          void handleMentionSelect({
-            id: channel.id,
-            name: displayName,
-            type: ChipType.CHANNEL,
-          });
-        }
-      } else {
-        // Selecting a DM
-        const dmIndex = selectedMentionIndex - regularChannelCount;
-        if (availableDMs[dmIndex]) {
-          const { channel, displayName } = availableDMs[dmIndex];
-          void handleMentionSelect({
-            id: channel.id,
-            name: displayName,
-            type: ChipType.CHANNEL,
-          });
-        }
-      }
-      return;
-    }
-
-    // Handle 'in:#' trigger - Channels only (NO DMs)
-    if (channelTrigger === 'in:#') {
-      if (availableRegularChannels[selectedMentionIndex]) {
-        const { channel, displayName } = availableRegularChannels[selectedMentionIndex];
-        void handleMentionSelect({
-          id: channel.id,
-          name: displayName,
-          type: ChipType.CHANNEL,
-        });
-      }
-      return;
-    }
-
-    // Handle 'in:@' trigger - DMs only (NOT Users!)
-    if (channelTrigger === 'in:@') {
-      if (availableDMs[selectedMentionIndex]) {
-        const { channel, displayName } = availableDMs[selectedMentionIndex];
-        void handleMentionSelect({
-          id: channel.id,
-          name: displayName,
-          type: ChipType.CHANNEL,
-        });
-      }
-      return;
-    }
-
-    // Handle '#' trigger - only Channels (legacy combined list)
-    if (channelTrigger === '#' && availableChannels[selectedMentionIndex]) {
-      const { channel, displayName } = availableChannels[selectedMentionIndex];
-      void handleMentionSelect({
-        id: channel.id,
-        name: displayName,
-        type: ChipType.CHANNEL,
-      });
-      return;
-    }
-
-    // Board value selection (candidate list from Zero, no backend lookup).
-    if (mentionSearchType === ChipType.BOARD && availableBoards[selectedMentionIndex]) {
-      const board = availableBoards[selectedMentionIndex];
-      void handleMentionSelect({ id: board.id, name: board.name, type: ChipType.BOARD });
-      return;
-    }
-
-    // Date value selection. Goes through `selectDate` rather than handleMentionSelect: a
-    // range has two bounds, which one chip can't hold, so it lands as two chips.
-    if (mentionSearchType === ChipType.DATE && availableDates[selectedMentionIndex]) {
-      selectDate(availableDates[selectedMentionIndex]);
-      return;
-    }
-
-    // `mentions:` value selection — one list, two kinds; the candidate carries its type.
-    if (mentionSearchType === ChipType.MENTIONS && availableMentionTargets[selectedMentionIndex]) {
-      const target = availableMentionTargets[selectedMentionIndex];
-      void handleMentionSelect({ id: target.id, name: target.name, type: target.type });
-      return;
-    }
-
-    // Handle priority value selection (closed enum, no backend)
-    if (mentionSearchType === ChipType.PRIORITY && availablePriorities[selectedMentionIndex]) {
-      const priority = availablePriorities[selectedMentionIndex];
-      void handleMentionSelect({
-        id: priority.id,
-        name: priority.name,
-        type: ChipType.PRIORITY,
-      });
-      return;
-    }
-
-    // Handle regular user mention search (@, from:, with:, assignee:)
-    if (mentionSearchType === ChipType.USER && availableUsers[selectedMentionIndex]) {
-      const user = availableUsers[selectedMentionIndex];
-      void handleMentionSelect({
-        id: user.id,
-        name: getUserDisplayName(user),
-        type: ChipType.USER,
-        ...(user.email ? { email: user.email } : {}),
-      });
-    } else if (mentionSearchType === ChipType.CHANNEL && availableChannels[selectedMentionIndex]) {
-      const { channel, displayName } = availableChannels[selectedMentionIndex];
-      void handleMentionSelect({
-        id: channel.id,
-        name: displayName,
-        type: ChipType.CHANNEL,
-      });
-    }
+    // Enter/Tab accept the highlighted mention row — one lookup into the shared flat list
+    // (built above), so it always matches what's rendered and what the ghost previews.
+    activeMentionCandidates[selectedMentionIndex]?.accept();
   };
 
   const handleCommandKeyDown = (e: React.KeyboardEvent<HTMLElement>): void => {
@@ -4095,243 +4076,52 @@ const ChannelCommandMenu = ({
                 {/* Mention Suggestions - Show when mention search is active */}
                 {mentionSearchType && (
                   <>
-                    {/* 'in:' trigger - Show Channels + DMs (NO Users) */}
-                    {channelTrigger === 'in:' && (
+                    {(mentionSearchType === ChipType.CHANNEL ||
+                      mentionSearchType === ChipType.USER) && (
                       <>
-                        {/* 1. Channels Section */}
-                        {availableRegularChannels.length > 0 && (
-                          <CommandSection heading='Channels'>
-                            {availableRegularChannels.map(({ channel, displayName }, index) => (
-                              <ChannelRow
-                                key={channel.id}
-                                value={`mention-channel-${channel.id}`}
-                                label={displayName}
-                                channel={channel}
-                                isActive={index === selectedMentionIndex}
-                                onMouseEnter={() => selectMention(index)}
-                                onSelect={() => {
-                                  void handleMentionSelect({
-                                    id: channel.id,
-                                    name: displayName,
-                                    type: ChipType.CHANNEL,
-                                  });
-                                }}
-                              />
-                            ))}
-                          </CommandSection>
-                        )}
-                        {/* 2. DMs Section (includes Group DMs) */}
-                        {availableDMs.length > 0 && (
-                          <CommandSection heading='DMs'>
-                            {availableDMs.map(({ channel, displayName }, index) => {
-                              // DMs render after channels in one list, so offset the highlight index.
-                              const adjustedIndex = availableRegularChannels.length + index;
-                              return (
-                                <ChannelRow
-                                  key={channel.id}
-                                  value={`mention-dm-${channel.id}`}
-                                  label={displayName}
-                                  channel={channel}
-                                  isActive={adjustedIndex === selectedMentionIndex}
-                                  onMouseEnter={() => selectMention(adjustedIndex)}
-                                  onSelect={() => {
-                                    void handleMentionSelect({
-                                      id: channel.id,
-                                      name: displayName,
-                                      type: ChipType.CHANNEL,
-                                    });
-                                  }}
-                                />
-                              );
+                        {mentionSectionGroups.map(({ section, startIndex, rows }) => (
+                          <CommandSection key={section} heading={section}>
+                            {rows.map((candidate, i) => {
+                              const index = startIndex + i;
+                              const isActive = index === selectedMentionIndex;
+                              const onHover = () => selectMention(index);
+                              if (candidate.channel) {
+                                return (
+                                  <ChannelRow
+                                    key={candidate.channel.id}
+                                    value={`mention-${section === 'DMs' ? 'dm' : 'channel'}-${candidate.channel.id}`}
+                                    label={candidate.name}
+                                    channel={candidate.channel}
+                                    isActive={isActive}
+                                    onMouseEnter={onHover}
+                                    onSelect={candidate.accept}
+                                  />
+                                );
+                              }
+                              if (candidate.user) {
+                                return (
+                                  <UserRow
+                                    key={candidate.user.id}
+                                    user={candidate.user}
+                                    value={`mention-user-${candidate.user.id}`}
+                                    isActive={isActive}
+                                    onMouseEnter={onHover}
+                                    badgeCount={dmUnreadCountForUser(candidate.user.id)}
+                                    onSelect={candidate.accept}
+                                  />
+                                );
+                              }
+                              return null;
                             })}
                           </CommandSection>
-                        )}
-                        {/* Empty state for in: when nothing matches */}
-                        {availableRegularChannels.length === 0 &&
-                          availableDMs.length === 0 &&
-                          mentionSearchQuery && (
-                            <Command.Empty className='py-6 text-center text-sm text-muted-foreground'>
-                              No results found for &quot;{mentionSearchQuery}&quot;
-                            </Command.Empty>
-                          )}
-
-                        {/* Regular USER mention search (@, from:, assignee:) - Show only Users */}
-                        {mentionSearchType === ChipType.USER &&
-                          (userTrigger === '@' ||
-                            userTrigger === 'from:' ||
-                            userTrigger === 'to:' ||
-                            userTrigger === 'assignee:') &&
-                          availableUsers.length > 0 && (
-                            <CommandSection heading='Users'>
-                              {availableUsers.map((user, index) => (
-                                <UserRow
-                                  key={user.id}
-                                  user={user}
-                                  value={`mention-user-${user.id}`}
-                                  isActive={index === selectedMentionIndex}
-                                  onMouseEnter={() => selectMention(index)}
-                                  badgeCount={dmUnreadCountForUser(user.id)}
-                                  onSelect={() => {
-                                    void handleMentionSelect({
-                                      id: user.id,
-                                      name: getUserDisplayName(user),
-                                      type: ChipType.USER,
-                                      ...(user.email ? { email: user.email } : {}),
-                                    });
-                                  }}
-                                />
-                              ))}
-                            </CommandSection>
-                          )}
-                        {mentionSearchType === ChipType.USER &&
-                          (userTrigger === '@' ||
-                            userTrigger === 'from:' ||
-                            userTrigger === 'to:' ||
-                            userTrigger === 'assignee:') &&
-                          availableUsers.length === 0 &&
-                          mentionSearchQuery && (
-                            <Command.Empty className='py-6 text-center text-sm text-muted-foreground'>
-                              No users found for &quot;{mentionSearchQuery}&quot;
-                            </Command.Empty>
-                          )}
-                      </>
-                    )}
-
-                    {/* 'in:#' trigger - Show Channels only (NO DMs, NO Users) */}
-                    {channelTrigger === 'in:#' && (
-                      <>
-                        {/* Channels Section */}
-                        {availableRegularChannels.length > 0 && (
-                          <CommandSection heading='Channels'>
-                            {availableRegularChannels.map(({ channel, displayName }, index) => (
-                              <ChannelRow
-                                key={channel.id}
-                                value={`mention-channel-${channel.id}`}
-                                label={displayName}
-                                channel={channel}
-                                isActive={index === selectedMentionIndex}
-                                onMouseEnter={() => selectMention(index)}
-                                onSelect={() => {
-                                  void handleMentionSelect({
-                                    id: channel.id,
-                                    name: displayName,
-                                    type: ChipType.CHANNEL,
-                                  });
-                                }}
-                              />
-                            ))}
-                          </CommandSection>
-                        )}
-                        {/* Empty state */}
-                        {availableRegularChannels.length === 0 && mentionSearchQuery && (
+                        ))}
+                        {activeMentionCandidates.length === 0 && mentionSearchQuery && (
                           <Command.Empty className='py-6 text-center text-sm text-muted-foreground'>
-                            No channels found for &quot;{mentionSearchQuery}&quot;
+                            {mentionEmptyText} for &quot;{mentionSearchQuery}&quot;
                           </Command.Empty>
                         )}
                       </>
                     )}
-
-                    {/* 'in:@' trigger - Show DMs only (NOT Users!) */}
-                    {channelTrigger === 'in:@' && availableDMs.length > 0 && (
-                      <CommandSection heading='DMs'>
-                        {availableDMs.map(({ channel, displayName }, index) => (
-                          <ChannelRow
-                            key={channel.id}
-                            value={`mention-dm-${channel.id}`}
-                            label={displayName}
-                            channel={channel}
-                            isActive={index === selectedMentionIndex}
-                            onMouseEnter={() => selectMention(index)}
-                            onSelect={() => {
-                              void handleMentionSelect({
-                                id: channel.id,
-                                name: displayName,
-                                type: ChipType.CHANNEL,
-                              });
-                            }}
-                          />
-                        ))}
-                      </CommandSection>
-                    )}
-                    {channelTrigger === 'in:@' &&
-                      availableDMs.length === 0 &&
-                      mentionSearchQuery && (
-                        <Command.Empty className='py-6 text-center text-sm text-muted-foreground'>
-                          No DMs found for &quot;{mentionSearchQuery}&quot;
-                        </Command.Empty>
-                      )}
-
-                    {/* '#' trigger - Show only Channels (Slack-style quick switcher) */}
-                    {channelTrigger === '#' && availableChannels.length > 0 && (
-                      <CommandSection heading='Channels'>
-                        {availableChannels.map(({ channel, displayName }, index) => (
-                          <ChannelRow
-                            key={channel.id}
-                            value={`mention-channel-${channel.id}`}
-                            label={displayName}
-                            channel={channel}
-                            isActive={index === selectedMentionIndex}
-                            onMouseEnter={() => selectMention(index)}
-                            onSelect={() => {
-                              void handleMentionSelect({
-                                id: channel.id,
-                                name: displayName,
-                                type: ChipType.CHANNEL,
-                              });
-                            }}
-                          />
-                        ))}
-                      </CommandSection>
-                    )}
-                    {channelTrigger === '#' &&
-                      availableChannels.length === 0 &&
-                      mentionSearchQuery && (
-                        <Command.Empty className='py-6 text-center text-sm text-muted-foreground'>
-                          No channels found for &quot;{mentionSearchQuery}&quot;
-                        </Command.Empty>
-                      )}
-
-                    {/* Regular USER mention search (@, from:, with:, assignee:) - Show only Users */}
-                    {mentionSearchType === ChipType.USER &&
-                      (userTrigger === '@' ||
-                        userTrigger === 'from:' ||
-                        userTrigger === 'to:' ||
-                        userTrigger === 'with:' ||
-                        userTrigger === 'assignee:') &&
-                      availableUsers.length > 0 && (
-                        <CommandSection heading='Users'>
-                          {availableUsers.map((user, index) => (
-                            <UserRow
-                              key={user.id}
-                              user={user}
-                              value={`mention-user-${user.id}`}
-                              isActive={index === selectedMentionIndex}
-                              onMouseEnter={() => selectMention(index)}
-                              badgeCount={dmUnreadCountForUser(user.id)}
-                              onSelect={() => {
-                                void handleMentionSelect({
-                                  id: user.id,
-                                  name: getUserDisplayName(user),
-                                  type: ChipType.USER,
-                                  ...(user.email ? { email: user.email } : {}),
-                                });
-                              }}
-                            />
-                          ))}
-                        </CommandSection>
-                      )}
-                    {mentionSearchType === ChipType.USER &&
-                      (userTrigger === '@' ||
-                        userTrigger === 'from:' ||
-                        userTrigger === 'to:' ||
-                        userTrigger === 'with:' ||
-                        userTrigger === 'assignee:') &&
-                      availableUsers.length === 0 &&
-                      mentionSearchQuery && (
-                        <Command.Empty className='py-6 text-center text-sm text-muted-foreground'>
-                          No users found for &quot;{mentionSearchQuery}&quot;
-                        </Command.Empty>
-                      )}
 
                     {/* 'priority:' trigger — the closed TicketPriority value list */}
                     {mentionSearchType === ChipType.BOARD && availableBoards.length > 0 && (

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -100,7 +100,8 @@ import { CallConfirmationModal } from '../../Call/CallConfirmationModal';
 import { ActionModal } from '../../Call/ActionModal';
 import { cn } from '../../../utils/classNames';
 import SearchResultItem from './SearchResultItem';
-import { getUserDisplayName, isUserDeactivated } from '../../../utils/userDisplayName';
+import { ChannelRow, UserRow, CommandSection } from './CommandRows';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
 import { LexicalSearchInput, type InitialQueryData } from './LexicalSearchInput';
 import { StatusIndicator } from '../../ui/StatusIndicator';
 import { useSearchMetrics, CMDK_USER_LIMIT } from '../../../hooks/useSearchMetrics';
@@ -576,17 +577,28 @@ const ChannelCommandMenu = ({
   // used by the empty-state DIRECT MESSAGES section). `rankUsers` uses this
   // both as a "frequent contact" signal AND as a tie-breaker so the `from:`
   // typeahead's empty state mirrors the plain-search DM ordering.
-  const dmContactRecency = useMemo(() => {
-    const map = new Map<string, number>();
+  // dmContactRecency (peer user id → recency rank) and dmChannelIdByUserId (peer user id → their
+  // 1:1 DM channel id, so a person row can read that DM's unread count for its badge). First 1:1 DM
+  // per peer wins — the same earliest-in-directMessages order used for the recency rank.
+  const { dmContactRecency, dmChannelIdByUserId } = useMemo(() => {
+    const recency = new Map<string, number>();
+    const channelByUser = new Map<string, string>();
     directMessages.forEach(channel => {
-      if (isOneToOneDMChannel(channel.scopeType)) {
-        const participants = parseDMParticipantIds(channel);
-        const otherUserId = participants.find(id => id !== currentUserID);
-        if (otherUserId && !map.has(otherUserId)) map.set(otherUserId, map.size);
-      }
+      if (!isOneToOneDMChannel(channel.scopeType)) return;
+      const otherUserId = parseDMParticipantIds(channel).find(id => id !== currentUserID);
+      if (!otherUserId || recency.has(otherUserId)) return;
+      recency.set(otherUserId, recency.size);
+      channelByUser.set(otherUserId, channel.id);
     });
-    return map;
+    return { dmContactRecency: recency, dmChannelIdByUserId: channelByUser };
   }, [directMessages, currentUserID]);
+
+  // A person row's unread badge: the count on their 1:1 DM only (group DMs are not counted), or 0
+  // when there's no 1:1 DM / nothing unread.
+  const dmUnreadCountForUser = (userId: string): number => {
+    const dmChannelId = dmChannelIdByUserId.get(userId);
+    return dmChannelId ? (unreadCounts[dmChannelId] ?? 0) : 0;
+  };
 
   // Resolved enabled tabs — computed early so useEffects below can reference it
   const activeEnabledTabs = enabledTabs ?? DEFAULT_ENABLED_TABS;
@@ -2614,30 +2626,27 @@ const ChannelCommandMenu = ({
     <>
       {isFlatAllView
         ? flatAllBackendResults.length > 0 && (
-            <div className='mb-4'>
-              <Command.Group
-                heading={`${getGroupLabel('others')} (${flatAllBackendResults.length})`}
-                className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono'
-              >
-                {flatAllBackendResults.map((result, index) => (
-                  <SearchResultItem
-                    key={`${result.type}-${result.id}`}
-                    result={result}
-                    channelDisplayName={getResultChannelLabel(result)}
-                    channelTag={getResultChannelTag(result)}
-                    onSelect={res => handleBackendResultSelect(res, index + 1)}
-                    onPreview={handleFilePreview}
-                    onItemMouseDown={handleItemMouseDown}
-                    onItemMouseEnter={handleTicketMouseEnter}
-                    onItemMouseLeave={handleTicketMouseLeave}
-                    isSelected={contextItems.some(c => c.id === `${result.type}-${result.id}`)}
-                    mergeMode={deskMergeMode && !!getDeskTicketId(result)}
-                    isMergeSelected={selectedMergeTickets.has(result.searchContext?.ticketId || '')}
-                    onToggleSelect={handleToggleDeskMergeSelect}
-                  />
-                ))}
-              </Command.Group>
-            </div>
+            <CommandSection
+              heading={`${getGroupLabel('others')} (${flatAllBackendResults.length})`}
+            >
+              {flatAllBackendResults.map((result, index) => (
+                <SearchResultItem
+                  key={`${result.type}-${result.id}`}
+                  result={result}
+                  channelDisplayName={getResultChannelLabel(result)}
+                  channelTag={getResultChannelTag(result)}
+                  onSelect={res => handleBackendResultSelect(res, index + 1)}
+                  onPreview={handleFilePreview}
+                  onItemMouseDown={handleItemMouseDown}
+                  onItemMouseEnter={handleTicketMouseEnter}
+                  onItemMouseLeave={handleTicketMouseLeave}
+                  isSelected={contextItems.some(c => c.id === `${result.type}-${result.id}`)}
+                  mergeMode={deskMergeMode && !!getDeskTicketId(result)}
+                  isMergeSelected={selectedMergeTickets.has(result.searchContext?.ticketId || '')}
+                  onToggleSelect={handleToggleDeskMergeSelect}
+                />
+              ))}
+            </CommandSection>
           )
         : ['conversation', 'ticket', 'attachment', 'canvas', 'transcript', 'recording', 'desk']
             .filter(groupKey => backendGroupBelongsToTab(groupKey, activeTab))
@@ -2665,47 +2674,45 @@ const ChannelCommandMenu = ({
               const showSeeMore = !!sectionTab && (!isScreenAll || hiddenCount > 0);
 
               return (
-                <div key={groupKey} className='mb-4'>
-                  <Command.Group
-                    heading={
-                      isScreenAll
-                        ? getGroupLabel(groupKey)
-                        : `${getGroupLabel(groupKey)} (${displayCount})`
-                    }
-                    className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono'
-                  >
-                    {displayItems.map((result, index) => (
-                      <SearchResultItem
-                        key={result.id}
-                        result={result}
-                        channelDisplayName={getResultChannelLabel(result)}
-                        channelTag={getResultChannelTag(result)}
-                        onSelect={res => handleBackendResultSelect(res, index + 1)}
-                        onPreview={handleFilePreview}
-                        onItemMouseDown={handleItemMouseDown}
-                        onItemMouseEnter={handleTicketMouseEnter}
-                        onItemMouseLeave={handleTicketMouseLeave}
-                        isSelected={contextItems.some(c => c.id === `${result.type}-${result.id}`)}
-                        mergeMode={deskMergeMode && !!getDeskTicketId(result)}
-                        isMergeSelected={selectedMergeTickets.has(
-                          result.searchContext?.ticketId || '',
-                        )}
-                        onToggleSelect={handleToggleDeskMergeSelect}
-                      />
-                    ))}
-                    {showSeeMore && sectionTab && (
-                      <SeeMoreItem
-                        value={`__see-more-backend-${groupKey}__`}
-                        label={hiddenCount > 0 ? `See ${hiddenCount} more` : 'See more'}
-                        onSelect={() => handleSeeMoreNavigate(sectionTab)}
-                        hoverable={!isMobile}
-                        trackCategory='SEARCH'
-                        trackName='SEE_MORE_SECTION'
-                        trackMetadata={JSON.stringify({ tab: sectionTab })}
-                      />
-                    )}
-                  </Command.Group>
-                </div>
+                <CommandSection
+                  key={groupKey}
+                  heading={
+                    isScreenAll
+                      ? getGroupLabel(groupKey)
+                      : `${getGroupLabel(groupKey)} (${displayCount})`
+                  }
+                >
+                  {displayItems.map((result, index) => (
+                    <SearchResultItem
+                      key={result.id}
+                      result={result}
+                      channelDisplayName={getResultChannelLabel(result)}
+                      channelTag={getResultChannelTag(result)}
+                      onSelect={res => handleBackendResultSelect(res, index + 1)}
+                      onPreview={handleFilePreview}
+                      onItemMouseDown={handleItemMouseDown}
+                      onItemMouseEnter={handleTicketMouseEnter}
+                      onItemMouseLeave={handleTicketMouseLeave}
+                      isSelected={contextItems.some(c => c.id === `${result.type}-${result.id}`)}
+                      mergeMode={deskMergeMode && !!getDeskTicketId(result)}
+                      isMergeSelected={selectedMergeTickets.has(
+                        result.searchContext?.ticketId || '',
+                      )}
+                      onToggleSelect={handleToggleDeskMergeSelect}
+                    />
+                  ))}
+                  {showSeeMore && sectionTab && (
+                    <SeeMoreItem
+                      value={`__see-more-backend-${groupKey}__`}
+                      label={hiddenCount > 0 ? `See ${hiddenCount} more` : 'See more'}
+                      onSelect={() => handleSeeMoreNavigate(sectionTab)}
+                      hoverable={!isMobile}
+                      trackCategory='SEARCH'
+                      trackName='SEE_MORE_SECTION'
+                      trackMetadata={JSON.stringify({ tab: sectionTab })}
+                    />
+                  )}
+                </CommandSection>
               );
             })}
 
@@ -2756,53 +2763,48 @@ const ChannelCommandMenu = ({
           const sectionTab = GROUP_KEY_TO_DOC_TYPE[type];
 
           return (
-            <div key={type} className='mb-4'>
-              <Command.Group
-                heading={`${getGroupLabel(type)} (${displayCount})`}
-                className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono'
-              >
-                {displayItems.map((result, index) => (
-                  <SearchResultItem
-                    key={result.id}
-                    result={result}
-                    channelDisplayName={getResultChannelLabel(result)}
-                    channelTag={getResultChannelTag(result)}
-                    onSelect={res => handleBackendResultSelect(res, index + 1)}
-                    onPreview={handleFilePreview}
-                    onItemMouseDown={handleItemMouseDown}
-                    onItemMouseEnter={handleTicketMouseEnter}
-                    onItemMouseLeave={handleTicketMouseLeave}
-                    isSelected={contextItems.some(c => c.id === `${result.type}-${result.id}`)}
-                  />
-                ))}
-                {isUserType && hasMore && (
-                  <SeeMoreItem
-                    value={`__see-more-default-${type}__`}
-                    label={isExpanded ? 'See less' : `See ${hiddenCount} more`}
-                    onSelect={() => toggleCategoryExpansion(type)}
-                    hoverable={!isMobile}
-                    trackCategory='CHANNEL_SEARCH'
-                    trackName='TOGGLE_BACKEND_USER_EXPANSION'
-                    trackMetadata={JSON.stringify({ type, isExpanded })}
-                  />
-                )}
-                {/* Same routing link the search branch offers. This renderer runs when
+            <CommandSection key={type} heading={`${getGroupLabel(type)} (${displayCount})`}>
+              {displayItems.map((result, index) => (
+                <SearchResultItem
+                  key={result.id}
+                  result={result}
+                  channelDisplayName={getResultChannelLabel(result)}
+                  channelTag={getResultChannelTag(result)}
+                  onSelect={res => handleBackendResultSelect(res, index + 1)}
+                  onPreview={handleFilePreview}
+                  onItemMouseDown={handleItemMouseDown}
+                  onItemMouseEnter={handleTicketMouseEnter}
+                  onItemMouseLeave={handleTicketMouseLeave}
+                  isSelected={contextItems.some(c => c.id === `${result.type}-${result.id}`)}
+                />
+              ))}
+              {isUserType && hasMore && (
+                <SeeMoreItem
+                  value={`__see-more-default-${type}__`}
+                  label={isExpanded ? 'See less' : `See ${hiddenCount} more`}
+                  onSelect={() => toggleCategoryExpansion(type)}
+                  hoverable={!isMobile}
+                  trackCategory='CHANNEL_SEARCH'
+                  trackName='TOGGLE_BACKEND_USER_EXPANSION'
+                  trackMetadata={JSON.stringify({ type, isExpanded })}
+                />
+              )}
+              {/* Same routing link the search branch offers. This renderer runs when
                     a filter chip is applied with no free-text query (`from:`,
                     `assignee:`), so it needs the way out to the full results page too.
                     Users are excluded — their row above expands in place instead. */}
-                {!isUserType && sectionTab && (
-                  <SeeMoreItem
-                    value={`__see-more-default-route-${type}__`}
-                    label='See more'
-                    onSelect={() => handleSeeMoreNavigate(sectionTab)}
-                    hoverable={!isMobile}
-                    trackCategory='SEARCH'
-                    trackName='SEE_MORE_SECTION'
-                    trackMetadata={JSON.stringify({ tab: sectionTab })}
-                  />
-                )}
-              </Command.Group>
-            </div>
+              {!isUserType && sectionTab && (
+                <SeeMoreItem
+                  value={`__see-more-default-route-${type}__`}
+                  label='See more'
+                  onSelect={() => handleSeeMoreNavigate(sectionTab)}
+                  hoverable={!isMobile}
+                  trackCategory='SEARCH'
+                  trackName='SEE_MORE_SECTION'
+                  trackMetadata={JSON.stringify({ tab: sectionTab })}
+                />
+              )}
+            </CommandSection>
           );
         })}
 
@@ -2825,9 +2827,8 @@ const ChannelCommandMenu = ({
   const renderSearchUsersSection = () =>
     (activeTab === TabType.ALL || activeTab === TabType.USERS) &&
     showGroupedUsers &&
-    filteredLocalUsers.length > 0 ? (
-      <div className='mb-4'>
-        {(() => {
+    filteredLocalUsers.length > 0
+      ? (() => {
           // Use the shared, hoisted Cmd+K user rank, then map to DisplaySearchResult.
           const allItems: DisplaySearchResult[] = rankedLocalUsers.map(user => ({
             id: user.id,
@@ -2852,10 +2853,7 @@ const ChannelCommandMenu = ({
           const hiddenCount = totalItemsCount - DISPLAY_LIMIT;
 
           return (
-            <Command.Group
-              heading={`${getGroupLabel('user')} (${displayCount})`}
-              className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono'
-            >
+            <CommandSection heading={`${getGroupLabel('user')} (${displayCount})`}>
               {displayItems.map((item, index) => (
                 <SearchResultItem
                   key={item.id}
@@ -2878,11 +2876,10 @@ const ChannelCommandMenu = ({
                   trackMetadata={JSON.stringify({ category: 'user', isExpanded })}
                 />
               )}
-            </Command.Group>
+            </CommandSection>
           );
-        })()}
-      </div>
-    ) : null;
+        })()
+      : null;
 
   // Render the plain-search CHANNELS section. Extracted (like
   // renderSearchUsersSection) so it can be rendered above the "Show results
@@ -2891,9 +2888,8 @@ const ChannelCommandMenu = ({
     (activeTab === TabType.ALL || activeTab === TabType.CHANNELS) &&
     showGroupedLocalResults &&
     groupedChannels['channels'] &&
-    groupedChannels['channels'].length > 0 ? (
-      <div className='mb-4'>
-        {(() => {
+    groupedChannels['channels'].length > 0
+      ? (() => {
           const items = groupedChannels['channels'];
           const category = ChannelCategory.CHANNELS;
           const isExpanded = expandedCategories.has(category);
@@ -2903,10 +2899,7 @@ const ChannelCommandMenu = ({
           const hiddenCount = items.length - DISPLAY_LIMIT;
 
           return (
-            <Command.Group
-              heading={getCategoryLabel(category)}
-              className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono'
-            >
+            <CommandSection heading={getCategoryLabel(category)}>
               {displayItems.map(({ channel }, index) => {
                 const unreadCount = unreadCounts[channel.id] ?? 0;
                 return (
@@ -2941,11 +2934,10 @@ const ChannelCommandMenu = ({
                   trackMetadata={JSON.stringify({ category: category as string, isExpanded })}
                 />
               )}
-            </Command.Group>
+            </CommandSection>
           );
-        })()}
-      </div>
-    ) : null;
+        })()
+      : null;
 
   // Render the plain-search STARRED section. Extracted (like
   // renderSearchUsersSection / renderSearchChannelsSection) so it can be pinned
@@ -2954,9 +2946,8 @@ const ChannelCommandMenu = ({
     (activeTab === TabType.ALL || activeTab === TabType.CHANNELS) &&
     showGroupedLocalResults &&
     groupedChannels['starred'] &&
-    groupedChannels['starred'].length > 0 ? (
-      <div className='mb-4'>
-        {(() => {
+    groupedChannels['starred'].length > 0
+      ? (() => {
           const items = groupedChannels['starred'];
           const category = ChannelCategory.STARRED;
           const isExpanded = expandedCategories.has(category);
@@ -2966,10 +2957,7 @@ const ChannelCommandMenu = ({
           const hiddenCount = items.length - DISPLAY_LIMIT;
 
           return (
-            <Command.Group
-              heading={getCategoryLabel(category)}
-              className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono'
-            >
+            <CommandSection heading={getCategoryLabel(category)}>
               {displayItems.map(({ channel }, index) => {
                 const unreadCount = unreadCounts[channel.id] ?? 0;
                 return (
@@ -3004,11 +2992,10 @@ const ChannelCommandMenu = ({
                   trackMetadata={JSON.stringify({ category: category as string, isExpanded })}
                 />
               )}
-            </Command.Group>
+            </CommandSection>
           );
-        })()}
-      </div>
-    ) : null;
+        })()
+      : null;
 
   // Render the local sections (Starred, Users, Group DMs, Channels) for the search branch.
   // Each `include*` flag is false when that section is pinned to the top of the
@@ -3042,47 +3029,42 @@ const ChannelCommandMenu = ({
             !isExpanded && hasMore ? localGroupDMs.slice(0, DISPLAY_LIMIT) : localGroupDMs;
           const hiddenCount = localGroupDMs.length - DISPLAY_LIMIT;
           return (
-            <div className='mb-4'>
-              <Command.Group
-                heading={getCategoryLabel(category)}
-                className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono'
-              >
-                {displayItems.map(({ channel }, index) => {
-                  const unreadCount = unreadCounts[channel.id] ?? 0;
-                  return (
-                    <ChannelCommandItem
-                      key={channel.id}
-                      channel={channel}
-                      currentUserID={currentUserID}
-                      unreadCount={unreadCount}
-                      onSelect={displayName => {
-                        void handleChannelSelect(channel, displayName, index + 1);
-                      }}
-                      onItemMouseDown={handleItemMouseDown}
-                      getChannelIcon={getChannelIcon}
-                      isSelected={contextItems.some(c => c.id === `channel-${channel.id}`)}
-                    />
-                  );
-                })}
-                {hasMore && (
-                  <SeeMoreItem
-                    value={`__see-more-group-dm-${category as string}__`}
-                    label={!routeSeeMore && isExpanded ? 'See less' : `See ${hiddenCount} more`}
-                    onSelect={() =>
-                      routeSeeMore
-                        ? handleSeeMoreNavigate('channels')
-                        : toggleCategoryExpansion(category)
-                    }
-                    hoverable={!isMobile}
-                    trackCategory={routeSeeMore ? 'SEARCH' : 'CHANNEL_SEARCH'}
-                    trackName={
-                      routeSeeMore ? 'SEE_MORE_SECTION' : 'TOGGLE_GROUP_DM_CATEGORY_EXPANSION'
-                    }
-                    trackMetadata={JSON.stringify({ category: category as string, isExpanded })}
+            <CommandSection heading={getCategoryLabel(category)}>
+              {displayItems.map(({ channel }, index) => {
+                const unreadCount = unreadCounts[channel.id] ?? 0;
+                return (
+                  <ChannelCommandItem
+                    key={channel.id}
+                    channel={channel}
+                    currentUserID={currentUserID}
+                    unreadCount={unreadCount}
+                    onSelect={displayName => {
+                      void handleChannelSelect(channel, displayName, index + 1);
+                    }}
+                    onItemMouseDown={handleItemMouseDown}
+                    getChannelIcon={getChannelIcon}
+                    isSelected={contextItems.some(c => c.id === `channel-${channel.id}`)}
                   />
-                )}
-              </Command.Group>
-            </div>
+                );
+              })}
+              {hasMore && (
+                <SeeMoreItem
+                  value={`__see-more-group-dm-${category as string}__`}
+                  label={!routeSeeMore && isExpanded ? 'See less' : `See ${hiddenCount} more`}
+                  onSelect={() =>
+                    routeSeeMore
+                      ? handleSeeMoreNavigate('channels')
+                      : toggleCategoryExpansion(category)
+                  }
+                  hoverable={!isMobile}
+                  trackCategory={routeSeeMore ? 'SEARCH' : 'CHANNEL_SEARCH'}
+                  trackName={
+                    routeSeeMore ? 'SEE_MORE_SECTION' : 'TOGGLE_GROUP_DM_CATEGORY_EXPANSION'
+                  }
+                  trackMetadata={JSON.stringify({ category: category as string, isExpanded })}
+                />
+              )}
+            </CommandSection>
           );
         })()}
 
@@ -3108,41 +3090,36 @@ const ChannelCommandMenu = ({
               const hiddenCount = items.length - DISPLAY_LIMIT;
 
               return (
-                <div key={category} className='mb-4'>
-                  <Command.Group
-                    heading={getCategoryLabel(typedCategory)}
-                    className='[&_[cmdk-group-heading]]:px-2  [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-["Geist_Mono"]'
-                  >
-                    {displayItems.map(({ channel }, index) => {
-                      const unreadCount = unreadCounts[channel.id] ?? 0;
-                      return (
-                        <ChannelCommandItem
-                          key={channel.id}
-                          channel={channel}
-                          currentUserID={currentUserID}
-                          unreadCount={unreadCount}
-                          onSelect={displayName => {
-                            void handleChannelSelect(channel, displayName, index + 1);
-                          }}
-                          onItemMouseDown={handleItemMouseDown}
-                          getChannelIcon={getChannelIcon}
-                          isSelected={contextItems.some(c => c.id === `channel-${channel.id}`)}
-                        />
-                      );
-                    })}
-                    {shouldLimit && hasMore && (
-                      <SeeMoreItem
-                        value={`__see-more-browse-${category}__`}
-                        label={isExpanded ? 'See less' : `See ${hiddenCount} more`}
-                        onSelect={() => toggleCategoryExpansion(category)}
-                        hoverable={!isMobile}
-                        trackCategory='CHANNEL_SEARCH'
-                        trackName='TOGGLE_LOCAL_CHANNEL_EXPANSION'
-                        trackMetadata={JSON.stringify({ category, isExpanded })}
+                <CommandSection key={category} heading={getCategoryLabel(typedCategory)}>
+                  {displayItems.map(({ channel }, index) => {
+                    const unreadCount = unreadCounts[channel.id] ?? 0;
+                    return (
+                      <ChannelCommandItem
+                        key={channel.id}
+                        channel={channel}
+                        currentUserID={currentUserID}
+                        unreadCount={unreadCount}
+                        onSelect={displayName => {
+                          void handleChannelSelect(channel, displayName, index + 1);
+                        }}
+                        onItemMouseDown={handleItemMouseDown}
+                        getChannelIcon={getChannelIcon}
+                        isSelected={contextItems.some(c => c.id === `channel-${channel.id}`)}
                       />
-                    )}
-                  </Command.Group>
-                </div>
+                    );
+                  })}
+                  {shouldLimit && hasMore && (
+                    <SeeMoreItem
+                      value={`__see-more-browse-${category}__`}
+                      label={isExpanded ? 'See less' : `See ${hiddenCount} more`}
+                      onSelect={() => toggleCategoryExpansion(category)}
+                      hoverable={!isMobile}
+                      trackCategory='CHANNEL_SEARCH'
+                      trackName='TOGGLE_LOCAL_CHANNEL_EXPANSION'
+                      trackMetadata={JSON.stringify({ category, isExpanded })}
+                    />
+                  )}
+                </CommandSection>
               );
             })}
           </>
@@ -4123,57 +4100,40 @@ const ChannelCommandMenu = ({
                       <>
                         {/* 1. Channels Section */}
                         {availableRegularChannels.length > 0 && (
-                          <Command.Group
-                            heading='Channels'
-                            className='[&_[cmdk-group-heading]]:px-2  [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-["Geist_Mono"]'
-                          >
-                            {availableRegularChannels.map(({ channel, displayName }, index) => {
-                              return (
-                                <Command.Item
-                                  key={channel.id}
-                                  value={`mention-channel-${channel.id}`}
-                                  onSelect={() => {
-                                    void handleMentionSelect({
-                                      id: channel.id,
-                                      name: displayName,
-                                      type: ChipType.CHANNEL,
-                                    });
-                                  }}
-                                  onMouseEnter={() => {
-                                    selectMention(index);
-                                  }}
-                                  className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-all duration-150 mt-1.5 ${
-                                    index === selectedMentionIndex ? 'cmdk-active-row' : ''
-                                  } ${!isMobile && 'active:bg-muted active:scale-[0.98]'}`}
-                                  style={{ WebkitTapHighlightColor: 'transparent' }}
-                                >
-                                  <div className='flex items-center justify-center h-4 w-5 flex-shrink-0 text-muted-foreground'>
-                                    {getChannelIcon(channel)}
-                                  </div>
-                                  <div className='flex-1 min-w-0'>
-                                    <div className='text-[15px] leading-[1.2] tracking-[-0.1px] text-foreground truncate'>
-                                      {displayName}
-                                    </div>
-                                  </div>
-                                </Command.Item>
-                              );
-                            })}
-                          </Command.Group>
+                          <CommandSection heading='Channels'>
+                            {availableRegularChannels.map(({ channel, displayName }, index) => (
+                              <ChannelRow
+                                key={channel.id}
+                                value={`mention-channel-${channel.id}`}
+                                label={displayName}
+                                channel={channel}
+                                isActive={index === selectedMentionIndex}
+                                onMouseEnter={() => selectMention(index)}
+                                onSelect={() => {
+                                  void handleMentionSelect({
+                                    id: channel.id,
+                                    name: displayName,
+                                    type: ChipType.CHANNEL,
+                                  });
+                                }}
+                              />
+                            ))}
+                          </CommandSection>
                         )}
                         {/* 2. DMs Section (includes Group DMs) */}
                         {availableDMs.length > 0 && (
-                          <Command.Group
-                            heading='DMs'
-                            className='[&_[cmdk-group-heading]]:px-2  [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-["Geist_Mono"]'
-                          >
+                          <CommandSection heading='DMs'>
                             {availableDMs.map(({ channel, displayName }, index) => {
-                              // Calculate index offset for keyboard navigation
-                              const channelCount = availableRegularChannels.length;
-                              const adjustedIndex = channelCount + index;
+                              // DMs render after channels in one list, so offset the highlight index.
+                              const adjustedIndex = availableRegularChannels.length + index;
                               return (
-                                <Command.Item
+                                <ChannelRow
                                   key={channel.id}
                                   value={`mention-dm-${channel.id}`}
+                                  label={displayName}
+                                  channel={channel}
+                                  isActive={adjustedIndex === selectedMentionIndex}
+                                  onMouseEnter={() => selectMention(adjustedIndex)}
                                   onSelect={() => {
                                     void handleMentionSelect({
                                       id: channel.id,
@@ -4181,26 +4141,10 @@ const ChannelCommandMenu = ({
                                       type: ChipType.CHANNEL,
                                     });
                                   }}
-                                  onMouseEnter={() => {
-                                    selectMention(adjustedIndex);
-                                  }}
-                                  className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-all duration-150 mt-1.5 ${
-                                    adjustedIndex === selectedMentionIndex ? 'cmdk-active-row' : ''
-                                  } ${!isMobile && 'active:bg-muted active:scale-[0.98]'}`}
-                                  style={{ WebkitTapHighlightColor: 'transparent' }}
-                                >
-                                  <div className='flex items-center justify-center h-4 w-5 flex-shrink-0 text-muted-foreground'>
-                                    {getChannelIcon(channel)}
-                                  </div>
-                                  <div className='flex-1 min-w-0'>
-                                    <div className='text-[15px] leading-[1.2] tracking-[-0.1px] text-foreground truncate'>
-                                      {displayName}
-                                    </div>
-                                  </div>
-                                </Command.Item>
+                                />
                               );
                             })}
-                          </Command.Group>
+                          </CommandSection>
                         )}
                         {/* Empty state for in: when nothing matches */}
                         {availableRegularChannels.length === 0 &&
@@ -4218,54 +4162,26 @@ const ChannelCommandMenu = ({
                             userTrigger === 'to:' ||
                             userTrigger === 'assignee:') &&
                           availableUsers.length > 0 && (
-                            <Command.Group
-                              heading='Users'
-                              className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono'
-                            >
-                              {availableUsers.map((user, index) => {
-                                const isDeactivated = isUserDeactivated(user);
-                                return (
-                                  <Command.Item
-                                    key={user.id}
-                                    value={`mention-user-${user.id}`}
-                                    onSelect={() => {
-                                      void handleMentionSelect({
-                                        id: user.id,
-                                        name: getUserDisplayName(user),
-                                        type: ChipType.USER,
-                                        ...(user.email ? { email: user.email } : {}),
-                                      });
-                                    }}
-                                    onMouseEnter={() => {
-                                      selectMention(index);
-                                    }}
-                                    className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-all duration-150 mt-1.5 ${
-                                      index === selectedMentionIndex ? 'cmdk-active-row' : ''
-                                    } ${!isMobile && 'active:bg-muted active:scale-[0.98]'}`}
-                                    style={{ WebkitTapHighlightColor: 'transparent' }}
-                                  >
-                                    <Avatar userId={user.id} size='xs' />
-                                    <div className='flex-1 min-w-0 flex items-center gap-2'>
-                                      <span
-                                        className={`min-w-0 truncate text-[15px] leading-[1.2] tracking-[-0.1px] ${isDeactivated ? 'text-muted-foreground' : 'text-foreground'}`}
-                                      >
-                                        {getUserDisplayName(user)}
-                                      </span>
-                                      {isDeactivated && (
-                                        <span className='shrink-0 text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded'>
-                                          Deactivated
-                                        </span>
-                                      )}
-                                      {user.email && (
-                                        <span className='min-w-0 truncate text-xs text-muted-foreground'>
-                                          {user.email}
-                                        </span>
-                                      )}
-                                    </div>
-                                  </Command.Item>
-                                );
-                              })}
-                            </Command.Group>
+                            <CommandSection heading='Users'>
+                              {availableUsers.map((user, index) => (
+                                <UserRow
+                                  key={user.id}
+                                  user={user}
+                                  value={`mention-user-${user.id}`}
+                                  isActive={index === selectedMentionIndex}
+                                  onMouseEnter={() => selectMention(index)}
+                                  badgeCount={dmUnreadCountForUser(user.id)}
+                                  onSelect={() => {
+                                    void handleMentionSelect({
+                                      id: user.id,
+                                      name: getUserDisplayName(user),
+                                      type: ChipType.USER,
+                                      ...(user.email ? { email: user.email } : {}),
+                                    });
+                                  }}
+                                />
+                              ))}
+                            </CommandSection>
                           )}
                         {mentionSearchType === ChipType.USER &&
                           (userTrigger === '@' ||
@@ -4286,42 +4202,25 @@ const ChannelCommandMenu = ({
                       <>
                         {/* Channels Section */}
                         {availableRegularChannels.length > 0 && (
-                          <Command.Group
-                            heading='Channels'
-                            className='[&_[cmdk-group-heading]]:px-2  [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-["Geist_Mono"]'
-                          >
-                            {availableRegularChannels.map(({ channel, displayName }, index) => {
-                              return (
-                                <Command.Item
-                                  key={channel.id}
-                                  value={`mention-channel-${channel.id}`}
-                                  onSelect={() => {
-                                    void handleMentionSelect({
-                                      id: channel.id,
-                                      name: displayName,
-                                      type: ChipType.CHANNEL,
-                                    });
-                                  }}
-                                  onMouseEnter={() => {
-                                    selectMention(index);
-                                  }}
-                                  className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-all duration-150 mt-1.5 ${
-                                    index === selectedMentionIndex ? 'cmdk-active-row' : ''
-                                  } ${!isMobile && 'active:bg-muted active:scale-[0.98]'}`}
-                                  style={{ WebkitTapHighlightColor: 'transparent' }}
-                                >
-                                  <div className='flex items-center justify-center h-4 w-5 flex-shrink-0 text-muted-foreground'>
-                                    {getChannelIcon(channel)}
-                                  </div>
-                                  <div className='flex-1 min-w-0'>
-                                    <div className='text-[15px] leading-[1.2] tracking-[-0.1px] text-foreground truncate'>
-                                      {displayName}
-                                    </div>
-                                  </div>
-                                </Command.Item>
-                              );
-                            })}
-                          </Command.Group>
+                          <CommandSection heading='Channels'>
+                            {availableRegularChannels.map(({ channel, displayName }, index) => (
+                              <ChannelRow
+                                key={channel.id}
+                                value={`mention-channel-${channel.id}`}
+                                label={displayName}
+                                channel={channel}
+                                isActive={index === selectedMentionIndex}
+                                onMouseEnter={() => selectMention(index)}
+                                onSelect={() => {
+                                  void handleMentionSelect({
+                                    id: channel.id,
+                                    name: displayName,
+                                    type: ChipType.CHANNEL,
+                                  });
+                                }}
+                              />
+                            ))}
+                          </CommandSection>
                         )}
                         {/* Empty state */}
                         {availableRegularChannels.length === 0 && mentionSearchQuery && (
@@ -4334,14 +4233,15 @@ const ChannelCommandMenu = ({
 
                     {/* 'in:@' trigger - Show DMs only (NOT Users!) */}
                     {channelTrigger === 'in:@' && availableDMs.length > 0 && (
-                      <Command.Group
-                        heading='DMs'
-                        className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-["Geist_Mono"]'
-                      >
+                      <CommandSection heading='DMs'>
                         {availableDMs.map(({ channel, displayName }, index) => (
-                          <Command.Item
+                          <ChannelRow
                             key={channel.id}
                             value={`mention-dm-${channel.id}`}
+                            label={displayName}
+                            channel={channel}
+                            isActive={index === selectedMentionIndex}
+                            onMouseEnter={() => selectMention(index)}
                             onSelect={() => {
                               void handleMentionSelect({
                                 id: channel.id,
@@ -4349,25 +4249,9 @@ const ChannelCommandMenu = ({
                                 type: ChipType.CHANNEL,
                               });
                             }}
-                            onMouseEnter={() => {
-                              selectMention(index);
-                            }}
-                            className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-all duration-150 mt-1.5 ${
-                              index === selectedMentionIndex ? 'cmdk-active-row' : ''
-                            } ${!isMobile && 'active:bg-muted active:scale-[0.98]'}`}
-                            style={{ WebkitTapHighlightColor: 'transparent' }}
-                          >
-                            <div className='flex items-center justify-center h-4 w-5 flex-shrink-0 text-muted-foreground'>
-                              {getChannelIcon(channel)}
-                            </div>
-                            <div className='flex-1 min-w-0'>
-                              <div className='text-[15px] leading-[1.2] tracking-[-0.1px] text-foreground truncate'>
-                                {displayName}
-                              </div>
-                            </div>
-                          </Command.Item>
+                          />
                         ))}
-                      </Command.Group>
+                      </CommandSection>
                     )}
                     {channelTrigger === 'in:@' &&
                       availableDMs.length === 0 &&
@@ -4379,42 +4263,25 @@ const ChannelCommandMenu = ({
 
                     {/* '#' trigger - Show only Channels (Slack-style quick switcher) */}
                     {channelTrigger === '#' && availableChannels.length > 0 && (
-                      <Command.Group
-                        heading='Channels'
-                        className='[&_[cmdk-group-heading]]:px-2  [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-["Geist_Mono"]'
-                      >
-                        {availableChannels.map(({ channel, displayName }, index) => {
-                          return (
-                            <Command.Item
-                              key={channel.id}
-                              value={`mention-channel-${channel.id}`}
-                              onSelect={() => {
-                                void handleMentionSelect({
-                                  id: channel.id,
-                                  name: displayName,
-                                  type: ChipType.CHANNEL,
-                                });
-                              }}
-                              onMouseEnter={() => {
-                                selectMention(index);
-                              }}
-                              className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-all duration-150 mt-1.5 ${
-                                index === selectedMentionIndex ? 'cmdk-active-row' : ''
-                              } ${!isMobile && 'active:bg-muted active:scale-[0.98]'}`}
-                              style={{ WebkitTapHighlightColor: 'transparent' }}
-                            >
-                              <div className='flex items-center justify-center h-4 w-5 flex-shrink-0 text-muted-foreground'>
-                                {getChannelIcon(channel)}
-                              </div>
-                              <div className='flex-1 min-w-0'>
-                                <div className='text-[15px] leading-[1.2] tracking-[-0.1px] text-foreground truncate'>
-                                  {displayName}
-                                </div>
-                              </div>
-                            </Command.Item>
-                          );
-                        })}
-                      </Command.Group>
+                      <CommandSection heading='Channels'>
+                        {availableChannels.map(({ channel, displayName }, index) => (
+                          <ChannelRow
+                            key={channel.id}
+                            value={`mention-channel-${channel.id}`}
+                            label={displayName}
+                            channel={channel}
+                            isActive={index === selectedMentionIndex}
+                            onMouseEnter={() => selectMention(index)}
+                            onSelect={() => {
+                              void handleMentionSelect({
+                                id: channel.id,
+                                name: displayName,
+                                type: ChipType.CHANNEL,
+                              });
+                            }}
+                          />
+                        ))}
+                      </CommandSection>
                     )}
                     {channelTrigger === '#' &&
                       availableChannels.length === 0 &&
@@ -4432,54 +4299,26 @@ const ChannelCommandMenu = ({
                         userTrigger === 'with:' ||
                         userTrigger === 'assignee:') &&
                       availableUsers.length > 0 && (
-                        <Command.Group
-                          heading='Users'
-                          className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono'
-                        >
-                          {availableUsers.map((user, index) => {
-                            const isDeactivated = isUserDeactivated(user);
-                            return (
-                              <Command.Item
-                                key={user.id}
-                                value={`mention-user-${user.id}`}
-                                onSelect={() => {
-                                  void handleMentionSelect({
-                                    id: user.id,
-                                    name: getUserDisplayName(user),
-                                    type: ChipType.USER,
-                                    ...(user.email ? { email: user.email } : {}),
-                                  });
-                                }}
-                                onMouseEnter={() => {
-                                  selectMention(index);
-                                }}
-                                className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-all duration-150 mt-1.5 ${
-                                  index === selectedMentionIndex ? 'cmdk-active-row' : ''
-                                } ${!isMobile && 'active:bg-muted active:scale-[0.98]'}`}
-                                style={{ WebkitTapHighlightColor: 'transparent' }}
-                              >
-                                <Avatar userId={user.id} size='xs' />
-                                <div className='flex-1 min-w-0 flex items-center gap-2'>
-                                  <span
-                                    className={`min-w-0 truncate text-[15px] leading-[1.2] tracking-[-0.1px] ${isDeactivated ? 'text-muted-foreground' : 'text-foreground'}`}
-                                  >
-                                    {getUserDisplayName(user)}
-                                  </span>
-                                  {isDeactivated && (
-                                    <span className='shrink-0 text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded'>
-                                      Deactivated
-                                    </span>
-                                  )}
-                                  {user.email && (
-                                    <span className='min-w-0 truncate text-xs text-muted-foreground'>
-                                      {user.email}
-                                    </span>
-                                  )}
-                                </div>
-                              </Command.Item>
-                            );
-                          })}
-                        </Command.Group>
+                        <CommandSection heading='Users'>
+                          {availableUsers.map((user, index) => (
+                            <UserRow
+                              key={user.id}
+                              user={user}
+                              value={`mention-user-${user.id}`}
+                              isActive={index === selectedMentionIndex}
+                              onMouseEnter={() => selectMention(index)}
+                              badgeCount={dmUnreadCountForUser(user.id)}
+                              onSelect={() => {
+                                void handleMentionSelect({
+                                  id: user.id,
+                                  name: getUserDisplayName(user),
+                                  type: ChipType.USER,
+                                  ...(user.email ? { email: user.email } : {}),
+                                });
+                              }}
+                            />
+                          ))}
+                        </CommandSection>
                       )}
                     {mentionSearchType === ChipType.USER &&
                       (userTrigger === '@' ||
@@ -4496,10 +4335,7 @@ const ChannelCommandMenu = ({
 
                     {/* 'priority:' trigger — the closed TicketPriority value list */}
                     {mentionSearchType === ChipType.BOARD && availableBoards.length > 0 && (
-                      <Command.Group
-                        heading='Board'
-                        className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono'
-                      >
+                      <CommandSection heading='Board'>
                         {availableBoards.map((board, index) => (
                           <Command.Item
                             key={board.id}
@@ -4533,7 +4369,7 @@ const ChannelCommandMenu = ({
                             </div>
                           </Command.Item>
                         ))}
-                      </Command.Group>
+                      </CommandSection>
                     )}
 
                     {/* 'mentions:' — people and channels are two separate lists with their
@@ -4548,11 +4384,7 @@ const ChannelCommandMenu = ({
                           .filter(({ target }) => target.type === group.type);
                         if (rows.length === 0) return null;
                         return (
-                          <Command.Group
-                            key={group.type}
-                            heading={group.heading}
-                            className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono'
-                          >
+                          <CommandSection key={group.type} heading={group.heading}>
                             {rows.map(({ target, index }) => (
                               <Command.Item
                                 key={`${target.type}-${target.id}`}
@@ -4613,15 +4445,12 @@ const ChannelCommandMenu = ({
                                 Show more
                               </button>
                             )}
-                          </Command.Group>
+                          </CommandSection>
                         );
                       })}
 
                     {mentionSearchType === ChipType.DATE && availableDates.length > 0 && (
-                      <Command.Group
-                        heading='Date'
-                        className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono'
-                      >
+                      <CommandSection heading='Date'>
                         {availableDates.map((option, index) => (
                           <Command.Item
                             key={`${option.id}-${option.name}`}
@@ -4654,14 +4483,11 @@ const ChannelCommandMenu = ({
                             )}
                           </Command.Item>
                         ))}
-                      </Command.Group>
+                      </CommandSection>
                     )}
 
                     {mentionSearchType === ChipType.PRIORITY && availablePriorities.length > 0 && (
-                      <Command.Group
-                        heading='Priority'
-                        className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono'
-                      >
+                      <CommandSection heading='Priority'>
                         {availablePriorities.map((priority, index) => (
                           <Command.Item
                             key={priority.id}
@@ -4695,7 +4521,7 @@ const ChannelCommandMenu = ({
                             </div>
                           </Command.Item>
                         ))}
-                      </Command.Group>
+                      </CommandSection>
                     )}
                   </>
                 )}
@@ -4708,10 +4534,7 @@ const ChannelCommandMenu = ({
                     <>
                       {/* Recent items — shown when search box is empty, read directly from localStorage */}
                       {!searchText.trim() && loadRecents(activeTab).length > 0 && (
-                        <Command.Group
-                          heading='Recent'
-                          className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono'
-                        >
+                        <CommandSection heading='Recent'>
                           {loadRecents(activeTab).map(item => {
                             const isChannelTab = activeTab === TabType.CHANNELS;
                             const subApp =
@@ -4777,7 +4600,7 @@ const ChannelCommandMenu = ({
                               </Command.Item>
                             );
                           })}
-                        </Command.Group>
+                        </CommandSection>
                       )}
                     </>
                   )}

--- a/apps/dashboard/src/components/Chat/ChatDirectory/CommandRows.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/CommandRows.tsx
@@ -1,0 +1,295 @@
+import { type ReactElement, type MouseEventHandler, type ReactNode } from 'react';
+import { Command } from 'cmdk';
+import { CheckTickSingle } from '@xyne/icons';
+import type { UserStatus, Channel } from '@xyne/shared';
+import Avatar, { type AvatarSize } from '../../ui/Avatar/Avatar';
+import Badge from '../../ui/Badge';
+import ChannelIcon from '../ChannelIcon/ChannelIcon';
+import { StatusIndicator } from '../../ui/StatusIndicator';
+import { getUserDisplayName, isUserDeactivated } from '../../../utils/userDisplayName';
+import { usePlatform } from '../../../hooks/usePlatform';
+import { cn } from '../../../utils/classNames';
+
+// Minimal user shape a command row reads. Satisfied by the slash palette's `User` rows, the cmd+K
+// mention picker's candidates, and search-result users (incl. synthetic desk contacts where id = email).
+export interface CommandRowUser {
+  id: string;
+  name?: string | null;
+  email?: string | null;
+  displayName?: string | null;
+  status?: UserStatus | string | null;
+}
+
+// Custom/presence status a row forwards to StatusIndicator (search/browse rows only; the
+// indicator self-guards to null when there is no valid status). Kept as data (not a prebuilt
+// element) so the picker can adopt status later without each caller wiring StatusIndicator.
+export interface CommandRowStatus {
+  statusEmoji?: string | null;
+  statusContent?: string | null;
+  statusExpiryAt?: number | null;
+}
+
+// Shared cmdk-row wiring for both row types (required fields first, optional last).
+export interface CommandRowBaseProps {
+  value: string;
+  onSelect: () => void;
+  // Highlight bridge — the one behavioral difference between the two surfaces:
+  //   mention picker: pass `isActive` (+ `onMouseEnter`) so the parent's manual
+  //     `selectedMentionIndex` drives the `cmdk-active-row` highlight.
+  //   slash palette: omit both, and cmdk's own `aria-selected` drives it.
+  isActive?: boolean;
+  onMouseEnter?: () => void;
+  onMouseDownCapture?: MouseEventHandler;
+  dataItemLabel?: string;
+  // Search/browse adornments — passed only by the legacy search-row adapters
+  // (ChannelCommandItem, UserSearchResultItem); picker callers omit them.
+  status?: CommandRowStatus; // renders a StatusIndicator just after the name
+  isSelected?: boolean; // renders the selected check at the row's trailing edge
+  badgeCount?: number; // unread count → success Badge at the trailing edge; hidden when isSelected
+  dataResultId?: string; // load-bearing: cmd+K keyboard-nav / selection / preview read these
+  dataResultType?: string;
+}
+
+export interface UserRowProps extends CommandRowBaseProps {
+  user: CommandRowUser;
+  isCurrentUser?: boolean;
+}
+
+export interface ChannelRowProps extends CommandRowBaseProps {
+  channel: Channel;
+  label: string;
+  avatarSize?: AvatarSize; // DM avatar size (default 'xs'); ContextPicker passes 'sm'
+}
+
+export interface SeeMoreRowProps {
+  value: string;
+  label: string;
+  onSelect: () => void;
+  hoverable: boolean;
+  trackCategory: string;
+  trackName: string;
+  trackMetadata: string;
+}
+
+export interface CommandSectionProps {
+  heading: string;
+  children: ReactNode;
+}
+
+/**
+ * One person row: avatar + name (+ "(you)") + email, with a "Deactivated" badge for INACTIVE
+ * users. Shared by the slash palette, the cmd+K mention picker, and — via UserSearchResultItem —
+ * user search results, which additionally pass `status` (StatusIndicator), `isSelected` (trailing
+ * check) and the `data-result-*` cmd+K nav attributes.
+ */
+export function UserRow(props: UserRowProps): ReactElement {
+  const {
+    user,
+    value,
+    onSelect,
+    isCurrentUser = false,
+    status,
+    isSelected = false,
+    badgeCount,
+    isActive,
+    onMouseEnter,
+    onMouseDownCapture,
+    dataItemLabel,
+    dataResultId,
+    dataResultType,
+  } = props;
+  const { isMobile } = usePlatform();
+  const displayName = getUserDisplayName(user);
+  const isDeactivated = isUserDeactivated(user);
+  const showUnreadBadge = !isSelected && (badgeCount ?? 0) > 0;
+
+  return (
+    <Command.Item
+      value={value}
+      data-item-label={dataItemLabel}
+      {...(dataResultId ? { 'data-result-id': dataResultId } : {})}
+      {...(dataResultType ? { 'data-result-type': dataResultType } : {})}
+      onSelect={onSelect}
+      onMouseEnter={onMouseEnter}
+      onMouseDownCapture={onMouseDownCapture}
+      className={commandRowClassName(isActive, isMobile)}
+      style={{ WebkitTapHighlightColor: 'transparent' }}
+    >
+      <Avatar userId={user.id} size='xs' />
+      <div className='flex-1 min-w-0 flex items-center gap-2'>
+        <span
+          className={`min-w-0 truncate text-[15px] leading-[1.2] tracking-[-0.1px] ${isDeactivated ? 'text-muted-foreground' : 'text-foreground'}`}
+        >
+          {displayName}
+          {isCurrentUser && <span className='text-muted-foreground'> (you)</span>}
+        </span>
+        {!isDeactivated && status && (
+          <StatusIndicator
+            statusEmoji={status.statusEmoji}
+            statusContent={status.statusContent}
+            statusExpiryAt={status.statusExpiryAt}
+            size='sm'
+          />
+        )}
+        {isDeactivated && (
+          <span className='shrink-0 text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded'>
+            Deactivated
+          </span>
+        )}
+        {user.email && (
+          <span className='min-w-0 truncate text-xs text-muted-foreground'>{user.email}</span>
+        )}
+      </div>
+      {isSelected && <SelectedCheck />}
+      {showUnreadBadge && (
+        <Badge variant='success' className='font-mono shrink-0 text-xs px-1.5 py-0'>
+          {badgeCount}
+        </Badge>
+      )}
+    </Command.Item>
+  );
+}
+
+/**
+ * One channel / DM / group-DM row: the channel's glyph in a fixed column + label. The shared
+ * `ChannelIcon` resolves public / private / 1:1-DM / group-DM straight from the channel. Browse
+ * rows (via ChannelCommandItem) additionally pass `status` (a DM peer's presence), `badgeCount`
+ * (unread), `isSelected` (trailing check) and the `data-result-*` cmd+K nav attributes.
+ */
+export function ChannelRow(props: ChannelRowProps): ReactElement {
+  const {
+    channel,
+    label,
+    value,
+    onSelect,
+    avatarSize = 'xs',
+    status,
+    isSelected = false,
+    badgeCount,
+    isActive,
+    onMouseEnter,
+    onMouseDownCapture,
+    dataItemLabel,
+    dataResultId,
+    dataResultType,
+  } = props;
+  const { isMobile } = usePlatform();
+  const showUnreadBadge = !isSelected && (badgeCount ?? 0) > 0;
+
+  return (
+    <Command.Item
+      value={value}
+      data-item-label={dataItemLabel}
+      {...(dataResultId ? { 'data-result-id': dataResultId } : {})}
+      {...(dataResultType ? { 'data-result-type': dataResultType } : {})}
+      onSelect={onSelect}
+      onMouseEnter={onMouseEnter}
+      onMouseDownCapture={onMouseDownCapture}
+      className={commandRowClassName(isActive, isMobile)}
+      style={{ WebkitTapHighlightColor: 'transparent' }}
+    >
+      <div className='flex items-center justify-center h-4 w-5 flex-shrink-0 text-muted-foreground'>
+        <ChannelIcon
+          channel={channel}
+          glyphClassName='text-muted-foreground'
+          avatarSize={avatarSize}
+        />
+      </div>
+      <div className='flex-1 min-w-0 flex items-center gap-1'>
+        <span className='min-w-0 truncate text-[15px] leading-[1.2] tracking-[-0.1px] text-foreground'>
+          {label}
+        </span>
+        {status && (
+          <StatusIndicator
+            statusEmoji={status.statusEmoji}
+            statusContent={status.statusContent}
+            statusExpiryAt={status.statusExpiryAt}
+            size='sm'
+          />
+        )}
+      </div>
+      {isSelected && <SelectedCheck />}
+      {showUnreadBadge && (
+        <Badge variant='success' className='font-mono shrink-0 text-xs px-1.5 py-0'>
+          {badgeCount}
+        </Badge>
+      )}
+    </Command.Item>
+  );
+}
+
+/**
+ * A "See N more" / "See less" affordance for a truncated result group. A cmdk item (not a button)
+ * so arrow keys reach it — but deliberately no `data-item-label`, which would splice the "See N
+ * more" text into the input's ghost preview. Carries `data-track-*` for search metrics.
+ */
+export function SeeMoreRow(props: SeeMoreRowProps): ReactElement {
+  const { value, label, onSelect, hoverable, trackCategory, trackName, trackMetadata } = props;
+  return (
+    <Command.Item
+      value={value}
+      onSelect={onSelect}
+      className={cn(
+        'w-full px-2 py-1.5 mt-1 text-sm text-muted-foreground rounded-lg text-left cursor-pointer transition-colors select-none aria-selected:text-foreground aria-selected:bg-accent',
+        hoverable && 'hover:text-foreground hover:bg-accent',
+      )}
+      style={{ WebkitTapHighlightColor: 'transparent' }}
+      data-track-category={trackCategory}
+      data-track-name={trackName}
+      data-track-metadata={trackMetadata}
+    >
+      {label}
+    </Command.Item>
+  );
+}
+
+/**
+ * A titled cmdk group with the standard uppercase-mono heading and consistent bottom
+ * spacing (mb-4) so consecutive sections never collapse together. Callers gate on
+ * non-empty results, so an empty section is never rendered (no phantom gap).
+ */
+export function CommandSection({ heading, children }: CommandSectionProps): ReactElement {
+  return (
+    <div className='mb-4'>
+      <Command.Group heading={heading} className={COMMAND_SECTION_HEADING_CLASS}>
+        {children}
+      </Command.Group>
+    </div>
+  );
+}
+
+const COMMAND_ROW_BASE_CLASS = 'flex items-center gap-3 p-3 rounded-lg cursor-pointer mt-1.5';
+
+// Standard cmdk group-heading style (uppercase mono muted) shared by every titled section.
+// `font-mono` resolves to Geist Mono via the Tailwind config.
+const COMMAND_SECTION_HEADING_CLASS =
+  '[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono';
+
+/**
+ * Build the row className, bridging the two surfaces' highlight models.
+ * Slash palette (`isActive` undefined): cmdk owns selection → style `aria-selected`.
+ * Mention picker (`isActive` boolean): the parent tracks the active index → mark
+ * `cmdk-active-row`, with desktop-only press feedback.
+ * The mode is picked by whether `isActive` is passed, so slash omits it entirely: passing
+ * `false` there would read as manual-inactive and drop the cmdk `aria-selected` highlight.
+ */
+function commandRowClassName(isActive: boolean | undefined, isMobile: boolean): string {
+  if (isActive === undefined) {
+    return cn(COMMAND_ROW_BASE_CLASS, 'hover:bg-accent aria-selected:bg-accent');
+  }
+  return cn(
+    COMMAND_ROW_BASE_CLASS,
+    'transition-all duration-150',
+    isActive && 'cmdk-active-row',
+    !isMobile && 'active:bg-muted active:scale-[0.98]',
+  );
+}
+
+// Trailing "selected" pill shared by both rows (identical markup in the legacy search rows).
+function SelectedCheck(): ReactElement {
+  return (
+    <span className='flex-shrink-0 flex items-center justify-center w-4 h-4 rounded-full bg-primary text-primary-foreground'>
+      <CheckTickSingle size={10} />
+    </span>
+  );
+}

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
@@ -15,11 +15,10 @@ import {
 import { DisplaySearchResult } from '../../../types/search';
 import { RenderMessageWithHTML } from '../RenderMessageWithHTML/RenderMessageWithHTML';
 import UserAvatar from '../../UserAvatar/UserAvatar';
-import Avatar from '../../ui/Avatar/Avatar';
+import { UserRow } from './CommandRows';
 import { SearchSnippetRenderer } from '../RenderMessageWithHTML/searchSnippetRender';
 import { useUser } from '../../../hooks/useUsers';
-import { isUserDeactivated, getUserDisplayName } from '../../../utils/userDisplayName';
-import { StatusIndicator } from '../../ui/StatusIndicator';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
 import { TicketPriority } from '@xyne/shared';
 
 interface SearchResultItemProps {
@@ -36,6 +35,9 @@ interface SearchResultItemProps {
   onSelect: (result: DisplaySearchResult) => Promise<void> | void;
   onPreview?: (result: DisplaySearchResult) => void;
   isSelected?: boolean;
+  // Unread badge for a user row whose person has an unread 1:1 DM. The parent resolves
+  // user → DM channel → unreadCounts and passes the count; other result types omit it.
+  badgeCount?: number;
   // Fires on mousedown before cmdk's click->onSelect chain so callers can
   // capture the modifier state of the gesture (cmdk's onSelect drops the event).
   onItemMouseDown?: (e: ReactMouseEvent, result: DisplaySearchResult) => void;
@@ -305,60 +307,49 @@ const AttachmentSearchResultItem = ({
   );
 };
 
+// Adapter: resolves the live user (for name / email / deactivation / status) and delegates the
+// row to the shared UserRow. title == getUserDisplayName(user) and subtitle == user.email for
+// these results, so UserRow derives both from `user` — no label/secondaryText override needed.
 const UserSearchResultItem = ({
   result,
   onSelect,
   isSelected,
   onItemMouseDown,
+  badgeCount,
 }: {
   result: DisplaySearchResult;
   onSelect: (result: DisplaySearchResult) => Promise<void> | void;
   isSelected: boolean;
   onItemMouseDown?: ((e: ReactMouseEvent, result: DisplaySearchResult) => void) | undefined;
+  badgeCount?: number;
 }): ReactElement => {
   const user = useUser(result.id);
-  const isDeactivated = isUserDeactivated(user);
+  const hasStatus = user && (user.statusEmoji || user.statusContent);
   const handleMouseDown = onItemMouseDown
     ? (e: ReactMouseEvent) => onItemMouseDown(e, result)
     : undefined;
 
   return (
-    <Command.Item
-      key={result.id}
+    <UserRow
+      user={user ?? { id: result.id, name: result.title }}
       value={`backend-${result.type}-${result.id}`}
-      data-result-id={result.id}
-      data-result-type={result.type}
-      data-item-label={result.title}
+      dataItemLabel={result.title}
+      dataResultId={result.id}
+      dataResultType={result.type}
       onSelect={() => void onSelect(result)}
-      onMouseDownCapture={handleMouseDown}
-      className='flex items-center gap-3 p-3 rounded-lg cursor-pointer hover:bg-accent aria-selected:bg-accent mt-1.5'
-    >
-      <Avatar userId={result.id} size='xs' />
-      <div className='flex-1 min-w-0 flex items-center gap-2'>
-        <span
-          className={`min-w-0 truncate text-[15px] leading-[1.2] tracking-[-0.1px] ${isDeactivated ? 'text-muted-foreground' : 'text-foreground'}`}
-        >
-          {result.title}
-        </span>
-        {!isDeactivated && (user?.statusEmoji || user?.statusContent) && (
-          <StatusIndicator
-            statusEmoji={user?.statusEmoji}
-            statusContent={user?.statusContent}
-            statusExpiryAt={user?.statusExpiryAt}
-            size='sm'
-          />
-        )}
-        {isDeactivated && (
-          <span className='shrink-0 text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded'>
-            Deactivated
-          </span>
-        )}
-        {result.subtitle && (
-          <span className='min-w-0 truncate text-xs text-muted-foreground'>{result.subtitle}</span>
-        )}
-      </div>
-      {isSelected && <SelectedBadge />}
-    </Command.Item>
+      isSelected={isSelected}
+      {...(badgeCount ? { badgeCount } : {})}
+      {...(handleMouseDown ? { onMouseDownCapture: handleMouseDown } : {})}
+      {...(hasStatus
+        ? {
+            status: {
+              statusEmoji: user.statusEmoji,
+              statusContent: user.statusContent,
+              statusExpiryAt: user.statusExpiryAt,
+            },
+          }
+        : {})}
+    />
   );
 };
 
@@ -368,6 +359,7 @@ const SearchResultItem = ({
   onSelect,
   onPreview,
   isSelected = false,
+  badgeCount,
   onItemMouseDown,
   onItemMouseEnter,
   onItemMouseLeave,
@@ -393,6 +385,7 @@ const SearchResultItem = ({
           onSelect={onSelect}
           isSelected={isSelected}
           onItemMouseDown={onItemMouseDown}
+          {...(badgeCount ? { badgeCount } : {})}
         />
       );
 

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SlashCommands/SlashCommandPalette.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SlashCommands/SlashCommandPalette.tsx
@@ -1,16 +1,9 @@
 import { ReactElement, type MouseEventHandler } from 'react';
 import { Command } from 'cmdk';
-import { UserTwo } from '@xyne/icons';
 import { COMMAND_KINDS, getCommand } from './commands';
 import { getUserDisplayName } from '../../../../utils/userDisplayName';
-import Avatar from '../../../ui/Avatar/Avatar';
-import ChannelIcon from '../../ChannelIcon/ChannelIcon';
+import { UserRow, ChannelRow, CommandSection } from '../CommandRows';
 import type { UseSlashCommandsReturn, GotoExtra } from './useSlashCommands';
-
-// cmdk group-heading style (uppercase mono muted) so the palette matches the menu's
-// other sections.
-const COMMAND_GROUP_HEADING_CLASS =
-  '[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono';
 
 // The whole slash-command controller is handed in as one prop. The palette reads the slice it needs
 // (below); the parent no longer forwards a prop per field, so a new command that adds palette data
@@ -69,7 +62,7 @@ export function SlashCommandPalette({
     }
     const shown = matches.length ? matches : COMMAND_KINDS;
     return (
-      <Command.Group heading='Commands' className={COMMAND_GROUP_HEADING_CLASS}>
+      <CommandSection heading='Commands'>
         {shown.map(kind => {
           const def = getCommand(kind);
           return (
@@ -90,7 +83,7 @@ export function SlashCommandPalette({
             </Command.Item>
           );
         })}
-      </Command.Group>
+      </CommandSection>
     );
   }
 
@@ -98,7 +91,7 @@ export function SlashCommandPalette({
   const activeDef = getCommand(commandKind);
   if (activeDef.type === 'action') {
     return (
-      <Command.Group heading={activeDef.heading} className={COMMAND_GROUP_HEADING_CLASS}>
+      <CommandSection heading={activeDef.heading}>
         <Command.Item
           value={`command-${commandKind}`}
           data-item-label={activeDef.title}
@@ -112,7 +105,7 @@ export function SlashCommandPalette({
             <span className='min-w-0 truncate text-muted-foreground'>{activeDef.description}</span>
           </div>
         </Command.Item>
-      </Command.Group>
+      </CommandSection>
     );
   }
 
@@ -147,7 +140,7 @@ export function SlashCommandPalette({
     return (
       <>
         {(pinnedExtras.length > 0 || commandNavResults.length > 0) && (
-          <Command.Group heading={activeDef.heading} className={COMMAND_GROUP_HEADING_CLASS}>
+          <CommandSection heading={activeDef.heading}>
             {pinnedExtras.map(renderExtra)}
             {commandNavResults.map(item => (
               <Command.Item
@@ -164,12 +157,10 @@ export function SlashCommandPalette({
                 </div>
               </Command.Item>
             ))}
-          </Command.Group>
+          </CommandSection>
         )}
         {settingsExtras.length > 0 && (
-          <Command.Group heading='Settings' className={COMMAND_GROUP_HEADING_CLASS}>
-            {settingsExtras.map(renderExtra)}
-          </Command.Group>
+          <CommandSection heading='Settings'>{settingsExtras.map(renderExtra)}</CommandSection>
         )}
       </>
     );
@@ -183,87 +174,56 @@ export function SlashCommandPalette({
   ) {
     return <div className='py-6 text-center text-sm text-muted-foreground'>No matches</div>;
   }
+  // Primes the parent's selection-gesture ref on mouse pick; omitted when the parent didn't supply it.
+  const mouseDownProps = onItemMouseDown ? { onMouseDownCapture: onItemMouseDown } : {};
   return (
     <>
       {commandUserResults.length > 0 && (
-        <Command.Group heading='Users' className={COMMAND_GROUP_HEADING_CLASS}>
+        <CommandSection heading='Users'>
           {commandUserResults.map(user => (
-            <Command.Item
+            <UserRow
               key={user.id}
+              user={user}
               value={`command-user-${user.id}`}
-              data-item-label={getUserDisplayName(user)}
+              dataItemLabel={getUserDisplayName(user)}
+              isCurrentUser={user.id === currentUserID}
               onSelect={() => onRunTarget({ type: 'user', user })}
-              onMouseDownCapture={onItemMouseDown}
-              className='flex items-center gap-3 p-3 rounded-lg cursor-pointer hover:bg-accent aria-selected:bg-accent mt-1.5'
-            >
-              <Avatar userId={user.id} size='xs' />
-              <div className='flex-1 min-w-0 flex items-center gap-2'>
-                <span className='min-w-0 truncate text-[15px] leading-[1.2] tracking-[-0.1px] text-foreground'>
-                  {getUserDisplayName(user)}
-                  {user.id === currentUserID && (
-                    <span className='text-muted-foreground'> (you)</span>
-                  )}
-                </span>
-                <span className='min-w-0 truncate text-xs text-muted-foreground'>{user.email}</span>
-              </div>
-            </Command.Item>
+              {...mouseDownProps}
+            />
           ))}
-        </Command.Group>
+        </CommandSection>
       )}
       {commandChannelResults.length > 0 && (
-        <Command.Group heading='Channels' className={COMMAND_GROUP_HEADING_CLASS}>
+        <CommandSection heading='Channels'>
           {commandChannelResults.map(channel => (
-            <Command.Item
+            <ChannelRow
               key={channel.id}
               value={`command-channel-${channel.id}`}
-              data-item-label={channel.name}
+              dataItemLabel={channel.name}
+              label={channel.name}
+              channel={channel}
               onSelect={() => onRunTarget({ type: 'channel', channel })}
-              onMouseDownCapture={onItemMouseDown}
-              className='flex items-center gap-3 p-3 rounded-lg cursor-pointer hover:bg-accent aria-selected:bg-accent mt-1.5'
-            >
-              <span className='shrink-0 text-muted-foreground'>
-                <ChannelIcon
-                  channel={channel}
-                  glyphClassName='text-muted-foreground'
-                  avatarSize='xs'
-                />
-              </span>
-              <div className='flex-1 min-w-0'>
-                <div className='text-[15px] leading-[1.2] tracking-[-0.1px] truncate text-foreground'>
-                  {channel.name}
-                </div>
-                {channel.description && (
-                  <div className='text-xs text-muted-foreground truncate'>
-                    {channel.description}
-                  </div>
-                )}
-              </div>
-            </Command.Item>
+              {...mouseDownProps}
+            />
           ))}
-        </Command.Group>
+        </CommandSection>
       )}
       {commandGroupDmResults.length > 0 && (
-        <Command.Group heading='Group DMs' className={COMMAND_GROUP_HEADING_CLASS}>
+        <CommandSection heading='Group DMs'>
           {commandGroupDmResults.map(({ channel, label }) => (
-            <Command.Item
+            <ChannelRow
               key={channel.id}
               value={`command-group-dm-${channel.id}`}
-              data-item-label={label}
+              dataItemLabel={label}
+              label={label}
+              channel={channel}
               onSelect={() =>
                 onRunTarget({ type: 'channel', channel, displayName: label, isDm: true })
               }
-              onMouseDownCapture={onItemMouseDown}
-              className='flex items-center gap-3 p-3 rounded-lg cursor-pointer hover:bg-accent aria-selected:bg-accent mt-1.5'
-            >
-              <UserTwo size={16} className='shrink-0 text-muted-foreground' />
-              <div className='flex-1 min-w-0'>
-                <div className='text-[15px] leading-[1.2] tracking-[-0.1px] truncate text-foreground'>
-                  {label}
-                </div>
-              </div>
-            </Command.Item>
+              {...mouseDownProps}
+            />
           ))}
-        </Command.Group>
+        </CommandSection>
       )}
     </>
   );

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPicker.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPicker.tsx
@@ -8,6 +8,7 @@ import ChannelIcon from '../../ChannelIcon/ChannelIcon';
 import { useSearchMetrics } from '../../../../hooks/useSearchMetrics';
 import { TabType } from '../../ChatDirectory/ChannelCommandMenu.types';
 import { ChannelCommandItem } from '../../ChatDirectory/ChannelCommandMenu';
+import { CommandSection } from '../../ChatDirectory/CommandRows';
 import SearchResultItem from '../../ChatDirectory/SearchResultItem';
 import { ChannelCategory } from '../../ChatDirectory/ChatDirectory.types';
 import { groupChannelsByScope, getDMNames } from '../../ChatDirectory/ChatDirectory.utils';
@@ -59,10 +60,6 @@ const CATEGORY_LABELS: Record<ChannelCategory, string> = {
   [ChannelCategory.DIRECT_MESSAGES]: 'Direct Messages',
   [ChannelCategory.GROUP_DMS]: 'Group DMs',
 };
-
-/** Group-heading chrome copied from ChannelCommandMenu's Command.Group usage. */
-const GROUP_HEADING_CLASS =
-  '[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:font-mono';
 
 /**
  * Which pill list a picked result lands in, per tab. CALL and RECORDING run the
@@ -404,11 +401,7 @@ export const ContextPicker = ({
                 const hiddenCount = items.length - DISPLAY_LIMIT;
 
                 return (
-                  <Command.Group
-                    key={category}
-                    heading={CATEGORY_LABELS[category]}
-                    className={GROUP_HEADING_CLASS}
-                  >
+                  <CommandSection key={category} heading={CATEGORY_LABELS[category]}>
                     {displayItems.map(({ channel }) => (
                       <ChannelCommandItem
                         key={channel.id}
@@ -442,7 +435,7 @@ export const ContextPicker = ({
                         {isExpanded ? 'Show less' : `Show ${hiddenCount} more`}
                       </button>
                     )}
-                  </Command.Group>
+                  </CommandSection>
                 );
               })
             )


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
