### PR TITLE
Fix/cmd k desk channel

### DIFF
--- a/apps/backend/src/services/vespaSearch/resultTransform.ts
+++ b/apps/backend/src/services/vespaSearch/resultTransform.ts
@@ -930,7 +930,7 @@ function transformCollection(
        relevanceScore: hit.relevance,
        metadata: {
          timestamp: formatTimestamp(sentAt),
-         channelName: doc.channelName || 'Desk',
+         channelName: doc.channelName,
        },
        searchContext: {
          messageId: doc.docId,
@@ -938,8 +938,8 @@ function transformCollection(
          conversationId: link?.conversationId,
          ticketId: link?.ticketId,
          xyneId: xyneIdPlain,
-         channelId: link?.channelId ?? doc.channelId,
-         channelTitle: doc.channelName || 'Desk',
+         channelId: doc.channelId,
+         channelTitle: doc.channelName,
          senderName,
          senderEmail,
          recipientCount,

--- a/apps/backend/src/services/vespaSearch/resultTransform.ts
+++ b/apps/backend/src/services/vespaSearch/resultTransform.ts
@@ -9,6 +9,7 @@ import { PrismaClient } from '@prisma/client';
      User,
      Channel,
      importedTicketFields,
+     importedMailFields,
      VespaFileDocument,
      VespaMailDocument,
      VespaCallDocument
@@ -416,7 +417,12 @@ import { PrismaClient } from '@prisma/client';
          break;
 
        case 'mail':
-         result = transformMail(hit, doc as VespaMailDocument, mailMap, formFieldNameMap);
+         result = transformMail(
+           hit,
+           doc as VespaMailDocument & importedMailFields,
+           mailMap,
+           formFieldNameMap,
+         );
          break;
 
        case 'call':
@@ -871,7 +877,7 @@ function transformCollection(
     */
    function transformMail(
      hit: VespaSearchHit,
-     doc: VespaMailDocument,
+     doc: VespaMailDocument & importedMailFields,
      mailMap: MailMap,
      formFieldNameMap: Record<string, string>,
    ): TransformedSearchResult {
@@ -924,7 +930,7 @@ function transformCollection(
        relevanceScore: hit.relevance,
        metadata: {
          timestamp: formatTimestamp(sentAt),
-         channelName: 'Desk',
+         channelName: doc.channelName || 'Desk',
        },
        searchContext: {
          messageId: doc.docId,
@@ -932,8 +938,8 @@ function transformCollection(
          conversationId: link?.conversationId,
          ticketId: link?.ticketId,
          xyneId: xyneIdPlain,
-         channelId: link?.channelId,
-         channelTitle: 'Desk',
+         channelId: link?.channelId ?? doc.channelId,
+         channelTitle: doc.channelName || 'Desk',
          senderName,
          senderEmail,
          recipientCount,

--- a/apps/backend/src/vespa/src/types.ts
+++ b/apps/backend/src/vespa/src/types.ts
@@ -134,6 +134,11 @@ export interface importedTicketFields {
   projectId: string;
 }
 
+export interface importedMailFields {
+  channelId: string;
+  channelName: string;
+}
+
 export interface importedChannelFields {
   isIm: boolean;
   isMpim: boolean;

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
@@ -458,11 +458,16 @@ const SearchResultItem = ({
                     <RenderMessageWithHTML message={deskTicketSubtitle} />
                   </div>
                 )}
-                {/* Line 3: sender on the left, timestamp on the right */}
+                {/* Line 3: sender + recipients, then the channel as a trailing
+                    "in <name>" phrase — same construct the ticket and file rows
+                    use — with the timestamp on the right. */}
                 <div className='flex items-center justify-between gap-2 text-xs text-muted-foreground'>
-                  <span className='min-w-0 truncate'>
-                    {senderName}
-                    {recipientCount > 0 && ` +${recipientCount} more`}
+                  <span className='flex min-w-0 items-center gap-1.5'>
+                    <span className='min-w-0 max-w-[30ch] truncate'>
+                      {senderName}
+                      {recipientCount > 0 && ` +${recipientCount} more`}
+                    </span>
+                    {channelTag && <ChannelSegment channelTag={channelTag} />}
                   </span>
                   <span className='whitespace-nowrap shrink-0'>
                     {utcToIst(result.metadata.timestamp)}

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -1395,8 +1395,16 @@ const SupportScreen = (): ReactElement => {
     const mailId = searchParams.get('mail');
     if (mailId) params.set('mail', mailId);
     const qs = params.toString();
+    // This is a URL normalisation, not a real navigation, so it must not discard
+    // the router state the caller arrived with — `fromSearch` (set by cmd+K and
+    // the search results screen) decides where Back goes, and this effect always
+    // runs for a mail deeplink, which is exactly how search opens a ticket.
+    // Read from `window.history` rather than `location.state`: this effect
+    // rewrites that state, so depending on it would re-trigger the effect.
+    const carriedState = (window.history.state as { usr?: Record<string, unknown> } | null)?.usr;
     void navigate(`${supportBase}/${selectedChannelId}/${xyneId}${qs ? `?${qs}` : ''}`, {
       replace: true,
+      state: carriedState,
     });
   }, [
     deeplinkConversationId,
@@ -4145,6 +4153,8 @@ export const SupportTicketDetail = ({
     ticketId?: string | null;
     returnToUrl?: string | null;
     fromDeskList?: boolean;
+    /** Set by cmd+K / the search results screen; see goBackToTicketList. */
+    fromSearch?: boolean;
   };
   // List navigation supplies stable IDs in router state; direct URL loads and
   // new-tab openings fall back to the :ticketId path parameter below.
@@ -4222,6 +4232,7 @@ export const SupportTicketDetail = ({
             replace: true,
             state: {
               ...(routerState?.fromDeskList ? { fromDeskList: true } : {}),
+              ...(routerState?.fromSearch ? { fromSearch: true } : {}),
               ...(routerState?.returnToUrl ? { returnToUrl: routerState.returnToUrl } : {}),
             },
           });
@@ -4399,6 +4410,7 @@ export const SupportTicketDetail = ({
         conversationId: t.conversationId,
         ticketId: t.id,
         ...(routerState?.fromDeskList ? { fromDeskList: true } : {}),
+        ...(routerState?.fromSearch ? { fromSearch: true } : {}),
         ...(routerState?.returnToUrl ? { returnToUrl: routerState.returnToUrl } : {}),
       },
     });
@@ -4455,10 +4467,20 @@ export const SupportTicketDetail = ({
       onBack();
       return;
     }
-    // Both markers are stamped by the opener (desk list, Kanban, My Tickets) as it pushes
-    // this entry, so its page is one Back away — pop it rather than stacking a second copy.
+    // Every marker is stamped by the opener (desk list, Kanban, My Tickets, cmd+K,
+    // the search results screen) as it pushes this entry, so its page is one Back
+    // away — pop it rather than stacking a second copy.
     // returnToUrl is only a signal now; we never navigate to it, so it needs no URL check.
-    if (routerState?.fromDeskList || routerState?.returnToUrl) {
+    //
+    // `idx` is react-router's position in the history stack; 0 means this entry is the
+    // first of the session, so there is nothing behind us to pop and going back would
+    // eject the user from the app. Markers only survive an in-app push, so this should
+    // not happen — it is a guard, not a code path.
+    const historyIdx = (window.history.state as { idx?: number } | null)?.idx ?? 0;
+    if (
+      (routerState?.fromDeskList || routerState?.returnToUrl || routerState?.fromSearch) &&
+      historyIdx > 0
+    ) {
       void navigate(-1);
       return;
     }
@@ -4472,6 +4494,7 @@ export const SupportTicketDetail = ({
     onBack,
     routerState?.fromDeskList,
     routerState?.returnToUrl,
+    routerState?.fromSearch,
     supportBase,
   ]);
 
@@ -5694,6 +5717,7 @@ const EmailThreadItem = ({
   const navigate = useNavigate();
   const emailRouterState = useLocation().state as {
     fromDeskList?: boolean;
+    fromSearch?: boolean;
     returnToUrl?: string | null;
   } | null;
   const { name: fromName, email: fromEmail } = parseFromField(email.from || '');
@@ -5742,6 +5766,7 @@ const EmailThreadItem = ({
               title: email.subject,
               ticketId: response.data.newTicket.ticketId,
               ...(emailRouterState?.fromDeskList ? { fromDeskList: true } : {}),
+              ...(emailRouterState?.fromSearch ? { fromSearch: true } : {}),
               ...(emailRouterState?.returnToUrl
                 ? { returnToUrl: emailRouterState.returnToUrl }
                 : {}),

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -4469,16 +4469,7 @@ export const SupportTicketDetail = ({
     // the search results screen) as it pushes this entry, so its page is one Back
     // away — pop it rather than stacking a second copy.
     // returnToUrl is only a signal now; we never navigate to it, so it needs no URL check.
-    //
-    // `idx` is react-router's position in the history stack; 0 means this entry is the
-    // first of the session, so there is nothing behind us to pop and going back would
-    // eject the user from the app. Markers only survive an in-app push, so this should
-    // not happen — it is a guard, not a code path.
-    const historyIdx = (window.history.state as { idx?: number } | null)?.idx ?? 0;
-    if (
-      (routerState?.fromDeskList || routerState?.returnToUrl || routerState?.fromSearch) &&
-      historyIdx > 0
-    ) {
+    if (routerState?.fromDeskList || routerState?.returnToUrl || routerState?.fromSearch) {
       void navigate(-1);
       return;
     }

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -1395,12 +1395,9 @@ const SupportScreen = (): ReactElement => {
     const mailId = searchParams.get('mail');
     if (mailId) params.set('mail', mailId);
     const qs = params.toString();
-    // This is a URL normalisation, not a real navigation, so it must not discard
-    // the router state the caller arrived with — `fromSearch` (set by cmd+K and
-    // the search results screen) decides where Back goes, and this effect always
-    // runs for a mail deeplink, which is exactly how search opens a ticket.
+    // the router state the caller arrived with — `shouldNavigateBack` (set by cmd+K
+    // and the search results screen) decides where Back goes, and this effect always
     // Read from `window.history` rather than `location.state`: this effect
-    // rewrites that state, so depending on it would re-trigger the effect.
     const carriedState = (window.history.state as { usr?: Record<string, unknown> } | null)?.usr;
     void navigate(`${supportBase}/${selectedChannelId}/${xyneId}${qs ? `?${qs}` : ''}`, {
       replace: true,
@@ -1913,7 +1910,7 @@ const SupportScreen = (): ReactElement => {
             state: {
               conversationId: parentTicket.conversationId,
               ticketId: parentTicket.id,
-              fromDeskList: true,
+              shouldNavigateBack: true,
             },
           });
         }
@@ -2221,7 +2218,7 @@ const SupportScreen = (): ReactElement => {
         state: {
           conversationId: ticketData.conversationId,
           ticketId: ticketData.id,
-          fromDeskList: true,
+          shouldNavigateBack: true,
         },
       });
     },
@@ -3612,7 +3609,7 @@ const SupportScreen = (): ReactElement => {
                   availableStages={availableStages}
                   onTicketClick={ticket => {
                     void navigate(`${supportBase}/${ticket.channelId}/${ticket.xyneId}`, {
-                      state: { ticketId: ticket.ticketId, fromDeskList: true },
+                      state: { ticketId: ticket.ticketId, shouldNavigateBack: true },
                     });
                   }}
                 />
@@ -3738,7 +3735,7 @@ const SupportScreen = (): ReactElement => {
                             state: {
                               conversationId: ticket.conversationId,
                               ticketId: ticket.id,
-                              fromDeskList: true,
+                              shouldNavigateBack: true,
                             },
                           });
                         }}
@@ -3760,7 +3757,7 @@ const SupportScreen = (): ReactElement => {
                             state: {
                               conversationId: ticket.conversationId,
                               ticketId: ticket.id,
-                              fromDeskList: true,
+                              shouldNavigateBack: true,
                             },
                           });
                         }}
@@ -3787,7 +3784,7 @@ const SupportScreen = (): ReactElement => {
                             state: {
                               conversationId: ticket.conversationId,
                               ticketId: ticket.id,
-                              fromDeskList: true,
+                              shouldNavigateBack: true,
                             },
                           });
                         }}
@@ -4152,9 +4149,7 @@ export const SupportTicketDetail = ({
     conversationId?: string | null;
     ticketId?: string | null;
     returnToUrl?: string | null;
-    fromDeskList?: boolean;
-    /** Set by cmd+K / the search results screen; see goBackToTicketList. */
-    fromSearch?: boolean;
+    shouldNavigateBack?: boolean;
   };
   // List navigation supplies stable IDs in router state; direct URL loads and
   // new-tab openings fall back to the :ticketId path parameter below.
@@ -4231,7 +4226,7 @@ export const SupportTicketDetail = ({
           void navigate(`${navBasePath ?? supportBase}/${channelIdParam}/${sourceTicketXyneId}`, {
             replace: true,
             state: {
-              ...(routerState?.fromDeskList ? { fromDeskList: true } : {}),
+              ...(routerState?.shouldNavigateBack ? { shouldNavigateBack: true } : {}),
               ...(routerState?.returnToUrl ? { returnToUrl: routerState.returnToUrl } : {}),
             },
           });
@@ -4247,7 +4242,7 @@ export const SupportTicketDetail = ({
       channelIdParam,
       navigate,
       navBasePath,
-      routerState?.fromDeskList,
+      routerState?.shouldNavigateBack,
       routerState?.returnToUrl,
       supportBase,
     ],
@@ -4408,7 +4403,7 @@ export const SupportTicketDetail = ({
       state: {
         conversationId: t.conversationId,
         ticketId: t.id,
-        ...(routerState?.fromDeskList ? { fromDeskList: true } : {}),
+        ...(routerState?.shouldNavigateBack ? { shouldNavigateBack: true } : {}),
         ...(routerState?.returnToUrl ? { returnToUrl: routerState.returnToUrl } : {}),
       },
     });
@@ -4469,7 +4464,7 @@ export const SupportTicketDetail = ({
     // the search results screen) as it pushes this entry, so its page is one Back
     // away — pop it rather than stacking a second copy.
     // returnToUrl is only a signal now; we never navigate to it, so it needs no URL check.
-    if (routerState?.fromDeskList || routerState?.returnToUrl || routerState?.fromSearch) {
+    if (routerState?.shouldNavigateBack || routerState?.returnToUrl) {
       void navigate(-1);
       return;
     }
@@ -4481,9 +4476,8 @@ export const SupportTicketDetail = ({
     navBasePath,
     navigate,
     onBack,
-    routerState?.fromDeskList,
+    routerState?.shouldNavigateBack,
     routerState?.returnToUrl,
-    routerState?.fromSearch,
     supportBase,
   ]);
 
@@ -5705,7 +5699,7 @@ const EmailThreadItem = ({
   const { channelId: channelIdParam } = useParams<{ channelId?: string }>();
   const navigate = useNavigate();
   const emailRouterState = useLocation().state as {
-    fromDeskList?: boolean;
+    shouldNavigateBack?: boolean;
     returnToUrl?: string | null;
   } | null;
   const { name: fromName, email: fromEmail } = parseFromField(email.from || '');
@@ -5753,7 +5747,7 @@ const EmailThreadItem = ({
               conversationId: response.data.newTicket.conversationId,
               title: email.subject,
               ticketId: response.data.newTicket.ticketId,
-              ...(emailRouterState?.fromDeskList ? { fromDeskList: true } : {}),
+              ...(emailRouterState?.shouldNavigateBack ? { shouldNavigateBack: true } : {}),
               ...(emailRouterState?.returnToUrl
                 ? { returnToUrl: emailRouterState.returnToUrl }
                 : {}),

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -4232,7 +4232,6 @@ export const SupportTicketDetail = ({
             replace: true,
             state: {
               ...(routerState?.fromDeskList ? { fromDeskList: true } : {}),
-              ...(routerState?.fromSearch ? { fromSearch: true } : {}),
               ...(routerState?.returnToUrl ? { returnToUrl: routerState.returnToUrl } : {}),
             },
           });
@@ -4410,7 +4409,6 @@ export const SupportTicketDetail = ({
         conversationId: t.conversationId,
         ticketId: t.id,
         ...(routerState?.fromDeskList ? { fromDeskList: true } : {}),
-        ...(routerState?.fromSearch ? { fromSearch: true } : {}),
         ...(routerState?.returnToUrl ? { returnToUrl: routerState.returnToUrl } : {}),
       },
     });
@@ -5717,7 +5715,6 @@ const EmailThreadItem = ({
   const navigate = useNavigate();
   const emailRouterState = useLocation().state as {
     fromDeskList?: boolean;
-    fromSearch?: boolean;
     returnToUrl?: string | null;
   } | null;
   const { name: fromName, email: fromEmail } = parseFromField(email.from || '');
@@ -5766,7 +5763,6 @@ const EmailThreadItem = ({
               title: email.subject,
               ticketId: response.data.newTicket.ticketId,
               ...(emailRouterState?.fromDeskList ? { fromDeskList: true } : {}),
-              ...(emailRouterState?.fromSearch ? { fromSearch: true } : {}),
               ...(emailRouterState?.returnToUrl
                 ? { returnToUrl: emailRouterState.returnToUrl }
                 : {}),

--- a/apps/dashboard/src/utils/searchNavigation.ts
+++ b/apps/dashboard/src/utils/searchNavigation.ts
@@ -212,7 +212,12 @@ export const navigateToMail = (result: DisplaySearchResult, navigate: NavigateFu
   params.set('conversationId', conversationId);
   if (ticketId) params.set('ticketId', ticketId);
   if (mailId) params.set('mail', mailId);
-  void navigate(`/support/${channelId}/${xyneId}?${params.toString()}`);
+  // `fromSearch` tells the ticket's Back control it was opened from cmd+K or the
+  // search results screen, so Back returns there instead of routing to the
+  // channel inbox the user never visited. See goBackToTicketList in SupportScreen.
+  void navigate(`/support/${channelId}/${xyneId}?${params.toString()}`, {
+    state: { fromSearch: true },
+  });
 };
 
 /**
@@ -241,7 +246,7 @@ export const navigateToTicket = (
   // If EMAIL channel (Support/Desk ticket) AND has xyneId → Support view
   if (isDeskChannelType(channel?.type) && xyneId) {
     void navigate(`/support/${channelId}/${xyneId}`, {
-      state: { conversationId, ticketId },
+      state: { conversationId, ticketId, fromSearch: true },
     });
     return;
   }

--- a/apps/dashboard/src/utils/searchNavigation.ts
+++ b/apps/dashboard/src/utils/searchNavigation.ts
@@ -212,11 +212,9 @@ export const navigateToMail = (result: DisplaySearchResult, navigate: NavigateFu
   params.set('conversationId', conversationId);
   if (ticketId) params.set('ticketId', ticketId);
   if (mailId) params.set('mail', mailId);
-  // `fromSearch` tells the ticket's Back control it was opened from cmd+K or the
-  // search results screen, so Back returns there instead of routing to the
-  // channel inbox the user never visited. See goBackToTicketList in SupportScreen.
+
   void navigate(`/support/${channelId}/${xyneId}?${params.toString()}`, {
-    state: { fromSearch: true },
+    state: { shouldNavigateBack: true },
   });
 };
 
@@ -246,7 +244,7 @@ export const navigateToTicket = (
   // If EMAIL channel (Support/Desk ticket) AND has xyneId → Support view
   if (isDeskChannelType(channel?.type) && xyneId) {
     void navigate(`/support/${channelId}/${xyneId}`, {
-      state: { conversationId, ticketId, fromSearch: true },
+      state: { conversationId, ticketId, shouldNavigateBack: true },
     });
     return;
   }

--- a/vespa-core/vespa/common/schemas/mail.sd
+++ b/vespa-core/vespa/common/schemas/mail.sd
@@ -203,6 +203,7 @@ schema mail {
 
   import field channelRef.docId as channelId {}
   import field channelRef.permissions as permissions {}
+  import field channelRef.channelName as channelName {}
 
   # Subject-line embedding. mail previously embedded ONLY `chunks`, so a query whose
   # meaning lives in the subject had nothing to match semantically -- the same gap
@@ -322,6 +323,8 @@ schema mail {
     summary chunks {
       bolding: on
     }
+    summary channelName {}
+    summary channelId {}
   }
 
   document-summary lean {
@@ -337,6 +340,8 @@ schema mail {
     summary entity {}
     summary permissions {}
     summary mailId {}
+    summary channelName {}
+    summary channelId {}
   }
 
 

--- a/vespa-core/vespa/common/schemas/ticket.sd
+++ b/vespa-core/vespa/common/schemas/ticket.sd
@@ -438,6 +438,7 @@ schema ticket {
     }
     summary description {}
     summary status {}
+    summary priority {}
     summary stage {}
     summary xyneId {}
     summary assignedTo {}
@@ -451,6 +452,7 @@ schema ticket {
     summary formFields {}
     # imported from channelRef
     summary channelId {}
+    summary channelName {}
   }
 
 }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
